### PR TITLE
fix(#13): scheduler drops livemode ctx — fan out + filter discovery queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp/
 .DS_Store
 velox
 temp.txt
+MANUAL_TEST_BUGS.md

--- a/internal/billing/scheduler.go
+++ b/internal/billing/scheduler.go
@@ -8,6 +8,7 @@ import (
 	mw "github.com/sagarsuperuser/velox/internal/api/middleware"
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/platform/clock"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
 )
 
 // DunningProcessor processes due dunning runs.
@@ -180,6 +181,13 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 // issuance, payment reconciliation, auto-charge retries, cleanup sweeps, and
 // reminders. Splitting from dunning lets two replicas divvy up roles instead
 // of one replica monopolising every periodic job.
+//
+// Mode fan-out: every mode-scoped step runs once per livemode (live, then
+// test) under its own ctx so downstream TxTenant transactions route to the
+// correct RLS partition. Without this the scheduler inherits the default
+// live-mode fallback from an unset ctx and silently hides test-mode rows
+// (reads) or misroutes writes into the live partition. Cross-mode cleanup
+// steps (token + idempotency purge) run once, outside the fan-out.
 func (s *Scheduler) runBillingHalf(ctx context.Context) {
 	start := time.Now()
 
@@ -196,51 +204,72 @@ func (s *Scheduler) runBillingHalf(ctx context.Context) {
 		defer lock.Release()
 	}
 
+	// Mode-scoped work: live first (the bulk of traffic), then test. One
+	// mode's errors do not gate the other — they share nothing at the
+	// DB level once the RLS predicate splits them.
+	for _, live := range []bool{true, false} {
+		modeCtx := postgres.WithLivemode(ctx, live)
+		s.runBillingCycleForMode(modeCtx, live)
+	}
+
+	duration := time.Since(start)
+	mw.RecordBillingCycleDuration(duration.Seconds())
+
+	// Cross-mode cleanup: TxBypass DELETEs that are mode-agnostic by design
+	// (tokens / idempotency keys expire regardless of mode). Running these
+	// once saves two DB round-trips per tick.
+	s.runCrossModeCleanup(ctx)
+}
+
+// runBillingCycleForMode runs a single mode's half-cycle (reconcile, retry,
+// bill, expire credits, list approaching-due). Called twice per tick — once
+// with ctx livemode=true, once with livemode=false. Logs are tagged with the
+// mode so operators can distinguish partitions.
+func (s *Scheduler) runBillingCycleForMode(ctx context.Context, live bool) {
+	mode := "live"
+	if !live {
+		mode = "test"
+	}
+
 	// 0a. Reconcile PaymentUnknown invoices against Stripe. Runs before
 	// auto-charge retry so any stuck-unknown charge that actually succeeded
 	// is marked paid before the retry path considers re-charging.
 	if s.paymentReconciler != nil {
 		resolved, rErrs := s.paymentReconciler.Run(ctx, s.batch)
 		if resolved > 0 {
-			slog.Info("payment reconciler resolved unknowns", "count", resolved)
+			slog.Info("payment reconciler resolved unknowns", "mode", mode, "count", resolved)
 		}
 		for _, e := range rErrs {
-			slog.Error("payment reconciler error", "error", e)
+			slog.Error("payment reconciler error", "mode", mode, "error", e)
 		}
 	}
 
 	// 0. Retry pending auto-charges from previous cycles
 	if chargeRetried, chargeErrs := s.engine.RetryPendingCharges(ctx, s.batch); chargeRetried > 0 || len(chargeErrs) > 0 {
-		slog.Info("auto-charge retries", "succeeded", chargeRetried, "errors", len(chargeErrs))
+		slog.Info("auto-charge retries", "mode", mode, "succeeded", chargeRetried, "errors", len(chargeErrs))
 		for i := 0; i < chargeRetried; i++ {
 			mw.RecordAutoChargeRetry("succeeded")
 		}
 		for _, e := range chargeErrs {
-			slog.Error("auto-charge retry error", "error", e)
+			slog.Error("auto-charge retry error", "mode", mode, "error", e)
 			mw.RecordAutoChargeRetry("failed")
 		}
 	}
 
 	// 1. Billing cycle — generate invoices
 	generated, errs := s.engine.RunCycle(ctx, s.batch)
-
-	duration := time.Since(start)
-	mw.RecordBillingCycleDuration(duration.Seconds())
 	if len(errs) > 0 {
 		slog.Error("billing cycle completed with errors",
+			"mode", mode,
 			"generated", generated,
 			"errors", len(errs),
-			"duration_ms", duration.Milliseconds(),
 		)
 		for _, err := range errs {
-			slog.Error("billing cycle error", "error", err)
+			slog.Error("billing cycle error", "mode", mode, "error", err)
 			mw.RecordBillingCycleError()
 		}
 	} else if generated > 0 {
-		slog.Info("billing cycle completed",
-			"generated", generated,
-			"duration_ms", duration.Milliseconds(),
-		)
+		slog.Info("billing cycle completed", "mode", mode, "generated", generated)
 	}
 
 	// 3. Credit expiry sweep
@@ -248,14 +277,14 @@ func (s *Scheduler) runBillingHalf(ctx context.Context) {
 		expired, cErrs := s.credits.ExpireCredits(ctx)
 		if len(cErrs) > 0 {
 			for _, e := range cErrs {
-				slog.Error("credit expiry error", "error", e)
+				slog.Error("credit expiry error", "mode", mode, "error", e)
 			}
 		}
 		for i := 0; i < expired; i++ {
 			mw.RecordCreditOperation("expiry")
 		}
 		if expired > 0 {
-			slog.Info("credits expired", "count", expired)
+			slog.Info("credits expired", "mode", mode, "count", expired)
 		}
 	}
 
@@ -263,12 +292,19 @@ func (s *Scheduler) runBillingHalf(ctx context.Context) {
 	if s.reminders != nil {
 		approaching, err := s.reminders.ListApproachingDue(ctx, 3)
 		if err != nil {
-			slog.Error("approaching due query failed", "error", err)
+			slog.Error("approaching due query failed", "mode", mode, "error", err)
 		} else if len(approaching) > 0 {
-			slog.Info("invoices approaching due date", "count", len(approaching))
+			slog.Info("invoices approaching due date", "mode", mode, "count", len(approaching))
 		}
 	}
+}
 
+// runCrossModeCleanup runs the mode-agnostic cleanup steps exactly once per
+// tick. These operate via TxBypass DELETEs that intentionally ignore livemode
+// (an expired idempotency key or payment-update token is expired regardless
+// of which partition it belonged to), so fanning out would just double the
+// DB round-trips for no additional work.
+func (s *Scheduler) runCrossModeCleanup(ctx context.Context) {
 	// 5. Payment update token cleanup (expired > 7 days)
 	if s.tokenCleaner != nil {
 		cleaned, err := s.tokenCleaner.Cleanup(ctx)
@@ -297,6 +333,11 @@ func (s *Scheduler) runBillingHalf(ctx context.Context) {
 // runDunningHalf runs the leader-gated half that advances dunning state.
 // Held behind a separate lock key so a replica can win dunning even if
 // another replica is currently running the (longer-lived) billing half.
+//
+// Fans out per livemode (live then test) so ProcessDueRuns — which opens
+// TxTenant and relies on ctx livemode for RLS — sees both partitions.
+// Tenant discovery runs once (ListTenantIDs is not mode-partitioned);
+// per-tenant dunning work is what needs the fan-out.
 func (s *Scheduler) runDunningHalf(ctx context.Context) {
 	if s.dunning == nil || s.tenants == nil {
 		return
@@ -320,18 +361,32 @@ func (s *Scheduler) runDunningHalf(ctx context.Context) {
 		slog.Error("dunning: failed to list tenants", "error", err)
 		return
 	}
+
+	for _, live := range []bool{true, false} {
+		modeCtx := postgres.WithLivemode(ctx, live)
+		s.runDunningForMode(modeCtx, live, tenantIDs)
+	}
+}
+
+// runDunningForMode processes due dunning runs for every tenant under the
+// given livemode. Called twice per tick.
+func (s *Scheduler) runDunningForMode(ctx context.Context, live bool, tenantIDs []string) {
+	mode := "live"
+	if !live {
+		mode = "test"
+	}
 	for _, tid := range tenantIDs {
 		processed, dErrs := s.dunning.ProcessDueRuns(ctx, tid, 20)
 		if len(dErrs) > 0 {
 			for _, e := range dErrs {
-				slog.Error("dunning error", "tenant_id", tid, "error", e)
+				slog.Error("dunning error", "mode", mode, "tenant_id", tid, "error", e)
 			}
 		}
 		for i := 0; i < processed; i++ {
 			mw.RecordDunningRun()
 		}
 		if processed > 0 {
-			slog.Info("dunning runs processed", "tenant_id", tid, "processed", processed)
+			slog.Info("dunning runs processed", "mode", mode, "tenant_id", tid, "processed", processed)
 		}
 	}
 }

--- a/internal/billing/scheduler_lock_test.go
+++ b/internal/billing/scheduler_lock_test.go
@@ -3,8 +3,11 @@ package billing
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
 )
 
 // fakeLocker lets a test simulate two replicas racing for the same key.
@@ -60,11 +63,27 @@ func (l *fakeLock) Release() {
 
 type countingDunning struct {
 	calls atomic.Int32
+
+	// modesMu guards modes; the scheduler fans out per livemode so every
+	// tick should record both true and false at least once per tenant.
+	modesMu sync.Mutex
+	modes   []bool
 }
 
-func (c *countingDunning) ProcessDueRuns(_ context.Context, _ string, _ int) (int, []error) {
+func (c *countingDunning) ProcessDueRuns(ctx context.Context, _ string, _ int) (int, []error) {
 	c.calls.Add(1)
+	c.modesMu.Lock()
+	c.modes = append(c.modes, postgres.Livemode(ctx))
+	c.modesMu.Unlock()
 	return 0, nil
+}
+
+func (c *countingDunning) observedModes() []bool {
+	c.modesMu.Lock()
+	defer c.modesMu.Unlock()
+	out := make([]bool, len(c.modes))
+	copy(out, c.modes)
+	return out
 }
 
 type fixedTenants struct {
@@ -148,15 +167,49 @@ func TestScheduler_LeaderGate_DunningHalfRuns(t *testing.T) {
 
 	s.runDunningHalf(context.Background())
 
-	if got := dunning.calls.Load(); got != 2 {
-		t.Fatalf("dunning body should have fired twice (once per tenant); got %d", got)
+	// Fan-out: 2 tenants × 2 livemodes = 4 calls per tick.
+	if got := dunning.calls.Load(); got != 4 {
+		t.Fatalf("dunning body should have fired four times (2 tenants × 2 modes); got %d", got)
 	}
 
 	// After release, the key must be free again — another runDunningHalf
 	// call should acquire the lock and run again.
 	s.runDunningHalf(context.Background())
-	if got := dunning.calls.Load(); got != 4 {
+	if got := dunning.calls.Load(); got != 8 {
 		t.Fatalf("second dunning tick should have fired after lock released; got %d", got)
+	}
+}
+
+// TestScheduler_DunningFansOutPerLivemode verifies #13's core guarantee: every
+// tick invokes the dunning body once per livemode per tenant, and each call
+// carries the correct livemode in ctx (not the default-to-live fallback).
+func TestScheduler_DunningFansOutPerLivemode(t *testing.T) {
+	t.Parallel()
+
+	dunning := &countingDunning{}
+	s := &Scheduler{
+		engine:  &Engine{},
+		dunning: dunning,
+		tenants: &fixedTenants{ids: []string{"t_1"}},
+		batch:   1,
+	}
+
+	s.runDunningHalf(context.Background())
+
+	modes := dunning.observedModes()
+	if len(modes) != 2 {
+		t.Fatalf("expected 2 calls (1 tenant × 2 modes); got %d", len(modes))
+	}
+	var sawLive, sawTest bool
+	for _, m := range modes {
+		if m {
+			sawLive = true
+		} else {
+			sawTest = true
+		}
+	}
+	if !sawLive || !sawTest {
+		t.Fatalf("fan-out must cover both live and test modes; saw live=%v test=%v", sawLive, sawTest)
 	}
 }
 
@@ -233,7 +286,8 @@ func TestScheduler_LockerNil_RunsUngated(t *testing.T) {
 	}
 
 	s.runDunningHalf(context.Background())
-	if got := dunning.calls.Load(); got != 1 {
-		t.Fatalf("nil locker should let body run once per tenant; got %d", got)
+	// Fan-out: 1 tenant × 2 livemodes = 2 calls per tick even without a locker.
+	if got := dunning.calls.Load(); got != 2 {
+		t.Fatalf("nil locker should let body run once per tenant per mode; got %d", got)
 	}
 }

--- a/internal/credit/postgres.go
+++ b/internal/credit/postgres.go
@@ -347,19 +347,22 @@ func (s *PostgresStore) ListExpiredGrants(ctx context.Context) ([]domain.CreditL
 	}
 	defer postgres.Rollback(tx)
 
+	// TxBypass crosses tenants for the credit-expiry sweep; livemode filter
+	// ensures test-mode expiries don't append under live ctx (see #13).
 	rows, err := tx.QueryContext(ctx, `
 		SELECT id, tenant_id, customer_id, amount_cents
 		FROM customer_credit_ledger
 		WHERE entry_type = 'grant'
 		  AND expires_at IS NOT NULL
 		  AND expires_at < NOW()
+		  AND livemode = $1
 		  AND NOT EXISTS (
 		    SELECT 1 FROM customer_credit_ledger e2
 		    WHERE e2.customer_id = customer_credit_ledger.customer_id
 		      AND e2.entry_type = 'expiry'
 		      AND e2.description LIKE 'Expired grant %' || customer_credit_ledger.id || '%'
 		  )
-	`)
+	`, postgres.Livemode(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dunning/postgres.go
+++ b/internal/dunning/postgres.go
@@ -61,7 +61,7 @@ func (s *PostgresStore) UpsertPolicy(ctx context.Context, tenantID string, p dom
 		INSERT INTO dunning_policies (id, tenant_id, name, enabled, retry_schedule,
 			max_retry_attempts, final_action, grace_period_days, created_at, updated_at)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9)
-		ON CONFLICT (tenant_id) DO UPDATE SET
+		ON CONFLICT (tenant_id, livemode) DO UPDATE SET
 			name = EXCLUDED.name, enabled = EXCLUDED.enabled,
 			retry_schedule = EXCLUDED.retry_schedule,
 			max_retry_attempts = EXCLUDED.max_retry_attempts,

--- a/internal/invoice/postgres.go
+++ b/internal/invoice/postgres.go
@@ -499,6 +499,8 @@ func (s *PostgresStore) ListApproachingDue(ctx context.Context, daysBeforeDue in
 	}
 	defer postgres.Rollback(tx)
 
+	// TxBypass crosses tenants for reminder sweep; livemode filter ensures
+	// reminders only fire for invoices in the ctx's mode (see #13).
 	rows, err := tx.QueryContext(ctx, `
 		SELECT `+invCols+` FROM invoices
 		WHERE status = 'finalized'
@@ -506,9 +508,10 @@ func (s *PostgresStore) ListApproachingDue(ctx context.Context, daysBeforeDue in
 		  AND due_at IS NOT NULL
 		  AND due_at BETWEEN NOW() AND NOW() + INTERVAL '1 day' * $1
 		  AND amount_due_cents > 0
+		  AND livemode = $2
 		ORDER BY due_at ASC
 		LIMIT 500
-	`, daysBeforeDue)
+	`, daysBeforeDue, postgres.Livemode(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -877,15 +880,18 @@ func (s *PostgresStore) ListAutoChargePending(ctx context.Context, limit int) ([
 		limit = 50
 	}
 
+	// TxBypass crosses tenants for the scheduler sweep; livemode must still
+	// be honoured explicitly from ctx (see scheduler fan-out in #13).
 	rows, err := tx.QueryContext(ctx, `
 		SELECT `+invCols+` FROM invoices
 		WHERE auto_charge_pending = TRUE
 		  AND payment_status = 'pending'
 		  AND status = 'finalized'
 		  AND amount_due_cents > 0
+		  AND livemode = $1
 		ORDER BY created_at ASC
-		LIMIT $1
-	`, limit)
+		LIMIT $2
+	`, postgres.Livemode(ctx), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -921,13 +927,16 @@ func (s *PostgresStore) ListUnknownPayments(ctx context.Context, olderThan time.
 		limit = 50
 	}
 
+	// TxBypass crosses tenants for reconciler sweep; livemode filter prevents
+	// test-mode unknowns from being reconciled under live ctx (see #13).
 	rows, err := tx.QueryContext(ctx, `
 		SELECT `+invCols+` FROM invoices
 		WHERE payment_status = 'unknown'
 		  AND updated_at < $1
+		  AND livemode = $2
 		ORDER BY updated_at ASC
-		LIMIT $2
-	`, olderThan, limit)
+		LIMIT $3
+	`, olderThan, postgres.Livemode(ctx), limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/subscription/postgres.go
+++ b/internal/subscription/postgres.go
@@ -348,14 +348,22 @@ func (s *PostgresStore) GetDueBilling(ctx context.Context, before time.Time, lim
 	// next_billing_at is on-or-before the clock's frozen time, not wall clock.
 	// LEFT JOIN keeps live subs (test_clock_id NULL) comparing against $1.
 	// Columns must be qualified because test_clocks shares id/tenant_id/etc.
+	//
+	// TxBypass is used to cross tenants (scheduler-wide sweep), but the
+	// caller's ctx livemode must still scope us to a single partition —
+	// otherwise the per-sub TxTenant calls downstream (plan / test-clock /
+	// settings lookups) default to live and silently fail for test-mode
+	// subs. The scheduler fans out ctx per livemode; we honour that here
+	// with an explicit WHERE clause since TxBypass doesn't set app.livemode.
 	rows, err := tx.QueryContext(ctx, `
 		SELECT `+qualifiedSubCols("s")+` FROM subscriptions s
 		LEFT JOIN test_clocks tc ON tc.id = s.test_clock_id
 		WHERE s.status = 'active'
-		  AND s.next_billing_at <= COALESCE(tc.frozen_time, $1)
-		ORDER BY s.next_billing_at ASC LIMIT $2
+		  AND s.livemode = $1
+		  AND s.next_billing_at <= COALESCE(tc.frozen_time, $2)
+		ORDER BY s.next_billing_at ASC LIMIT $3
 		FOR UPDATE OF s SKIP LOCKED
-	`, before, limit)
+	`, postgres.Livemode(ctx), before, limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes #13.

- Scheduler `runBillingHalf` / `runDunningHalf` now fan out per livemode (`WithLivemode(ctx, true)` then `WithLivemode(ctx, false)`). Every mode-scoped step runs once per partition; cross-mode cleanup (expired tokens, idempotency keys) runs once. Logs are tagged with `mode="live"/"test"` so a missing half is visible in prod.
- Cross-tenant discovery queries (`TxBypass`) now filter by `ctx` livemode explicitly: `subscription.GetDueBilling`, `invoice.ListAutoChargePending`, `invoice.ListUnknownPayments`, `invoice.ListApproachingDue`, `credit.ListExpiredGrants`. Without this filter `TxBypass` skips the DB's `app.livemode` session var, so the scheduler read one mode's rows while writing under ctx=live (silent corruption risk for test-mode unknowns / expired credits).
- Drive-by: `dunning_policies` upsert had `ON CONFLICT (tenant_id)` while the unique constraint is `(tenant_id, livemode)` (from migration 0020) — any test-mode dunning-policy save returned `SQLSTATE 42P10`. Fixed to `ON CONFLICT (tenant_id, livemode)`.

## Why this matters

The scheduler runs on a fresh `context.Background()` per tick, so `TxTenant` falls through to the default-to-live branch in `postgres.BeginTx`. That meant test-mode subscriptions/invoices/credits/dunning runs were being read under live ctx — missed in some sweeps, and in others (unknown-payment reconciler, credit-expiry ledger append) could write into the wrong partition.

Industry reference: Stripe's billing engine runs mode-scoped workers per livemode. We now do the same.

## Scope

Four commits, narrowly scoped to #13:

1. `fix(dunning): ON CONFLICT must include livemode column`
2. `fix(scheduler): fan out billing/dunning halves per livemode`
3. `fix(stores): filter cross-tenant discovery queries by ctx livemode`
4. `test(scheduler): assert per-livemode fan-out in dunning half`

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./internal/billing ./internal/invoice ./internal/subscription ./internal/credit ./internal/dunning -short` — all green.
- [x] New `TestScheduler_DunningFansOutPerLivemode` asserts one tick observes both live and test mode per tenant.
- [ ] Manual: create a test-mode subscription with `next_billing_at` in the past → confirm the next scheduler tick generates the invoice (was previously silently skipped).
- [ ] Manual: save a dunning policy in test mode via `PUT /v1/dunning/policy` → confirm 200 (was 500 with `SQLSTATE 42P10`).

## Follow-ups

- #14 (tracked separately): make missing ctx livemode in `TxTenant` a loud failure instead of the current silent default-to-live. The fix here closes the scheduler hole, but the underlying footgun remains until #14 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)