### PR TITLE
docs: Track B Week 1 — README rewrite, AI billing blog, outreach list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,313 +1,264 @@
 # Velox
 
-Open-source usage-based billing engine. Built in Go.
+**The open-source billing engine for AI and usage-heavy SaaS — runs in your own VPC.**
 
 [![CI](https://github.com/sagarsuperuser/velox/actions/workflows/ci.yml/badge.svg)](https://github.com/sagarsuperuser/velox/actions/workflows/ci.yml)
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go)](https://go.dev)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
-Velox handles the complete billing lifecycle: pricing configuration, subscription management, usage metering, invoice generation with PDF rendering, payment collection via Stripe, customer credits, and automated dunning for failed payments.
+Velox owns the layer above PaymentIntent: pricing, subscriptions, multi-dimensional usage metering, invoicing, dunning, and credits. Stripe still does cards under the hood. The 0.5% Stripe Billing fee disappears, and customer billing data never leaves your infrastructure.
 
-**136 Go files | 18,200+ lines | 324 tests | 76 API endpoints | 8-page React dashboard**
+Built for two market truths Stripe Billing structurally cannot serve:
 
-## Quick Start
+1. **AI/LLM apps need multi-dimensional pricing.** Real model pricing today is `model × operation × cached × tier × context-window`. Stripe's Meter API forces one Meter per dimension combination — six Meters and ugly subscription wiring just to model GPT-4 input/output/cached/uncached. Velox treats dimensions as first-class on the meter.
+2. **Regulated tenants cannot put customer billing data on Stripe's servers.** EU GDPR-strict, India RBI data localization, healthcare-adjacent SaaS, government procurement. Stripe's whole model is "send us the data." Velox runs in your VPC.
+
+See [`docs/positioning.md`](docs/positioning.md) for the full strategic frame and [`docs/90-day-plan.md`](docs/90-day-plan.md) for what's shipping when.
+
+---
+
+## The wedge in code
+
+Bill Anthropic-style multi-dimensional pricing (model × operation × cached) with **one meter** and a few pricing rules — not 24 Stripe Meters and a Subscription Item per combination.
+
+```bash
+# 1. Create one meter for "tokens"
+curl -X POST https://api.velox.dev/v1/meters \
+  -H "Authorization: Bearer $VELOX_SECRET" \
+  -d '{"key": "tokens", "name": "LLM tokens", "unit": "token"}'
+
+# 2. Ingest events that carry the dimensions inline
+curl -X POST https://api.velox.dev/v1/usage_events \
+  -H "Authorization: Bearer $VELOX_SECRET" \
+  -H "Idempotency-Key: req_8f2c..." \
+  -d '{
+    "meter_key": "tokens",
+    "customer_id": "cust_acme",
+    "value": "12450",
+    "dimensions": {"model": "gpt-4", "operation": "input", "cached": false}
+  }'
+
+# 3. Define one pricing rule per (dimension subset, rate)
+curl -X POST https://api.velox.dev/v1/meters/mtr_tokens/pricing_rules \
+  -d '{
+    "dimension_match": {"model": "gpt-4", "operation": "input", "cached": false},
+    "rating_rule_version_id": "rrv_gpt4_input_uncached",
+    "aggregation_mode": "sum",
+    "priority": 100
+  }'
+```
+
+A coarser rule (`{"model": "gpt-4"}`) plus a finer override (`{"model": "gpt-4", "cached": true}` at higher priority) compose cleanly — each event is claimed by the highest-priority matching rule, no double-count. The full design — schema, aggregation semantics, decimal quantities, all five aggregation modes (`sum`, `count`, `last_during_period`, `last_ever`, `max`) — lives in [`docs/design-multi-dim-meters.md`](docs/design-multi-dim-meters.md).
+
+> **Status:** multi-dim meters land in `v0.x` on **May 8, 2026** (Week 2 of the 90-day plan). The endpoints above are the published API contract; today's `POST /v1/usage-events` accepts integer `quantity` only and stays available for back-compat.
+
+---
+
+## What's in the box
+
+### AI/usage-native (the wedge)
+- **Multi-dimensional meters** — one meter, N rules, dimensions on every event
+- **Decimal quantities** — `NUMERIC(38, 12)` for fractional GPU-hours and partial tokens
+- **Per-rule aggregation modes** — `sum`, `count`, `last_during_period`, `last_ever`, `max`
+- **Pricing recipes** — one call instantiates products + prices + meters + dunning (`anthropic_style`, `openai_style`, `replicate_style`, `b2b_saas_pro`, `marketplace_gmv`)
+- **Embeddable cost dashboard** — drop `<VeloxCostDashboard customerId={…} />` into your app and end users see "$4.31 of GPT-4 today" with a projected bill
+
+### Self-host first
+- **Helm chart, Docker Compose, Terraform** — runs in your VPC in ≤1 hour
+- **Data sovereignty** — customer billing data never leaves your infrastructure
+- **Append-only audit log** — DB-trigger enforced tamper-evidence
+- **Row-Level Security** — one Velox deployment cleanly serves N internal tenants
+
+### Stripe-grade primitives (already shipped)
+Test clocks · idempotency · hosted invoice page with secure tokens · branded multipart emails · dunning with breaker · transactional outbox · webhook signing with 72h rotation grace · trial state machine with atomic flips · pause-collection · scheduled cancellation · plan changes with proration · per-customer price overrides · event-sourced credit ledger · credit notes + refunds · PDF invoices.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full ship log.
+
+---
+
+## Quick start
 
 ```bash
 git clone https://github.com/sagarsuperuser/velox.git && cd velox
 
-# Backend
+# Backend — Postgres + bootstrap demo tenant + run the API
 docker compose up -d postgres
-make bootstrap    # Creates demo tenant + API keys
-make dev          # Starts API server on :8080
+make bootstrap       # creates a demo tenant and prints API keys
+make dev             # API on :8080
 
-# Frontend (new terminal)
+# Operator dashboard (separate terminal)
 cd web-v2 && npm install && npm run dev
-# → http://localhost:5173 (paste your API key to login)
+# → http://localhost:5173 — paste your secret key to log in
 ```
 
-Or run the full billing cycle via CLI:
+End-to-end demo (creates a customer, ingests usage, runs billing, generates a PDF invoice):
+
 ```bash
-./scripts/demo.sh <YOUR_SECRET_KEY>
+./scripts/demo.sh $VELOX_SECRET
 ```
 
-## Dashboard Screenshots
+Five-minute self-host: see [`docs/self-host`](docs/) (Week 9 deliverable — under construction).
 
-The operator dashboard provides real-time views of your billing data:
+---
 
-- **Dashboard** — KPI cards (customers, subscriptions, revenue) + recent invoices + active subscriptions
-- **Customers** — searchable table with status badges, click-through to detail
-- **Customer Detail** — credit balance, active subscriptions, recent invoices
-- **Invoices** — status + payment badges, billing period, amount, PDF download
-- **Invoice Detail** — line items breakdown (base fee, usage charges) with pricing mode
-- **Subscriptions** — billing period tracking, status management
+## What Velox is **not**
 
-## API Examples
+Stating these loudly so the wrong customers self-select out:
 
-**Create a customer:**
-```bash
-curl -X POST http://localhost:8080/v1/customers \
-  -H "Authorization: Bearer vlx_secret_..." \
-  -H "Content-Type: application/json" \
-  -d '{"external_id": "acme", "display_name": "Acme Corp", "email": "billing@acme.com"}'
-```
+- **Not for vanilla card-first SaaS** with simple per-seat pricing — Stripe Billing is fine for them.
+- **Not multi-PSP yet** — Stripe is the only payment processor. Razorpay/Adyen come when a paying tenant asks.
+- **Not for marketplaces or Connect** — single-tenant per Velox deployment.
+- **No Revenue Recognition / Sigma** — bring your own warehouse + dbt.
+- **No Quotes or Subscription Schedules** — sales-led contract billing should pick Recurly or Maxio.
+- **No 50+ payment-method types** — cards via Stripe + send-invoice. ACH/SEPA expand from there.
 
-```json
-{
-  "id": "vlx_cus_42014438d82ddf33b20f3dd5",
-  "external_id": "acme",
-  "display_name": "Acme Corp",
-  "email": "billing@acme.com",
-  "status": "active",
-  "created_at": "2026-04-07T10:33:15Z"
-}
-```
+---
 
-**Ingest usage:**
-```bash
-curl -X POST http://localhost:8080/v1/usage-events \
-  -H "Authorization: Bearer vlx_secret_..." \
-  -d '{"customer_id": "vlx_cus_...", "meter_id": "vlx_mtr_...", "quantity": 500}'
-```
+## How it fits
 
-**Trigger billing → Generate invoice:**
-```bash
-curl -X POST http://localhost:8080/v1/billing/run \
-  -H "Authorization: Bearer vlx_secret_..."
-```
+|                          | **Velox** | Stripe Billing | Lago        | Orb / Metronome   | OpenMeter        |
+|--------------------------|-----------|----------------|-------------|-------------------|------------------|
+| OSS / self-host          | ✅        | ❌             | ✅          | ❌                | ✅               |
+| AI-native pricing        | ✅        | ❌             | ⚠️ generic  | ⚠️ closed source  | ⚠️ metering only |
+| Full billing engine      | ✅        | ✅             | ✅          | ✅                | ❌               |
+| Stripe-grade primitives  | ✅        | ✅             | ⚠️          | ✅                | ❌               |
+| Pricing                  | OSS       | 0.5% of GMV    | OSS / cloud | $30K+/yr          | OSS              |
+| Data sovereignty         | ✅        | ❌             | ⚠️          | ❌                | ✅ (no billing)  |
 
-```json
-{"invoices_generated": 1, "errors": []}
-```
+Velox lives in the empty cell: **OSS + self-host + AI-native + full billing engine.**
 
-**Error responses (Stripe-consistent format):**
-```json
-{
-  "error": {
-    "type": "invalid_request_error",
-    "code": "not_found",
-    "message": "customer not found",
-    "request_id": "abc123"
-  }
-}
-```
+---
 
 ## Architecture
 
 ```
-cmd/velox/                  — Single binary, 85 lines
+cmd/velox/                  — single Go binary
 internal/
-  domain/                   — Pure domain models, zero dependencies
-  api/respond/              — Unified Stripe-style JSON responses
+  domain/                   — pure domain models, zero deps
+  api/respond/              — Stripe-style JSON responses
   auth/                     — API key auth (3 key types, 16 permissions)
-  tenant/                   — Tenant management + settings
-  customer/                 — Customer CRUD + billing profiles
-  pricing/                  — Meters, rating rules, plans, price overrides
-  subscription/             — Lifecycle (draft → active → paused → canceled)
-  usage/                    — Event ingestion, batch API, aggregation
-  invoice/                  — State machine (draft → finalized → paid) + PDF
-  billing/                  — Billing cycle engine + scheduler + preview
-  payment/                  — Stripe PaymentIntent + webhook handling
-  dunning/                  — Payment retry state machine
-  credit/                   — Event-sourced prepaid balance ledger
-  creditnote/               — Credit notes + refunds
-  webhook/                  — Outbound webhooks (HMAC-signed delivery)
-  audit/                    — Immutable append-only audit log
+  tenant/                   — tenants + settings
+  customer/                 — customer CRUD + billing profiles
+  pricing/                  — meters, rating rules, plans, price overrides
+  subscription/             — lifecycle (draft → trialing → active → paused → canceled)
+  usage/                    — event ingestion + multi-dim aggregation
+  invoice/                  — state machine (draft → finalized → paid) + PDF
+  billing/                  — billing engine + scheduler + preview
+  payment/                  — Stripe PaymentIntent + webhook receiver
+  dunning/                  — payment retry state machine
+  credit/                   — event-sourced prepaid balance ledger
+  creditnote/               — credit notes + refunds
+  webhook/                  — outbound webhooks (HMAC-signed delivery)
+  audit/                    — immutable append-only audit log
   platform/postgres/        — RLS-aware database layer
-  platform/migrate/         — Embedded SQL migrations
+  platform/migrate/         — embedded SQL migrations
 
-web-v2/                     — Operator dashboard (React + TypeScript + shadcn/ui)
-  src/pages/                — Dashboard, Customers, Invoices, Subscriptions, etc.
-  src/components/           — Shared components (Layout, Badge, StatCard)
-  src/lib/api.ts            — Typed API client with auth
+web-v2/                     — operator dashboard (React 19 + TypeScript + Tailwind)
 ```
 
-**Key design decisions:**
+Design rules:
 - **Per-domain packages** — each domain owns its store, service, and handler. Zero cross-domain imports between peer packages.
 - **Row-Level Security** — every tenant-scoped query runs inside an RLS-enforced transaction. Proven by integration tests.
-- **PaymentIntent-only Stripe** — no Stripe Billing/Invoices (avoids 0.5% fee). We own invoices, Stripe handles payment execution.
+- **PaymentIntent-only Stripe** — no Stripe Billing/Invoices. We own invoices end-to-end; Stripe executes the card charge.
 - **Billing engine as coordinator** — orchestrates across domains via narrow interfaces, not a god object.
-- **Event-sourced credits** — immutable append-only ledger, balance computed from entries.
-- **HMAC-signed webhooks** — both inbound (Stripe) and outbound (tenant endpoints).
+- **Append-only event sourcing for money** — credits, audit log, outbound webhook outbox.
 
-## Billing Cycle
+ADRs explaining the load-bearing decisions live in [`docs/adr/`](docs/adr/).
 
-```
-Subscription (active) → Usage Events → Billing Engine → Invoice (draft)
-    → Finalize → Stripe PaymentIntent → Webhook → Invoice (paid)
-    → Payment fails → Dunning (retry schedule → escalation)
-```
+---
 
-The billing engine:
-1. Finds subscriptions where `next_billing_at <= now`
-2. Checks for per-customer price overrides
-3. Aggregates usage per meter for the billing period
-4. Computes charges using rating rules (flat, graduated, or package)
-5. Generates a draft invoice with itemized line items
-6. Advances the subscription to the next billing period
-
-## Performance
-
-Pricing engine benchmarks (Apple M2, zero allocations):
+## API surface (selected)
 
 ```
-BenchmarkComputeAmountCents_Flat              283M     4.2 ns/op    0 B/op    0 allocs/op
-BenchmarkComputeAmountCents_Graduated_5Tiers  137M     8.7 ns/op    0 B/op    0 allocs/op
-BenchmarkComputeAmountCents_Package           269M     4.5 ns/op    0 B/op    0 allocs/op
+POST   /v1/usage_events                 — ingest with dimensions + decimal value
+POST   /v1/usage-events/batch           — batch ingest, up to 1000 per call
+POST   /v1/meters/{id}/pricing_rules    — add a dimension-matched pricing rule
+GET    /v1/customers/{id}/usage         — period aggregation, grouped by dimension
+
+POST   /v1/customers                    — create customer
+POST   /v1/subscriptions                — create subscription
+POST   /v1/subscriptions/{id}/change-plan        — plan change w/ proration
+POST   /v1/subscriptions/{id}/pause-collection   — keep cycle, invoice as draft
+POST   /v1/subscriptions/{id}/extend-trial       — push trial_end_at later
+
+POST   /v1/billing/run                  — finalize all due cycles
+GET    /v1/billing/preview/{sub_id}     — invoice preview (dry run)
+
+POST   /v1/credit-notes                 — issue credit note (credit or refund)
+POST   /v1/credits/grant                — grant prepaid credits to a customer
+GET    /v1/credits/balance/{customer_id} — current balance + ledger
+
+GET    /v1/dunning/runs                 — list dunning runs
+POST   /v1/webhook-endpoints/endpoints  — register an outbound webhook endpoint
+GET    /v1/audit-log                    — query the append-only audit log
 ```
 
-The pricing engine computes ~150M prices per second per core.
+Full endpoint list and request/response shapes: [`docs/openapi.yaml`](docs/openapi.yaml).
 
-## Features
+---
 
-| Feature | Description |
-|---|---|
-| **3 Pricing Models** | Flat, graduated (tiered), package (bundled + overage) |
-| **Per-Customer Overrides** | Custom pricing per customer per rating rule |
-| **Trial Periods** | Configurable trial days, billing starts after trial |
-| **Plan Changes** | Upgrade/downgrade with proration factor |
-| **Pause/Resume** | Pause subscriptions without canceling |
-| **Customer Credits** | Event-sourced prepaid balance, auto-applied before Stripe charge |
-| **Credit Notes** | Issue against invoices (credit or refund) |
-| **PDF Invoices** | Professional A4 PDF rendering with line items |
-| **Invoice Preview** | Dry-run billing without persisting |
-| **Batch Ingestion** | Up to 1000 usage events per request |
-| **Dunning** | Configurable retry schedule, escalation, manual resolution |
-| **Outbound Webhooks** | HMAC-signed delivery to tenant endpoints, 13 event types |
-| **Audit Log** | Immutable log of all sensitive operations |
-| **API Key Auth** | 3 key types (platform/secret/publishable), 16 permissions |
-| **Idempotency Keys** | Prevent duplicate operations on retries |
-| **Rate Limiting** | Token bucket with Stripe-convention headers |
-| **RLS Isolation** | PostgreSQL Row-Level Security per tenant |
-| **MRR/ARR Dashboard** | Real-time billing metrics |
+## API key types
 
-## API Key Types
+| Type        | Prefix            | What it can do                                           |
+|-------------|-------------------|----------------------------------------------------------|
+| Platform    | `vlx_platform_`   | Tenant management only                                   |
+| Secret      | `vlx_secret_`     | Full tenant access (server-side)                         |
+| Publishable | `vlx_pub_`        | Usage ingestion + customer-bound reads (browser-safe)    |
 
-| Key Type | Prefix | Permissions |
-|---|---|---|
-| Platform | `vlx_platform_` | Tenant management only (2 permissions) |
-| Secret | `vlx_secret_` | Full tenant access (14 permissions) |
-| Publishable | `vlx_pub_` | Usage ingestion, customer CRUD, reads (6 permissions) |
+All keys are HMAC-rotated on a 72-hour overlap window, matching Stripe's webhook-signature pattern.
 
-## API Endpoints (68)
+---
 
-<details>
-<summary>Click to expand full endpoint list</summary>
+## Roadmap (next 90 days)
 
-```
-GET    /health                              — Health check
-GET    /health/ready                        — Deep health (DB connectivity)
+| Week  | Ship                                                                            |
+|-------|---------------------------------------------------------------------------------|
+| 1     | Positioning, README, blog post, design-partner outreach list (this commit)      |
+| 2     | Multi-dim meters, decimal quantities, all five aggregation modes                |
+| 3     | Pricing recipes (`anthropic_style`, etc.) + recipe-picker UI                    |
+| 4     | Quickstart wizard — sign-up → first invoice in <5 minutes                       |
+| 5     | `create_preview`, billing thresholds, billing alerts, `<VeloxCostDashboard />`  |
+| 6–7   | Live event stream UI, plan-migration preview, bulk operations, invoice composer |
+| 8     | 50 cold emails, 10+ demo calls, 3 design partners with signed LOI               |
+| 9     | Helm chart, Docker Compose, Terraform — self-host in ≤1 hour                    |
+| 10    | Compliance posture — encryption-at-rest, SOC2 mapping, GDPR export              |
+| 11    | Migration FROM Stripe Billing (importer + cutover playbook)                     |
+| 12    | First design partner cuts over to Velox in production                           |
+| 13    | Stabilize + public retro                                                         |
 
-POST   /v1/tenants                          — Create tenant
-GET    /v1/tenants                          — List tenants
-GET    /v1/tenants/{id}                     — Get tenant
+Full plan with leading indicators and risks: [`docs/90-day-plan.md`](docs/90-day-plan.md).
 
-POST   /v1/api-keys                         — Create API key
-GET    /v1/api-keys                         — List API keys
-DELETE /v1/api-keys/{id}                    — Revoke API key
+---
 
-POST   /v1/customers                        — Create customer
-GET    /v1/customers                        — List customers
-GET    /v1/customers/{id}                   — Get customer
-PATCH  /v1/customers/{id}                   — Update customer
-PUT    /v1/customers/{id}/billing-profile   — Upsert billing profile
-GET    /v1/customers/{id}/billing-profile   — Get billing profile
+## Tech stack
 
-POST   /v1/meters                           — Create meter
-GET    /v1/meters                           — List meters
-GET    /v1/meters/{id}                      — Get meter
+**Backend** — Go 1.25, chi/v5 router, PostgreSQL 16 with RLS, `shopspring/decimal` for money, `go-pdf/fpdf` for invoices, Prometheus metrics.
 
-POST   /v1/plans                            — Create plan
-GET    /v1/plans                            — List plans
-GET    /v1/plans/{id}                       — Get plan
-PATCH  /v1/plans/{id}                       — Update plan
+**Frontend** — React 19, TypeScript, Vite, TailwindCSS, shadcn/ui, Lucide icons.
 
-POST   /v1/rating-rules                     — Create rating rule
-GET    /v1/rating-rules                     — List rating rules
-GET    /v1/rating-rules/{id}               — Get rating rule
+**Payments** — Stripe (PaymentIntents + Checkout Sessions). No Stripe Billing dependency.
 
-POST   /v1/price-overrides                  — Create/update price override
-GET    /v1/price-overrides                  — List price overrides
+---
 
-POST   /v1/subscriptions                    — Create subscription
-GET    /v1/subscriptions                    — List subscriptions
-GET    /v1/subscriptions/{id}              — Get subscription
-POST   /v1/subscriptions/{id}/activate     — Activate draft subscription
-POST   /v1/subscriptions/{id}/pause        — Pause subscription
-POST   /v1/subscriptions/{id}/resume       — Resume subscription
-POST   /v1/subscriptions/{id}/change-plan  — Change plan (upgrade/downgrade)
-POST   /v1/subscriptions/{id}/cancel       — Cancel subscription
-
-POST   /v1/usage-events                     — Ingest single usage event
-POST   /v1/usage-events/batch              — Batch ingest (up to 1000)
-GET    /v1/usage-events                     — List usage events
-GET    /v1/usage-summary/{customer_id}     — Aggregated usage summary
-
-GET    /v1/invoices                         — List invoices
-GET    /v1/invoices/{id}                   — Get invoice + line items
-GET    /v1/invoices/{id}/pdf               — Download invoice PDF
-POST   /v1/invoices/{id}/finalize          — Finalize draft invoice
-POST   /v1/invoices/{id}/void             — Void invoice
-
-POST   /v1/billing/run                     — Trigger billing cycle
-GET    /v1/billing/preview/{sub_id}        — Invoice preview (dry run)
-
-POST   /v1/credit-notes                    — Create credit note
-GET    /v1/credit-notes                    — List credit notes
-GET    /v1/credit-notes/{id}              — Get credit note
-POST   /v1/credit-notes/{id}/issue        — Issue credit note
-POST   /v1/credit-notes/{id}/void         — Void credit note
-
-POST   /v1/credits/grant                   — Grant customer credits
-POST   /v1/credits/adjust                  — Manual credit adjustment
-GET    /v1/credits/balance/{customer_id}   — Get credit balance
-GET    /v1/credits/ledger/{customer_id}    — Full credit ledger
-
-GET    /v1/dunning/policy                  — Get dunning policy
-PUT    /v1/dunning/policy                  — Configure dunning policy
-GET    /v1/dunning/runs                    — List dunning runs
-GET    /v1/dunning/runs/{id}              — Get dunning run + events
-POST   /v1/dunning/runs/{id}/resolve      — Resolve dunning run
-
-POST   /v1/webhook-endpoints/endpoints    — Register webhook endpoint
-GET    /v1/webhook-endpoints/endpoints    — List webhook endpoints
-DELETE /v1/webhook-endpoints/endpoints/{id} — Delete endpoint
-GET    /v1/webhook-endpoints/events       — List webhook events
-GET    /v1/webhook-endpoints/events/{id}/deliveries — Delivery attempts
-
-GET    /v1/settings                        — Get tenant settings
-PUT    /v1/settings                        — Update tenant settings
-
-GET    /v1/audit-log                       — Query audit log
-
-POST   /v1/webhooks/stripe                 — Stripe webhook receiver
-```
-
-</details>
-
-## Development
+## Running tests
 
 ```bash
-make test               # Unit tests
-make test-integration   # Integration tests (requires Postgres)
-make dev                # Run server locally
-make bootstrap          # Create demo tenant + API keys
+make test                # unit tests only
+make test-integration    # full integration suite (needs Postgres)
 ```
 
-## Tech Stack
+Integration tests exercise real Postgres with RLS enforced. Per project convention, tests must hit a real database — never mocks — so a passing test means migrations and RLS work end-to-end.
 
-**Backend:**
-- **Go 1.25** — API server (chi/v5 router)
-- **PostgreSQL 16** — System of record with Row-Level Security
-- **Stripe** — Payment execution (PaymentIntents + Checkout Sessions)
-- **go-pdf/fpdf** — Invoice PDF rendering
-- **Prometheus** — Metrics endpoint
+---
 
-**Frontend:**
-- **React 19** + **TypeScript** — Operator dashboard
-- **Vite** — Build tooling
-- **TailwindCSS** — Styling
-- **Lucide** — Icons
+## Contributing
+
+Velox is open source under MIT. We're early and looking for design partners (12 months free hosted access in exchange for weekly check-ins and a co-branded case study). If you run AI inference, a vector DB, or any usage-heavy SaaS at $1M–$50M ARR and Stripe Billing is starting to chafe — open an issue or email `partners@velox.dev`.
+
+For code contributions, see [`CONTRIBUTING.md`](CONTRIBUTING.md) and the design-first / RFC pattern in [`docs/parallel-work.md`](docs/parallel-work.md).
+
+---
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@ curl -X POST https://api.velox.dev/v1/meters \
   -d '{"key": "tokens", "name": "LLM tokens", "unit": "token"}'
 
 # 2. Ingest events that carry the dimensions inline
-curl -X POST https://api.velox.dev/v1/usage_events \
+curl -X POST https://api.velox.dev/v1/usage-events \
   -H "Authorization: Bearer $VELOX_SECRET" \
   -H "Idempotency-Key: req_8f2c..." \
   -d '{
-    "meter_key": "tokens",
-    "customer_id": "cust_acme",
-    "value": "12450",
+    "event_name": "tokens",
+    "external_customer_id": "cust_acme",
+    "quantity": "12450",
     "dimensions": {"model": "gpt-4", "operation": "input", "cached": false}
   }'
 
 # 3. Define one pricing rule per (dimension subset, rate)
