### PR TITLE
feat(#14): harden livemode — warn/strict-panic on unset TxTenant ctx

### DIFF
--- a/internal/billing/scheduler.go
+++ b/internal/billing/scheduler.go
@@ -226,6 +226,12 @@ func (s *Scheduler) runBillingHalf(ctx context.Context) {
 // with ctx livemode=true, once with livemode=false. Logs are tagged with the
 // mode so operators can distinguish partitions.
 func (s *Scheduler) runBillingCycleForMode(ctx context.Context, live bool) {
+	// Sanity: the only legitimate caller (runBillingHalf) always wraps ctx
+	// with WithLivemode before calling us. Assert here so a future refactor
+	// that skips the wrap crashes the test that exercises this path, not
+	// silently routes test-mode work into the live partition.
+	ctx = postgres.WithRequiredLivemode(ctx)
+
 	mode := "live"
 	if !live {
 		mode = "test"
@@ -371,6 +377,9 @@ func (s *Scheduler) runDunningHalf(ctx context.Context) {
 // runDunningForMode processes due dunning runs for every tenant under the
 // given livemode. Called twice per tick.
 func (s *Scheduler) runDunningForMode(ctx context.Context, live bool, tenantIDs []string) {
+	// Assert the fan-out site did its job; see note on runBillingCycleForMode.
+	ctx = postgres.WithRequiredLivemode(ctx)
+
 	mode := "live"
 	if !live {
 		mode = "test"

--- a/internal/billing/scheduler_lock_test.go
+++ b/internal/billing/scheduler_lock_test.go
@@ -3,6 +3,7 @@ package billing
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -211,6 +212,34 @@ func TestScheduler_DunningFansOutPerLivemode(t *testing.T) {
 	if !sawLive || !sawTest {
 		t.Fatalf("fan-out must cover both live and test modes; saw live=%v test=%v", sawLive, sawTest)
 	}
+}
+
+// TestScheduler_RunDunningForMode_PanicsWithoutLivemode is the regression
+// guard for #14: runDunningForMode is a mode-aware entry point and must
+// panic if its caller forgot to wrap ctx with WithLivemode. Without this
+// assertion the scheduler would silently route test-mode work into the
+// live partition via the default-to-live fallback.
+func TestScheduler_RunDunningForMode_PanicsWithoutLivemode(t *testing.T) {
+	t.Parallel()
+
+	s := &Scheduler{
+		engine:  &Engine{},
+		dunning: &countingDunning{},
+		tenants: &fixedTenants{ids: []string{"t_1"}},
+		batch:   1,
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("runDunningForMode should panic on ctx without WithLivemode")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "without explicit livemode") {
+			t.Fatalf("panic should mention missing livemode; got %q", msg)
+		}
+	}()
+	s.runDunningForMode(context.Background(), true, []string{"t_1"})
 }
 
 // TestScheduler_LeaderGate_DunningHalfSkipsWhenHeld verifies that when the

--- a/internal/platform/postgres/livemode_test.go
+++ b/internal/platform/postgres/livemode_test.go
@@ -1,0 +1,160 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestLivemode_DefaultsToLive documents the public API's fallback semantics:
+// without any WithLivemode on the chain, Livemode(ctx) returns true. Callers
+// must not rely on this to *detect* unset — use livemodeSet for that.
+func TestLivemode_DefaultsToLive(t *testing.T) {
+	t.Parallel()
+	if !Livemode(context.Background()) {
+		t.Fatal("Livemode of bare ctx should default to true")
+	}
+	if livemodeSet(context.Background()) {
+		t.Fatal("livemodeSet of bare ctx should be false")
+	}
+}
+
+// TestWithLivemode_RoundTrip verifies the ctx key stores *bool correctly so
+// a later WithLivemode(false) call isn't masked by the default fallback.
+func TestWithLivemode_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := WithLivemode(context.Background(), false)
+	if !livemodeSet(ctx) {
+		t.Fatal("livemodeSet should be true after WithLivemode")
+	}
+	if Livemode(ctx) {
+		t.Fatal("Livemode should return false after WithLivemode(ctx, false)")
+	}
+
+	ctx = WithLivemode(context.Background(), true)
+	if !Livemode(ctx) {
+		t.Fatal("Livemode should return true after WithLivemode(ctx, true)")
+	}
+}
+
+// TestWithRequiredLivemode_PanicsWhenUnset is the fan-out safety assertion:
+// the helper must panic if called without an upstream WithLivemode. This is
+// the behaviour that catches "I forgot to fan out" at the boundary instead
+// of 30 frames later.
+func TestWithRequiredLivemode_PanicsWhenUnset(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("WithRequiredLivemode should panic when ctx has no livemode")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "without explicit livemode") {
+			t.Fatalf("panic message should name the issue; got %q", msg)
+		}
+	}()
+	WithRequiredLivemode(context.Background())
+}
+
+// TestWithRequiredLivemode_PassesWhenSet confirms the helper is a no-op when
+// the caller did propagate — otherwise the assertion would break every
+// legitimate fan-out site.
+func TestWithRequiredLivemode_PassesWhenSet(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("WithRequiredLivemode should not panic when ctx has livemode; got %v", r)
+		}
+	}()
+	out := WithRequiredLivemode(WithLivemode(context.Background(), false))
+	if Livemode(out) {
+		t.Fatal("livemode should survive the assertion unchanged")
+	}
+}
+
+// TestReportUnsetLivemode_WarnsOncePerSite verifies the diagnostic dedup: the
+// warning is valuable the first time per call site but noisy afterwards, so
+// it must fire exactly once per unique caller file:line.
+func TestReportUnsetLivemode_WarnsOncePerSite(t *testing.T) {
+	// Not t.Parallel — mutates package-level slog default + dedup map.
+	resetLivemodeSeen()
+
+	var buf bytes.Buffer
+	var bufMu sync.Mutex
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&syncBuf{Buffer: &buf, mu: &bufMu}, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// Same call site hit three times — expect one log line.
+	for range 3 {
+		reportUnsetLivemode(1) // skip=1: caller is this for-loop statement
+	}
+
+	bufMu.Lock()
+	output := buf.String()
+	bufMu.Unlock()
+	if n := strings.Count(output, "velox: livemode propagation missing"); n != 1 {
+		t.Fatalf("expected exactly 1 warning, got %d:\n%s", n, output)
+	}
+}
+
+// TestReportUnsetLivemode_PanicsUnderStrict verifies VELOX_LIVEMODE_STRICT
+// escalates the warning to a panic. This is the mode CI/tests run under so
+// any accidentally mode-blind TxTenant surfaces immediately.
+func TestReportUnsetLivemode_PanicsUnderStrict(t *testing.T) {
+	// Not t.Parallel — mutates env.
+	t.Setenv("VELOX_LIVEMODE_STRICT", "true")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("reportUnsetLivemode should panic under VELOX_LIVEMODE_STRICT")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "VELOX_LIVEMODE_STRICT") {
+			t.Fatalf("panic message should name the flag; got %q", msg)
+		}
+	}()
+	reportUnsetLivemode(1)
+}
+
+// TestReportUnsetLivemode_StrictDisabledByDefault documents the production
+// default: no env → warn, not panic. If this flips, every prod deploy with a
+// stray unset-livemode call site starts crashing.
+func TestReportUnsetLivemode_StrictDisabledByDefault(t *testing.T) {
+	// Not t.Parallel — mutates env and dedup map.
+	t.Setenv("VELOX_LIVEMODE_STRICT", "")
+	resetLivemodeSeen()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("reportUnsetLivemode should not panic without the flag; got %v", r)
+		}
+	}()
+	reportUnsetLivemode(1)
+}
+
+// resetLivemodeSeen clears the package-level dedup map so tests that exercise
+// warning behaviour start from a clean slate. Test-only helper.
+func resetLivemodeSeen() {
+	unsetLivemodeSeen.Range(func(k, _ any) bool {
+		unsetLivemodeSeen.Delete(k)
+		return true
+	})
+}
+
+// syncBuf serializes writes to a *bytes.Buffer across goroutines. slog.Handler
+// gives no concurrency guarantees on the underlying writer, so wrap it.
+type syncBuf struct {
+	*bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Buffer.Write(p)
+}