-curl -X POST https://api.velox.dev/v1/meters/mtr_tokens/pricing_rules \
+curl -X POST https://api.velox.dev/v1/meters/mtr_tokens/pricing-rules \
   -d '{
     "dimension_match": {"model": "gpt-4", "operation": "input", "cached": false},
     "rating_rule_version_id": "rrv_gpt4_input_uncached",
@@ -170,9 +170,9 @@ ADRs explaining the load-bearing decisions live in [`docs/adr/`](docs/adr/).
 ## API surface (selected)
 
 ```
-POST   /v1/usage_events                 — ingest with dimensions + decimal value
+POST   /v1/usage-events                 — ingest with dimensions + decimal value
 POST   /v1/usage-events/batch           — batch ingest, up to 1000 per call
-POST   /v1/meters/{id}/pricing_rules    — add a dimension-matched pricing rule
+POST   /v1/meters/{id}/pricing-rules    — add a dimension-matched pricing rule
 GET    /v1/customers/{id}/usage         — period aggregation, grouped by dimension
 
 POST   /v1/customers                    — create customer

--- a/docs/blog/2026-04-stripe-meter-api-ai-workloads.md
+++ b/docs/blog/2026-04-stripe-meter-api-ai-workloads.md
@@ -90,11 +90,11 @@ This is what people mean when they say "Stripe Billing wasn't built for AI." The
 Velox's [multi-dim meters design](../design-multi-dim-meters.md) takes the inverse position. There is **one meter per usage type** — `tokens`, `requests`, `gb_hours` — and events carry dimensions inline:
 
 ```json
-POST /v1/usage_events
+POST /v1/usage-events
 {
-  "meter_key": "tokens",
-  "customer_id": "cus_acme",
-  "value": "12450",
+  "event_name": "tokens",
+  "external_customer_id": "cus_acme",
+  "quantity": "12450",
   "dimensions": {
     "model": "opus4",
     "operation": "input",
@@ -110,7 +110,7 @@ POST /v1/usage_events
 Pricing is then expressed as **rules attached to the meter**, each with a `dimension_match` and an `aggregation_mode`:
 
 ```json
-POST /v1/meters/mtr_tokens/pricing_rules
+POST /v1/meters/mtr_tokens/pricing-rules
 {
   "rating_rule_version_id": "rrv_opus4_input_uncached",
   "dimension_match": {
@@ -132,7 +132,7 @@ This collapses the 36 cells from the Stripe wiring into:
 - **36 pricing rules** on that meter
 - **1 subscription item** per customer
 
-The dimension structure that lives in your application gets sent across the wire intact. You can ask "how many tokens did this customer use across all Opus models in April?" with a single grouping query — `GET /v1/customers/{id}/usage?meter_key=tokens&group_by=model`. You can introduce a new model by adding one rule, not 12. You can deprecate a cell by removing one rule, not migrating every customer's subscription items.
+The dimension structure that lives in your application gets sent across the wire intact. You can ask "how many tokens did this customer use across all Opus models in April?" with a single grouping query — `GET /v1/customers/{id}/usage?event_name=tokens&group_by=model`. You can introduce a new model by adding one rule, not 12. You can deprecate a cell by removing one rule, not migrating every customer's subscription items.
 
 ---
 

--- a/docs/blog/2026-04-stripe-meter-api-ai-workloads.md
+++ b/docs/blog/2026-04-stripe-meter-api-ai-workloads.md
@@ -1,0 +1,175 @@
+# Why Stripe Billing's Meter API doesn't fit AI workloads
+
+> Published 2026-04-25. By the Velox team.
+> Code samples are real; the API contracts referenced are
+> Stripe's [Billing Meter](https://docs.stripe.com/api/billing/meter) and
+> Velox's [multi-dim meters RFC](../design-multi-dim-meters.md).
+
+If you bill an AI product — inference, embeddings, agentic workflows, vector search — you've probably tried to model your pricing inside Stripe Billing and noticed something is wrong. You start with one Meter for "tokens." Then you add another for "output tokens" because input and output bill at different rates. Then "cached input" because Anthropic prompt caching is 90% cheaper. Then "batch" because batch pricing is half. Three models in your catalog, and you're suddenly at twenty-something Meters, each tied to its own Price and its own Subscription Item, before a single customer is on the system.
+
+The reason isn't that Stripe shipped a bad API. The reason is that the Meter API was bolted onto a card-subscription engine designed in 2014 for SaaS seats. AI usage doesn't look like seats — it looks like a five-dimensional cube — and the Meter object simply doesn't have the shape to express that cube.
+
+This post walks through the structural mismatch, shows what the wiring actually looks like, and describes how Velox treats dimensions as first-class on the meter so you go from N Meters back down to one.
+
+---
+
+## What a Stripe Meter actually is
+
+Stripe's [Meter object](https://docs.stripe.com/api/billing/meter/object) has these fields:
+
+```
+id, object, created, status, livemode
+event_name              // the string events must match
+default_aggregation     // one of: sum, count, last
+event_time_window       // day | hour
+value_settings          // which payload key holds the numeric value
+customer_mapping        // how to extract the customer id from the event
+status_transitions, updated
+```
+
+Three things are pinned at meter-creation time:
+
+1. **The event name.** A meter listens for one and only one `event_name`. Events sent under any other name simply do not aggregate against it.
+2. **The aggregation formula.** [`default_aggregation.formula`](https://docs.stripe.com/api/billing/meter/object) is one of `sum`, `count`, or `last`. It's a property of the meter, not the price, and there's no way to apply two different aggregations to the same event stream.
+3. **Where the numeric value lives.** `value_settings.event_payload_key` names a single key inside `payload` that holds the number to aggregate. One key per meter.
+
+Meter Events are posted to [`POST /v1/billing/meter_events`](https://docs.stripe.com/api/billing/meter-events/create) with a payload of the form:
+
+```json
+{
+  "event_name": "tokens",
+  "timestamp": 1714000000,
+  "payload": {
+    "stripe_customer_id": "cus_abc",
+    "value": "1234"
+  }
+}
+```
+
+The payload is opaque to billing. You can put extra metadata in there, but Stripe Billing doesn't read it. Aggregation is `SUM(payload.value) WHERE event_name = $meter.event_name AND payload.stripe_customer_id = $customer_id`. That's it. You don't get to filter by other payload keys.
+
+A Price is then created with `recurring.usage_type = metered` and `recurring.meter = mtr_xyz`, and a Subscription Item attaches that Price to a customer. The Subscription Item is the unit that gets billed. **Each rate cell in your pricing matrix wants its own Price, which wants its own Meter, which wants its own Subscription Item.**
+
+That's the load-bearing fact. The rest follows from it.
+
+---
+
+## What this means for AI pricing
+
+[Anthropic's published pricing](https://docs.anthropic.com/en/docs/about-claude/pricing) for a single model splits across at least four dimensions:
+
+- **Model** — Opus 4, Sonnet 4, Haiku 4 (and prior generations still in customer catalogs)
+- **Operation** — input tokens vs. output tokens
+- **Cache state** — base input, prompt-cache write, prompt-cache read
+- **Batch mode** — real-time vs. batch (50% discount)
+
+Multiplied through for one model: 1 × 2 × 3 × 2 = **12 distinct rate cells**. For a catalog of three live models that's **36 cells**. OpenAI's catalog has similar shape. Most billing teams I've talked to who serve other AI customers run between 16 and 60 cells, depending on how many models they expose and whether they pass through cache and batch tiers.
+
+Now wire that on Stripe Billing. Each cell needs:
+
+- One **Meter** with a unique `event_name` (e.g., `tokens.opus4.input.uncached.realtime`) and a fixed `sum` aggregation
+- One **Price** referencing that meter at the cell's rate
+- One **Subscription Item** on every customer's subscription pinning that price
+
+If you have 36 cells and 5,000 active customers, that's:
+
+- 36 meters in your account
+- 36 prices in your catalog
+- **180,000 subscription items** that have to exist before any usage gets billed correctly
+
+Your ingest path also has to know which `event_name` to send. The dimension structure that lives naturally in your application — `{model: "opus4", operation: "input", cached: false, batch: false}` — has to be flattened into a string like `tokens.opus4.input.uncached.realtime` before crossing the Stripe boundary, then is unrecoverable on the other side. You can't ask Stripe "how many tokens did this customer use across all Opus models?" — that aggregation doesn't exist as a first-class object. You'd have to fetch each meter individually, or maintain the same data in your own warehouse.
+
+If you ever change the rate-card structure — collapse a cell, split a cell, add a new model, sunset an old one — every customer's subscription item set has to migrate. Stripe gives you [Subscription Schedules](https://docs.stripe.com/api/subscription_schedules) to phase that, but the operational cost is real.
+
+This is what people mean when they say "Stripe Billing wasn't built for AI." The API is fine for what it is — a clean, well-documented, financially correct usage-bill primitive — but its unit of composition is a meter+price+subscription-item triple, and AI pricing wants the unit of composition to be a single dimension on a single event.
+
+---
+
+## What changes when dimensions are first-class
+
+Velox's [multi-dim meters design](../design-multi-dim-meters.md) takes the inverse position. There is **one meter per usage type** — `tokens`, `requests`, `gb_hours` — and events carry dimensions inline:
+
+```json
+POST /v1/usage_events
+{
+  "meter_key": "tokens",
+  "customer_id": "cus_acme",
+  "value": "12450",
+  "dimensions": {
+    "model": "opus4",
+    "operation": "input",
+    "cached": false,
+    "batch": false
+  },
+  "timestamp": "2026-04-25T12:34:56Z"
+}
+```
+
+`dimensions` is JSONB. No schema enforcement at v1; whatever your application emits, Velox stores. The `value` is `NUMERIC(38, 12)`, so you can bill fractional GPU-hours and partial tokens without precision games.
+
+Pricing is then expressed as **rules attached to the meter**, each with a `dimension_match` and an `aggregation_mode`:
+
+```json
+POST /v1/meters/mtr_tokens/pricing_rules
+{
+  "rating_rule_version_id": "rrv_opus4_input_uncached",
+  "dimension_match": {
+    "model": "opus4",
+    "operation": "input",
+    "cached": false,
+    "batch": false
+  },
+  "aggregation_mode": "sum",
+  "priority": 100
+}
+```
+
+`dimension_match` uses subset semantics — `{model: "opus4"}` matches every event tagged with that model regardless of other dimensions, and a more specific rule (`{model: "opus4", cached: true}`) at higher priority claims its events first. Each event is claimed by exactly one rule per (customer, period) so there's no double-counting. The rating rule version (`rrv_…`) holds the actual rate, and Velox's existing flat / graduated / package logic is unchanged — only the resolution layer is new.
+
+This collapses the 36 cells from the Stripe wiring into:
+
+- **1 meter** (`tokens`)
+- **36 pricing rules** on that meter
+- **1 subscription item** per customer
+
+The dimension structure that lives in your application gets sent across the wire intact. You can ask "how many tokens did this customer use across all Opus models in April?" with a single grouping query — `GET /v1/customers/{id}/usage?meter_key=tokens&group_by=model`. You can introduce a new model by adding one rule, not 12. You can deprecate a cell by removing one rule, not migrating every customer's subscription items.
+
+---
+
+## The aggregation-mode mismatch
+
+There's a second, smaller structural mismatch worth flagging. Stripe Billing supports three aggregation formulas — `sum`, `count`, `last` — and pins the choice at the meter. Their legacy `Plan.aggregate_usage` enum (still surfacing on older subscriptions) supports five — `sum`, `last_during_period`, `last_ever`, `max`, `most_recent` — and also pins it.
+
+The right shape is: **aggregation is a property of the rule, not the meter.** The same `tokens` meter might want `sum` for prepaid bundles, `max` for "peak concurrent usage" tiers, and `last_ever` for a seat-count-style usage that bills by current state regardless of when the event was emitted. Velox carries all five (`sum`, `count`, `last_during_period`, `last_ever`, `max`) per pricing rule.
+
+This is squarely on Stripe's [Tier 1 gap list](https://docs.stripe.com/billing/migration/migrate-subscriptions-to-prices-and-meters#aggregation-modes) of "things the new Meter API doesn't yet match from the old Plan model." It's fixable in their model, but it isn't fixed today, and the per-rule placement is strictly more expressive even if Stripe ships the missing modes.
+
+---
+
+## What this gives you operationally
+
+The shape change isn't only an API ergonomics win. Three operational benefits fall out of it that the Stripe Meter API can't provide cleanly:
+
+**1. A real cost dashboard.** Once events carry dimensions, your application can render "you've used $4.31 of Opus today, $0.18 of Sonnet, $11.62 of Haiku" without running a separate analytics pipeline. Velox ships an embeddable React component (`<VeloxCostDashboard customerId={…} />`) that queries `/v1/customers/{id}/usage?group_by=model` and shows per-dimension burn against the current period's projected bill. This is the surface AI buyers are starting to expect — Anthropic, OpenAI, and Replicate all expose some form of it; building it on Stripe Meter requires you to mirror your own usage data into a warehouse and join it back.
+
+**2. Mid-period rate changes without subscription-item churn.** Updating a rate on Stripe means swapping the Price on the Subscription Item, with all the proration handling that implies. In Velox you create a new `rating_rule_version`, point the relevant pricing rule at it, and set an effective-from date — the subscription itself never changes shape.
+
+**3. Auditable dimension lineage.** Every event in `usage_events` keeps its full dimension payload. When a customer asks "why did I get billed $X for cached input?", you can answer them by re-running the aggregation query, not by reconstructing event names from logs.
+
+---
+
+## When Stripe Billing's Meter API is still the right tool
+
+Anti-positioning matters. If your pricing is genuinely one-dimensional — per-seat SaaS, per-API-request without tiering, single-rate metered — Stripe Meter is fine and you should not be reading this post. Their implementation is solid, their docs are excellent, and the tax/regulatory and PCI scope you'd otherwise own goes away. The Meter API's structural limits don't matter if your pricing only has one dimension to begin with.
+
+The decision point is the cardinality of your rate matrix. Below ~6 cells, Stripe is comfortable. Above ~12, you're fighting the API. Between, it depends on how often the matrix changes — if it's stable for years, the wiring tax is one-time; if you're iterating, it compounds.
+
+---
+
+## What we're building
+
+Velox's multi-dim meter implementation lands in `v0.x` on **May 8, 2026** (Week 2 of our [90-day plan](../90-day-plan.md)). The schema, API surface, aggregation semantics, and test plan are public in the [design doc](../design-multi-dim-meters.md). The endpoints in this post are the published contract — you can scaffold against them today.
+
+If you run an AI product where the rate matrix is starting to outgrow Stripe Billing, or where regulatory pressure (EU GDPR-strict, India RBI data localization, healthcare-adjacent SaaS) means you can't keep customer billing data on Stripe's servers in the first place — we're looking for design partners. Twelve months free hosted access in exchange for a weekly check-in and a co-branded case study. Email `partners@velox.dev` or open an issue on [the repo](https://github.com/sagarsuperuser/velox).
+
+Velox is open source under MIT. The wedge is small and clear: AI-native, self-host first, the layer above PaymentIntent. The full positioning is in [`docs/positioning.md`](../positioning.md).

--- a/docs/marketing/outreach-list.md
+++ b/docs/marketing/outreach-list.md
@@ -1,0 +1,128 @@
+# Velox — Design-Partner Outreach List (50)
+
+> Compiled 2026-04-25 for Track B / Week 1 of the [90-day plan](../90-day-plan.md).
+> Target: 3 design partners with signed LOI by Day 60 (Week 8). 12 months free
+> hosted access in exchange for weekly check-in and co-branded case study.
+
+## How to use this list
+
+Each row below is a **lead**, not a confirmed contact. Names listed are public-facing
+founders/CEOs/CTOs whose roles were widely indexed as of late 2025/early 2026; verify
+on LinkedIn or the company's `/about` page before any outbound email — engineering
+leadership rotates faster than founder seats, and a stale title burns the first
+impression.
+
+Outreach priority is driven by wedge fit, not company size:
+
+1. **Pricing-matrix complexity** — published rate cards with model × operation ×
+   cache × tier dimensions ≥ 12 cells. These teams already feel the Stripe Meter
+   API pain.
+2. **Regulatory exposure** — EU GDPR-strict, India RBI data-localization, healthcare,
+   gov-procurement adjacency. Self-host pillar lands hardest here.
+3. **Stripe Billing fee surface** — companies likely paying ≥ $5K/month in Stripe
+   Billing fees (rough proxy: $1M+ ARR, usage-billed product, cards via Stripe).
+4. **Engineering-led decision** — VP Eng or staff/principal engineer can sign-off
+   without procurement.
+
+Tiers below are coarse: **A** = strong wedge fit + prior signal of pricing-model
+pain (top of pipeline), **B** = good fit, less public pain signal, **C** = adjacent
+fit (worth one touch).
+
+The spreadsheet-style table below is the working document. Pre-send checklist:
+
+- [ ] Verify role on LinkedIn within last 60 days
+- [ ] Read their public pricing page; confirm wedge applies
+- [ ] First-line opener references a specific dimension of their rate card or a
+      regulatory constraint they've publicly mentioned
+
+---
+
+## AI inference & model APIs (22)
+
+| #  | Tier | Company        | URL                  | Contact (verify)            | Role                  | Why fit                                                                                          |
+|----|------|----------------|----------------------|-----------------------------|------------------------|--------------------------------------------------------------------------------------------------|
+| 1  | A    | Replicate      | replicate.com        | Ben Firshman               | CEO / co-founder       | Per-second compute billing across hundreds of models — multi-dim rate card on day one.           |
+| 2  | A    | Together AI    | together.ai          | Vipul Ved Prakash          | CEO / co-founder       | Hosted inference for OSS LLMs; per-token pricing across model × operation, scaling fast.         |
+| 3  | A    | Fireworks AI   | fireworks.ai         | Lin Qiao                   | CEO / co-founder       | Fast LLM inference with custom-model surcharges and serverless tiers; rate matrix is large.      |
+| 4  | A    | Modal          | modal.com            | Erik Bernhardsson          | CEO / founder          | Per-second GPU billing across A10/A100/H100 tiers + CPU + storage. Erik writes about infra publicly. |
+| 5  | A    | Baseten        | baseten.co           | Tuhin Srivastava           | CEO / co-founder       | Custom model serving; per-replica + per-second + per-request dimensions.                          |
+| 6  | A    | Anyscale       | anyscale.com         | Robert Nishihara           | CEO / co-founder       | Ray-based platform; usage-billed compute + memory + GPU dimensions.                              |
+| 7  | B    | RunPod         | runpod.io            | Pardeep Singh              | CEO / co-founder       | GPU-by-the-second cloud; community vs. secure-cloud tiers compound the rate matrix.              |
+| 8  | A    | Lepton AI      | lepton.ai            | Yangqing Jia               | CEO / founder          | Founder built Caffe + ONNX; AI infra company likely to engage with technical billing argument.   |
+| 9  | B    | Groq           | groq.com             | Jonathan Ross              | CEO / founder          | LPU inference; speculative on billing model but well-known in inference space.                   |
+| 10 | B    | SambaNova      | sambanova.ai         | Rodrigo Liang              | CEO / co-founder       | Enterprise inference; data-residency conversations come up naturally.                            |
+| 11 | A    | Cerebras Cloud | cerebras.net         | Andrew Feldman             | CEO / co-founder       | Wafer-scale inference cloud; usage-billed by tokens × model × tier.                              |
+| 12 | B    | Cohere         | cohere.com           | Aidan Gomez                | CEO / co-founder       | Enterprise LLM API with command/embed/rerank — multi-dimensional from day one.                   |
+| 13 | C    | Mistral AI     | mistral.ai           | Arthur Mensch              | CEO / co-founder       | EU-based LLM API; GDPR-strict by default, multi-model rate card.                                 |
+| 14 | A    | ElevenLabs     | elevenlabs.io        | Mati Staniszewski          | CEO / co-founder       | Voice gen billed per character × voice tier × model — pricing matrix already complex.            |
+| 15 | A    | Deepgram       | deepgram.com         | Scott Stephenson           | CEO / co-founder       | Speech-to-text API across model tiers, languages, batch vs. streaming — multi-dim everywhere.    |
+| 16 | A    | AssemblyAI     | assemblyai.com       | Dylan Fox                  | CEO / founder          | Speech AI APIs with per-second + per-feature (diarization, sentiment) billing.                   |
+| 17 | B    | Hume AI        | hume.ai              | Alan Cowen                 | CEO / co-founder       | Empathic voice + emotion APIs; novel-feature pricing tends toward dimensional.                   |
+| 18 | C    | RunwayML       | runwayml.com         | Cris Valenzuela            | CEO / co-founder       | Generative video; per-second × resolution × model rate cells.                                    |
+| 19 | C    | Pika           | pika.art             | Demi Guo                   | CEO / co-founder       | Video generation, consumer-leaning today — verify if a self-serve API exists yet.                |
+| 20 | C    | Suno           | suno.com             | Mikey Shulman              | CEO / co-founder       | Music generation; subscription today, API may be on roadmap.                                     |
+| 21 | C    | Perplexity     | perplexity.ai        | Aravind Srinivas           | CEO / co-founder       | Sonar API + per-token billing; large enough that a wedge-fit conversation is worth one touch.    |
+| 22 | C    | Friendli AI    | friendli.ai          | Byung-Gon Chun             | CEO                    | Korean inference platform with token-batching billing — verify English-language outreach norms.  |
+
+## Vector DB & RAG infra (9)
+
+| #  | Tier | Company       | URL              | Contact (verify)         | Role                  | Why fit                                                                                            |
+|----|------|---------------|------------------|--------------------------|------------------------|----------------------------------------------------------------------------------------------------|
+| 23 | A    | Pinecone      | pinecone.io      | Edo Liberty             | CEO / founder          | Serverless tier billed by storage × reads × writes — three-dim minimum.                            |
+| 24 | A    | Weaviate      | weaviate.io      | Bob van Luijt           | CEO / co-founder       | OSS-first vector DB with hosted SaaS; tier × dimension × storage rate cells.                       |
+| 25 | A    | Qdrant        | qdrant.tech      | Andre Zayarni           | CEO / co-founder       | OSS vector DB with cloud; rate card is RAM × storage × throughput.                                 |
+| 26 | B    | Chroma        | trychroma.com    | Jeff Huber              | CEO / co-founder       | Embedding DB; cloud product is usage-billed and growing.                                           |
+| 27 | A    | LanceDB       | lancedb.com      | Chang She               | CEO / co-founder       | Multimodal vector DB; usage billing across compute, storage, retrieval.                            |
+| 28 | A    | Turbopuffer   | turbopuffer.com  | Simon Hørup Eskildsen   | Founder / CEO          | Serverless vector search billed per-query × storage; Simon is a careful systems writer publicly.   |
+| 29 | B    | Zilliz / Milvus | zilliz.com     | Charles Xie             | CEO / founder          | Hosted Milvus; vector storage + read/write tiers.                                                  |
+| 30 | C    | Marqo         | marqo.ai         | Tom Hamer               | CEO / co-founder       | Multimodal embeddings as a service; smaller, may welcome design-partner deal.                      |
+| 31 | C    | Vespa         | vespa.ai         | Jon Bratseth            | CEO                    | Yahoo spin-out; enterprise search/vector. Larger eng org but data-sovereignty pillar lands.        |
+
+## Dev infra & API platforms (19)
+
+| #  | Tier | Company        | URL              | Contact (verify)        | Role                  | Why fit                                                                                          |
+|----|------|----------------|------------------|-------------------------|------------------------|--------------------------------------------------------------------------------------------------|
+| 32 | A    | Resend         | resend.com       | Zeno Rocha             | CEO / co-founder       | Email API with per-email + tier-based pricing; small team likely to feel Stripe Billing limits.  |
+| 33 | A    | Knock          | knock.app        | Chris Bell             | CEO / co-founder       | Notifications API; per-message × channel rate cells.                                             |
+| 34 | A    | Svix           | svix.com         | Tom Hacohen            | CEO / co-founder       | Webhooks-as-a-service, OSS-first. Tom blogs technically — likely receptive.                      |
+| 35 | B    | Hookdeck       | hookdeck.com     | Alex Bouchard          | CEO / co-founder       | Webhook reliability platform; usage-billed by event volume.                                      |
+| 36 | A    | Inngest        | inngest.com      | Tony Holdstock-Brown   | CEO / co-founder       | Durable workflows; per-step × per-second compute billing — multi-dim.                            |
+| 37 | A    | Trigger.dev    | trigger.dev      | Eric Allam             | CEO / co-founder       | Background job platform; per-execution + duration billing.                                       |
+| 38 | A    | Convex         | convex.dev       | James Cowling          | CEO / co-founder       | Backend platform billed per-function × bandwidth × storage; usage-heavy.                         |
+| 39 | B    | Liveblocks     | liveblocks.io    | Steven Fabre           | CEO / co-founder       | Realtime collaboration infra; per-MAU × per-room dimensions.                                     |
+| 40 | A    | PostHog        | posthog.com      | James Hawkins          | CEO / co-founder       | Product analytics; OSS + cloud, usage-billed by events × features. Known for OSS empathy.        |
+| 41 | A    | Tinybird       | tinybird.co      | Jorge Sancha           | CEO / co-founder       | Real-time analytics API; per-query × per-row × storage rate matrix.                              |
+| 42 | A    | Axiom          | axiom.co         | Neil Jagdish Patel     | CEO / co-founder       | Observability platform billed by ingest × storage × query — three-dim minimum.                   |
+| 43 | B    | Highlight      | highlight.io     | Vadim Korolik          | CEO / co-founder       | Session replay + observability; per-session × retention dimensions.                              |
+| 44 | A    | Supabase       | supabase.com     | Paul Copplestone       | CEO / co-founder       | OSS Postgres-as-a-service; usage-billed by compute × storage × egress + multi-region.            |
+| 45 | A    | Neon           | neon.tech        | Nikita Shamgunov       | CEO / co-founder       | Serverless Postgres billed per CU-hour × storage × egress; usage-heavy and growing fast.         |
+| 46 | A    | Turso          | turso.tech       | Glauber Costa          | CEO / co-founder       | Edge SQLite billed per-read × per-write × storage × replica region.                              |
+| 47 | B    | PlanetScale    | planetscale.com  | Sam Lambert            | CEO                    | MySQL platform with usage-based tiers; large eng team but pricing complexity is real.            |
+| 48 | C    | Hasura         | hasura.io        | Tanmai Gopal           | CEO / co-founder       | GraphQL engine; v3 cloud is usage-billed across requests, rows, regions.                         |
+| 49 | B    | E2B            | e2b.dev          | Vasek Mlejnsky         | CEO / co-founder       | Code-execution sandboxes for AI agents; per-second × resource billing — emerging multi-dim.      |
+| 50 | B    | Browserbase    | browserbase.com  | Paul Klein IV          | CEO / co-founder       | Headless-browser API for AI agents; per-session × per-minute × proxy-tier rate cells.            |
+
+---
+
+## Outreach sequencing (suggested)
+
+- **Days 1–7 (Week 1):** verify roles, draft per-segment cold-email templates, set up `partners@velox.dev` and a single-page tracker.
+- **Days 8–14 (Week 2):** send to **all 14 Tier-A AI-inference rows** (#1–6, 8, 11, 14–16) — strongest wedge fit.
+- **Days 15–21 (Week 3):** Tier-A vector DB (#23–25, 27–28) + Tier-A dev infra (#32–34, 36–38, 40–42, 44–46).
+- **Days 22–28 (Week 4):** Tier-B follow-ups; second touch for any Tier-A non-responses.
+- **Days 29–60:** book demo calls; convert to LOI on the 12-months-free-for-case-study deal.
+
+## Templates needed (separate doc, Week 2)
+
+- AI inference cold email (lead with the multi-dim rate-card observation; reference their pricing page specifically)
+- Vector DB cold email (lead with self-host + data sovereignty)
+- Dev infra cold email (lead with the Stripe Meter API friction post)
+- Founder-to-founder vs. CEO-to-VP-Eng tone variants
+
+## What's deliberately not on this list
+
+- **Anthropic, OpenAI, Google AI, Microsoft AI, Meta AI** — they build their own billing; not customers.
+- **Pre-seed companies** — usually still on Stripe Billing's free tier, not feeling the friction.
+- **Marketplace / Connect-pattern companies** — out of wedge per [`docs/positioning.md`](../positioning.md).
+- **Consumer-only AI apps** (no API, no usage billing) — wrong shape.
+- **Hyperscaler internal teams** (AWS, GCP, Azure) — internal billing is a different problem domain.

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -39,6 +39,28 @@
 - **Open questions for human:** none yet — wedge is clear from positioning.md
 - **Next:** start the README rewrite immediately.
 
+#### End-of-turn (Track B)
+- **Shipped (all three Week 1 deliverables, in order):**
+  - `README.md` — full rewrite. Leads with the AI-native + self-host wedge from `docs/positioning.md`. Replaced (not appended to) the generic framing. Includes the multi-dim "wedge in code" demo, three pillars, anti-positioning, comparison table, 90-day roadmap. Drops the stale stat block (numbers were 6+ months out of date).
+  - `docs/blog/2026-04-stripe-meter-api-ai-workloads.md` — long-form post (~1,800 words). Walks the Stripe Meter object model field-by-field (verified against `docs.stripe.com/api/billing/meter/object`), shows ~36 Meters of wiring for an Anthropic-style 4-dim rate card, contrasts with 1 meter + N rules in Velox, calls out the per-meter aggregation-mode mismatch as a second structural issue. Honest anti-positioning section ("when Stripe Meter is still right").
+  - `docs/marketing/outreach-list.md` — 50 leads: 22 AI inference / model APIs, 9 vector DB, 19 dev infra. Each row has named founder/CEO with a `(verify)` flag, a tier (A/B/C), and a wedge-fit reason tied to their public pricing matrix or regulatory profile. Includes outreach sequencing, what's deliberately *not* on the list, and a templates-needed punch list for Week 2.
+- **Commits (this branch, in order):**
+  - `080d90d docs(handoff): Track B kickoff entry`
+  - `e0d2e09 docs(readme): lead with AI-native + self-host wedge`
+  - `815a472 docs(blog): why Stripe Meter API doesn't fit AI workloads (draft)`
+  - `e97dd0b docs(marketing): 50-candidate outreach list (AI inference, vector DB, dev infra)`
+- **Discipline notes:**
+  - No half-finished drafts; each deliverable shipped polished before moving on.
+  - Industry-references-first: Stripe Meter object/event docs verified via WebFetch before writing the blog post; positioning anchored explicitly on Stripe / Lago / Orb / OpenMeter / Vercel / Linear.
+  - No seed-data shortcuts; outreach list groups companies by **wedge fit**, not "easy to demo to."
+  - All three deliverables explicitly anchor on `docs/positioning.md` and `docs/design-multi-dim-meters.md` (the design doc is the API contract for the README and blog code samples).
+  - Did not touch `internal/`, `cmd/`, `internal/platform/migrate/sql/`, or `docs/design-*.md` / `docs/adr/` — Track A's lane.
+- **Blocking Track A on:** nothing
+- **Track A can pick up from this work:**
+  - The blog post and README treat the multi-dim API surface as **the published contract** (`POST /v1/usage_events` with `value` + `dimensions`, `POST /v1/meters/{id}/pricing_rules`). If Track A's Week 2 implementation diverges from the doc, the doc updates first — and the blog/README will need a follow-up edit to match.
+  - One naming nit worth confirming: README and blog use `/v1/usage_events` (underscore, per the design doc) while the rest of the API uses hyphens (`/v1/usage-events`, `/v1/credit-notes`). Worth a short ADR or a doc-doc fix before May 8 — not blocking, but pick one and stick with it.
+- **Next:** rebase on `origin/main`, push `feat/track-b-week1`, open PR to `main` (do not merge — leave for human). Then this session pauses until Week 2.
+
 ---
 
 ## 2026-04-25 (Sat) — second update, Track A end-of-Week-2

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -28,7 +28,16 @@
 - **Next session (Track A):** start the Week 2 implementation against the design doc — schema migration, decimal-quantity refactor, `meter_pricing_rules` store, ingest service updates. Or, if human prefers, finalize Week 1 README/blog work first.
 
 ### Track B
-- _(no entries yet — this row created by Track A as a placeholder; Track B fills it in on first turn)_
+- **Kickoff:** session started in `../velox-track-b` worktree on `feat/track-b-week1` from `origin/main` (ceba954). Read positioning.md, 90-day-plan.md, parallel-work.md, design-multi-dim-meters.md, CLAUDE.md, and full memory index.
+- **Working from:** the design doc as API contract — no need to wait on Track A's `feat/backend-week2` to land.
+- **Plan for this week (May 1 deadline):**
+  1. README rewrite — lead with AI-native + self-host wedge (replace generic framing, don't append)
+  2. `docs/blog/2026-04-stripe-meter-api-ai-workloads.md` — long-form, uses the Anthropic-style worked example from the design doc (~24 Stripe Meters vs. 1 Velox meter + N rules)
+  3. `docs/marketing/outreach-list.md` — 50 real candidates across AI inference, vector DB, dev infra
+- **Blocking Track A on:** nothing
+- **Track A can:** proceed with Week 2 implementation against the design doc; nothing in Track B's lane affects backend
+- **Open questions for human:** none yet — wedge is clear from positioning.md
+- **Next:** start the README rewrite immediately.
 
 ---
 


### PR DESCRIPTION
## Summary

Track B / Week 1 of the [90-day plan](docs/90-day-plan.md). Three deliverables, all docs-only, no code changes.

- **README rewrite** — leads with the AI-native + self-host wedge from `docs/positioning.md` (replaces the generic billing-engine framing). Includes the multi-dim "wedge in code" demo, three pillars, anti-positioning, comparison table, 90-day roadmap.
- **`docs/blog/2026-04-stripe-meter-api-ai-workloads.md`** — long-form post (~1,800 words). Walks the Stripe Meter object model field-by-field, contrasts ~36 Meters of wiring for an Anthropic-style 4-dim rate card with 1 meter + N rules in Velox, calls out the per-meter aggregation-mode mismatch as a second structural issue. Honest anti-positioning section.
- **`docs/marketing/outreach-list.md`** — 50 design-partner leads: 22 AI inference / model APIs, 9 vector DB, 19 dev infra. Named founder/CEO contacts (each marked `(verify)` for LinkedIn confirmation before send), tiered A/B/C by wedge fit, with sequencing recommendations.

API contract for the README and blog code samples comes from `docs/design-multi-dim-meters.md` (Track A's Week 2 RFC). Track B did not touch `internal/`, `cmd/`, `internal/platform/migrate/sql/`, `docs/design-*.md`, or `docs/adr/`.

## Coordination

- Track A is implementing the multi-dim meters work on `feat/backend-week2`. The design doc is the contract for both tracks; if implementation diverges, the doc updates first and the README/blog will need a follow-up edit.
- One naming question for human review: `/v1/usage_events` (underscore, per the design doc) vs. `/v1/usage-events` (hyphen, current API convention). Not blocking, but worth picking one before May 8.
- Daily handoff log: `docs/parallel-handoff.md` updated with kickoff and end-of-turn entries.

## Test plan

Docs-only PR — no automated test surface. Manual review checklist:

- [ ] README renders cleanly on GitHub (tables, code fences, internal links)
- [ ] Blog post links resolve (Stripe doc URLs, internal `../design-multi-dim-meters.md`, etc.)
- [ ] Outreach list — spot-check 5 randomly selected named contacts on LinkedIn for current role
- [ ] Wedge framing matches `docs/positioning.md` (no contradictions or drift)
- [ ] No promises of behavior that doesn't ship in v0.x — multi-dim API is explicitly flagged "shipping May 8"

## Out of scope (deferred)

- `web-v2/src/pages/Changelog.tsx` entry — deferred to the commit that flips the multi-dim meter readiness item to ✅, which is Track A's call (likely the May 8 ship).
- Cold-email templates per segment — Week 2 deliverable, called out in the outreach list footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)