--- a/internal/platform/postgres/postgres.go
+++ b/internal/platform/postgres/postgres.go
@@ -5,7 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -47,23 +51,87 @@ const (
 // live here avoids circular imports between auth and postgres.
 type livemodeCtxKey struct{}
 
+// Stored as *bool so BeginTx can distinguish "caller explicitly chose live"
+// from "nobody set this, defaulting to live". The public Livemode() still
+// returns a plain bool and keeps the default-to-live fallback — only BeginTx
+// and WithRequiredLivemode need to care about the set/unset distinction.
+
 // WithLivemode returns a derived context carrying the mode flag. BeginTx
 // reads this to set app.livemode on the tx session, which the RLS policy
 // uses to filter rows by mode alongside tenant.
 func WithLivemode(ctx context.Context, live bool) context.Context {
-	return context.WithValue(ctx, livemodeCtxKey{}, live)
+	return context.WithValue(ctx, livemodeCtxKey{}, &live)
 }
 
 // Livemode reads the livemode flag from ctx. Absent a value, defaults to
 // true — the RLS policy interprets unset as "live mode" so background
 // workers and bootstrap tooling that don't propagate mode operate safely
-// against production data by default.
+// against production data by default. Callers that need to know whether
+// the value was set explicitly should use WithRequiredLivemode at their
+// entry point instead of inspecting the return value here.
 func Livemode(ctx context.Context) bool {
-	v, ok := ctx.Value(livemodeCtxKey{}).(bool)
-	if !ok {
+	p, ok := ctx.Value(livemodeCtxKey{}).(*bool)
+	if !ok || p == nil {
 		return true
 	}
-	return v
+	return *p
+}
+
+// livemodeSet reports whether ctx had WithLivemode called on it anywhere up
+// the chain. Package-private because it's a diagnostic for BeginTx and
+// WithRequiredLivemode — callers that want the mode should use Livemode().
+func livemodeSet(ctx context.Context) bool {
+	p, ok := ctx.Value(livemodeCtxKey{}).(*bool)
+	return ok && p != nil
+}
+
+// WithRequiredLivemode asserts that ctx has an explicit livemode set, and
+// returns ctx unchanged if so. Panics otherwise. Call at the top of any
+// background worker or scheduler path that opens a TxTenant — it catches
+// "I forgot to fan out per mode" at the fan-out site instead of 30 frames
+// deeper, where the bug would surface as silent test-mode data loss.
+func WithRequiredLivemode(ctx context.Context) context.Context {
+	if !livemodeSet(ctx) {
+		panic("velox: background worker entered a mode-aware path without explicit livemode — wrap ctx with postgres.WithLivemode(ctx, true/false) at the fan-out site")
+	}
+	return ctx
+}
+
+// livemodeStrict reports whether the process should escalate unset-livemode
+// warnings to panics. Enabled in tests (via VELOX_LIVEMODE_STRICT=true) so
+// any test that opens a TxTenant without setting a mode fails loudly
+// instead of silently routing to live. Default off in production — the
+// warning is the signal, crashing a live install over a forgotten
+// propagation is not.
+func livemodeStrict() bool {
+	return strings.EqualFold(os.Getenv("VELOX_LIVEMODE_STRICT"), "true")
+}
+
+// unsetLivemodeSeen tracks call sites that have already logged the
+// "TxTenant opened without ctx livemode" warning. The warning is valuable
+// the first time per site but noisy if fired for every tick of a long-
+// running scheduler — dedup on caller file:line so operators get one log
+// line per forgotten propagation, not one per request.
+var unsetLivemodeSeen sync.Map // map[string]struct{}
+
+// reportUnsetLivemode logs (or panics under strict mode) when a TxTenant
+// opens without ctx livemode. Skip is the number of stack frames above
+// this function to attribute the warning to — 2 lands on the caller of
+// BeginTx, which is the interesting site.
+func reportUnsetLivemode(skip int) {
+	_, file, line, ok := runtime.Caller(skip)
+	site := "unknown"
+	if ok {
+		site = fmt.Sprintf("%s:%d", file, line)
+	}
+	msg := "TxTenant opened without ctx livemode; defaulting to live. Wrap ctx with postgres.WithLivemode(ctx, true/false) at the entry point."
+	if livemodeStrict() {
+		panic(fmt.Sprintf("velox (VELOX_LIVEMODE_STRICT): %s caller=%s", msg, site))
+	}
+	if _, loaded := unsetLivemodeSeen.LoadOrStore(site, struct{}{}); loaded {
+		return
+	}
+	slog.Warn("velox: livemode propagation missing", "caller", site, "detail", msg)
 }
 
 func (db *DB) BeginTx(ctx context.Context, mode TxMode, tenantID string) (*sql.Tx, error) {
@@ -74,6 +142,13 @@ func (db *DB) BeginTx(ctx context.Context, mode TxMode, tenantID string) (*sql.T
 
 	switch mode {
 	case TxTenant:
+		// Diagnostic: every TxTenant must carry an explicit livemode. The
+		// runtime still falls back to live, but under VELOX_LIVEMODE_STRICT
+		// a missing propagation panics so tests surface the bug immediately.
+		// skip=3: runtime.Caller → reportUnsetLivemode → BeginTx → caller.
+		if !livemodeSet(ctx) {
+			reportUnsetLivemode(3)
+		}
 		if _, err := tx.ExecContext(ctx, `SELECT set_config('app.bypass_rls', 'off', true)`); err != nil {
 			_ = tx.Rollback()
 			return nil, err


### PR DESCRIPTION
## Summary

Fixes #14. (Rebased onto main now that #15 has merged.)

Turns `postgres.Livemode(ctx)` missing-context from a silent default-to-live into an observable, actionable signal — so the *next* background worker that forgets `WithLivemode` can't reproduce the #13 class of bug.

### Changes

1. **`livemodeCtxKey` storage is now `*bool`** — internal change, public `Livemode()` API unchanged. `BeginTx` can now distinguish "caller chose live" from "nobody set this."
2. **`BeginTx(TxTenant)` diagnostics** — if ctx has no livemode:
   - Default: `slog.Warn` dedup'd by caller `file:line` (one log line per site, not one per request).
   - `VELOX_LIVEMODE_STRICT=true`: panic. Intended for tests/CI so a mode-blind `TxTenant` fails immediately instead of silently routing to live.
   - RLS runtime semantics unchanged — still falls back to live. Diagnostics only.
3. **`WithRequiredLivemode(ctx)`** public helper panics if ctx has no livemode. Called at the top of `runBillingCycleForMode` and `runDunningForMode` so a future refactor that skips the fan-out wrap crashes the test, not prod.

### Out of scope (deliberately)

- Removing the default-to-live fallback — would churn every test/bootstrap/CLI caller for 5% additional safety on top of the warning path.
- Enforcing livemode on `TxBypass` — deliberately cross-mode.
- Phase-2 `go vet`-style analyzer.

### Industry reference

- Stripe: every cross-mode-sensitive path carries mode as an explicit typed value; missing-mode panics at boundary checks in dev, alerts in prod.
- Go stdlib: `context.Deadline()` / `context.Value` return an `ok` bool so callers can distinguish unset from zero. This PR restores that distinction for livemode.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./... -short` all green.
- [x] `TestLivemode_DefaultsToLive` + `TestWithLivemode_RoundTrip` — `*bool` storage doesn't regress the public API.
- [x] `TestWithRequiredLivemode_PanicsWhenUnset` / `_PassesWhenSet`.
- [x] `TestReportUnsetLivemode_WarnsOncePerSite` — dedup proven.
- [x] `TestReportUnsetLivemode_PanicsUnderStrict` — `VELOX_LIVEMODE_STRICT=true` escalates.
- [x] `TestReportUnsetLivemode_StrictDisabledByDefault` — guards against a flag flip that would crash prod.
- [x] `TestScheduler_RunDunningForMode_PanicsWithoutLivemode` — end-to-end panic regression.

## Follow-ups

- Phase-2 analyzer: static check that flags `TxTenant` paths whose call graph reaches a `go func` / `time.NewTicker` without a `WithLivemode` on the path.
- Enable `VELOX_LIVEMODE_STRICT=true` in CI once the full test suite is clean under strict mode.

Supersedes #16 (which was auto-closed when its base branch was deleted after #15 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)