### PR TITLE
feat(usage,pricing): multi-dimensional meters foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ tmp/
 .env.local
 .DS_Store
 velox
+velox-bench
 temp.txt
 MANUAL_TEST_BUGS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,35 @@ Two surfaces mirror this file:
 
 ### Added
 
+- **Multi-dimensional meters foundation — AI-native wedge** (2026-04-25) —
+  the runtime engine for Velox's positioning bet (per
+  `docs/positioning.md`): one meter receives events with arbitrary
+  dimensions, many pricing rules pick out subsets at different rates.
+  Migration `0054_multi_dim_meters` widens `usage_events.quantity` to
+  `NUMERIC(38,12)` (Stripe `quantity_decimal` parity), adds a GIN index
+  over `properties` for JSONB-superset dispatch, and introduces
+  `meter_pricing_rules (dimension_match, aggregation_mode, priority)` —
+  N rules per meter, claim-based, no double-count. Per-rule
+  `aggregation_mode` adds `count`, `last_during_period`, `last_ever`,
+  `max` to the existing `sum` (Stripe Tier 1 gap closed). Ingest
+  accepts a `dimensions` field (alias for `properties`) capped at 16
+  scalar keys, matching the rule-side `dimension_match` cap. The
+  priority+claim resolution query lives in
+  `usage.Store.AggregateByPricingRules`: rules walked in `priority
+  DESC, created_at ASC` order, each in-period event claimed by its
+  top-priority match via `LATERAL JOIN`, per-mode aggregation
+  dispatched in SQL via a `CASE` over the per-group constant mode;
+  `last_ever` runs a separate query that ignores period bounds for
+  "current state" billing (e.g. seat counts). Unclaimed events fall
+  through to the meter's default `rating_rule_version_id` with
+  `meters.aggregation` — backward-compatible for tenants without rules.
+  Local benchmark harness (`cmd/velox-bench`) baselines ~2.5k
+  events/sec on dev hardware; the design doc's 50k/sec target requires
+  cloud-grade Postgres + batched INSERTs, both follow-up work. HTTP
+  endpoints for `meter_pricing_rules` CRUD will land in a follow-up PR
+  (engine first, surface second). See
+  `docs/design-multi-dim-meters.md` for the full algorithm.
+
 - **Trial extension — Stripe parity** (2026-04-25) — operators can now
   push a trialing subscription's `trial_end_at` later via `POST
   /v1/subscriptions/{id}/extend-trial` with `{trial_end:<RFC3339>}`. The

--- a/cmd/velox-bench/main.go
+++ b/cmd/velox-bench/main.go
@@ -1,0 +1,203 @@
+// velox-bench is a synthetic ingest benchmark validating the 50k events/sec
+// target from docs/design-multi-dim-meters.md.
+//
+// It bootstraps (idempotently) a benchmark tenant, customer, and meter,
+// then spawns N worker goroutines that POST through usage.Service.Ingest
+// — the real production path, transactions and all. Workers pick from a
+// realistic dimension cardinality (10 models × 4 operations × 2 cache
+// states = 80 combinations) so the JSONB column behaves like a live
+// AI-platform tenant rather than a synthetic single-row hammer.
+//
+// Output: total events, throughput (events/sec), and latency p50/p95/p99.
+//
+// Usage:
+//
+//	DATABASE_URL="postgres://velox:velox@localhost:5432/velox?sslmode=disable" \
+//	  go run ./cmd/velox-bench --workers 32 --duration 30s
+//
+// The benchmark is destructive: it writes a large number of rows to the
+// usage_events table under a dedicated benchmark tenant. Drop and recreate
+// the database between runs if you care about exact comparisons.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"math/rand/v2"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/config"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/usage"
+)
+
+func main() {
+	workers := flag.Int("workers", 16, "concurrent ingest workers (default 16)")
+	duration := flag.Duration("duration", 30*time.Second, "benchmark wall-clock duration")
+	flag.Parse()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})))
+
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	// Workers will saturate the pool — set max conns ≥ workers.
+	if cfg.DB.MaxOpenConns < *workers {
+		cfg.DB.MaxOpenConns = *workers
+	}
+	pool, err := config.OpenPostgres(cfg.DB)
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = pool.Close() }()
+
+	db := postgres.NewDB(pool, 30*time.Second)
+	ctx := context.Background()
+
+	tenantID, customerID, meterID := bootstrapFixtures(ctx, db)
+	store := usage.NewPostgresStore(db)
+	svc := usage.NewService(store)
+
+	fmt.Printf("velox-bench: workers=%d duration=%s tenant=%s meter=%s\n",
+		*workers, *duration, tenantID, meterID)
+
+	var totalEvents int64
+	var totalErrors int64
+	var wg sync.WaitGroup
+	latencyChan := make(chan []time.Duration, *workers)
+
+	deadline := time.Now().Add(*duration)
+	start := time.Now()
+
+	for i := 0; i < *workers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewPCG(uint64(workerID), uint64(workerID)+1))
+			samples := make([]time.Duration, 0, 4096)
+			for time.Now().Before(deadline) {
+				props := pickDimensions(rng)
+				qty := decimal.NewFromInt(int64(rng.IntN(1000) + 1))
+				t0 := time.Now()
+				_, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
+					CustomerID: customerID, MeterID: meterID,
+					Quantity: qty, Properties: props,
+				})
+				lat := time.Since(t0)
+				if err != nil {
+					atomic.AddInt64(&totalErrors, 1)
+					continue
+				}
+				atomic.AddInt64(&totalEvents, 1)
+				samples = append(samples, lat)
+			}
+			latencyChan <- samples
+		}(i)
+	}
+
+	wg.Wait()
+	close(latencyChan)
+	elapsed := time.Since(start)
+
+	all := make([]time.Duration, 0, totalEvents)
+	for s := range latencyChan {
+		all = append(all, s...)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i] < all[j] })
+
+	throughput := float64(totalEvents) / elapsed.Seconds()
+	fmt.Printf("\n--- result ---\n")
+	fmt.Printf("elapsed:    %s\n", elapsed.Round(time.Millisecond))
+	fmt.Printf("events:     %d (errors: %d)\n", totalEvents, totalErrors)
+	fmt.Printf("throughput: %.0f events/sec\n", throughput)
+	if len(all) > 0 {
+		fmt.Printf("p50:        %s\n", all[len(all)*50/100].Round(time.Microsecond))
+		fmt.Printf("p95:        %s\n", all[len(all)*95/100].Round(time.Microsecond))
+		fmt.Printf("p99:        %s\n", all[len(all)*99/100].Round(time.Microsecond))
+		fmt.Printf("max:        %s\n", all[len(all)-1].Round(time.Microsecond))
+	}
+	target := 50_000.0
+	if throughput >= target {
+		fmt.Printf("\n✓ target %.0f events/sec MET (%.1fx)\n", target, throughput/target)
+	} else {
+		fmt.Printf("\n✗ target %.0f events/sec MISSED (%.0f%%)\n", target, throughput/target*100)
+		fmt.Printf("  see docs/design-multi-dim-meters.md 'Mitigations' for next steps\n")
+	}
+}
+
+// pickDimensions returns a realistic AI-platform dimension set. Mirrors
+// the cardinality assumed in the design doc benchmark plan: 10 models,
+// 4 operations, 2 cache states (~80 unique combinations).
+func pickDimensions(rng *rand.Rand) map[string]any {
+	return map[string]any{
+		"model":     models[rng.IntN(len(models))],
+		"operation": operations[rng.IntN(len(operations))],
+		"cached":    rng.IntN(2) == 0,
+	}
+}
+
+var (
+	models     = []string{"gpt-4", "gpt-4-turbo", "gpt-3.5-turbo", "claude-3-opus", "claude-3-sonnet", "claude-3-haiku", "gemini-pro", "llama-2-70b", "mistral-large", "command-r"}
+	operations = []string{"input", "output", "embedding", "moderation"}
+)
+
+// bootstrapFixtures ensures the benchmark tenant/customer/meter exist.
+// Idempotent: safe to run repeatedly. Uses TxBypass because we're in a
+// CLI tool with full DB access; the runtime path will set tenant_id
+// per-request via TxTenant as usual.
+func bootstrapFixtures(ctx context.Context, db *postgres.DB) (string, string, string) {
+	const (
+		benchTenant   = "vlx_ten_bench"
+		benchCustomer = "vlx_cus_bench"
+		benchMeter    = "vlx_mtr_bench"
+	)
+
+	tx, err := db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		log.Fatalf("begin bootstrap: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO tenants (id, name, status) VALUES ($1, 'velox-bench', 'active')
+		ON CONFLICT (id) DO NOTHING
+	`, benchTenant)
+	if err != nil {
+		log.Fatalf("upsert tenant: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO customers (id, tenant_id, external_id, display_name, email)
+		VALUES ($1, $2, 'bench-customer', 'Bench Customer', 'bench@velox.local')
+		ON CONFLICT (id) DO NOTHING
+	`, benchCustomer, benchTenant)
+	if err != nil {
+		log.Fatalf("upsert customer: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO meters (id, tenant_id, name, key, unit, aggregation)
+		VALUES ($1, $2, 'Bench Tokens', 'bench_tokens', 'tokens', $3)
+		ON CONFLICT (id) DO NOTHING
+	`, benchMeter, benchTenant, string(domain.AggSum))
+	if err != nil {
+		log.Fatalf("upsert meter: %v", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Fatalf("commit bootstrap: %v", err)
+	}
+	return benchTenant, benchCustomer, benchMeter
+}

--- a/docs/design-multi-dim-meters.md
+++ b/docs/design-multi-dim-meters.md
@@ -119,24 +119,30 @@ GRANT ALL ON TABLE meter_pricing_rules TO velox_app;
 
 ## API surface
 
-### `POST /v1/usage_events`
+> **Wire-contract conventions** (consistent with the rest of `/v1/*`):
+>
+> - **Paths use hyphens**, not underscores: `/v1/usage-events`, `/v1/meters/{id}/pricing-rules`, `/v1/usage-records`. Matches `/v1/credit-notes`, `/v1/rating-rules`, etc.
+> - **Quantity field is `quantity`, both directions.** JSON wire form is a string for decimal precision (`"1234.5"`); numeric form is also accepted on input. There is no `value` alias — pre-launch we don't owe back-compat, and one canonical name beats two.
+> - **External identifiers on input.** Ingest takes `external_customer_id` (the developer's own ID) and `event_name` (the meter key); the handler resolves both to internal `customer_id` / `meter_id` server-side.
+
+### `POST /v1/usage-events`
 
 ```http
-POST /v1/usage_events
+POST /v1/usage-events
 Idempotency-Key: <key>
 Authorization: Bearer <secret_key>
 
 {
-  "meter_key": "tokens",
-  "customer_id": "cust_xyz",
-  "subscription_id": "sub_abc",       // optional
-  "value": "1234.5",                  // string for decimal precision; numeric also accepted
+  "external_customer_id": "cust_xyz",
+  "event_name": "tokens",
+  "quantity": "1234.5",                // string for decimal precision; numeric also accepted
   "dimensions": {
     "model": "gpt-4",
     "operation": "input",
     "cached": false
   },
-  "timestamp": "2026-04-25T12:34:56Z" // optional, defaults to now
+  "idempotency_key": "evt-1",          // optional; alternative to the header form
+  "timestamp": "2026-04-25T12:34:56Z"  // optional, defaults to now
 }
 ```
 
@@ -145,21 +151,24 @@ Response `201`:
 {
   "id": "vlx_evt_...",
   "tenant_id": "tnt_...",
+  "customer_id": "vlx_cus_...",
   "meter_id": "vlx_mtr_...",
-  "customer_id": "cust_xyz",
-  "value": "1234.5",
-  "dimensions": { "model": "gpt-4", "operation": "input", "cached": false },
+  "subscription_id": "vlx_sub_...",
+  "quantity": "1234.5",
+  "properties": { "model": "gpt-4", "operation": "input", "cached": false },
   "timestamp": "2026-04-25T12:34:56Z",
-  "subscription_id": "sub_abc"
+  "origin": "api"
 }
 ```
 
-Existing `POST /v1/usage_records` stays for back-compat (no `dimensions`, integer-only `quantity`); ingests into the same `usage_events` table with empty `properties`.
+The response carries internal IDs (`vlx_cus_*`, `vlx_mtr_*`) and surfaces dimensions on `properties` (the storage column name) — `dimensions` on the request is just an alias and collapses onto `properties` at the storage layer.
 
-### `POST /v1/meters/{id}/pricing_rules`
+Existing `POST /v1/usage-records` stays for back-compat (no `dimensions`, integer-only `quantity`); ingests into the same `usage_events` table with empty `properties`.
+
+### `POST /v1/meters/{id}/pricing-rules`
 
 ```http
-POST /v1/meters/mtr_xyz/pricing_rules
+POST /v1/meters/mtr_xyz/pricing-rules
 Authorization: Bearer <secret_key>
 
 {
@@ -179,7 +188,7 @@ Plus `GET`, `LIST`, `DELETE` for full CRUD.
 ### `GET /v1/customers/{id}/usage`
 
 ```http
-GET /v1/customers/cust_xyz/usage?meter_key=tokens&period_start=2026-04-01&period_end=2026-04-30&group_by=model,operation
+GET /v1/customers/cust_xyz/usage?event_name=tokens&period_start=2026-04-01&period_end=2026-04-30&group_by=model,operation
 ```
 
 Returns the per-rule aggregated quantity + projected charges, grouped by requested dimensions. Powers the cost-dashboard component (Week 5).
@@ -192,11 +201,11 @@ When billing finalizes for `(customer, meter, period_start, period_end)`:
 2. Iterate rules. For each rule:
    - Find events in the period whose `properties` is a **superset** of `dimension_match` AND that haven't been claimed by a higher-priority rule.
    - Apply the rule's `aggregation_mode`:
-     - `sum` → `SUM(value)`
+     - `sum` → `SUM(quantity)`
      - `count` → `COUNT(*)`
-     - `last_during_period` → value of the latest event by `timestamp` within the period
-     - `last_ever` → value of the latest event by `timestamp` across all time, regardless of period (used for "current state" billing like seat counts)
-     - `max` → `MAX(value)`
+     - `last_during_period` → quantity of the latest event by `timestamp` within the period
+     - `last_ever` → quantity of the latest event by `timestamp` across all time, regardless of period (used for "current state" billing like seat counts)
+     - `max` → `MAX(quantity)`
    - Resolve the aggregated quantity → cents via the rule's `rating_rule_version` (existing flat / graduated / package logic, unchanged).
 3. Events not claimed by any pricing rule fall back to the meter's default `rating_rule_version_id` with mode `meters.aggregation`.
 
@@ -225,7 +234,7 @@ WITH ranked_rules AS (
 ),
 claimed AS (
     SELECT DISTINCT ON (e.id)
-        e.id, e.value, e.timestamp,
+        e.id, e.quantity, e.timestamp,
         r.id AS rule_id, r.aggregation_mode, r.rating_rule_version_id
     FROM usage_events e
     CROSS JOIN ranked_rules r
@@ -250,7 +259,7 @@ For `last_during_period`, `last_ever`, `max` modes the aggregation differs — i
 
 - Domain type: `decimal.Decimal` from `github.com/shopspring/decimal` (already battle-tested, used by Stripe's own SDK and many Go billing systems)
 - Postgres driver: `pgtype.Numeric` ↔ `decimal.Decimal` conversion in store layer
-- All `domain.UsageEvent.Quantity` (or rename to `Value`) becomes `decimal.Decimal`
+- `domain.UsageEvent.Quantity` becomes `decimal.Decimal` (kept the `Quantity` name — wire field is `quantity`, no rename to `Value`)
 - Existing internal callers passing `int64` need adapters
 
 Per memory `feedback_prefer_battle_tested_libs`: use `shopspring/decimal`, do not roll our own.
@@ -293,7 +302,7 @@ Per memory `feedback_prefer_battle_tested_libs`: use `shopspring/decimal`, do no
 
 1. **Should dimensions be schema-validated against the meter?** Proposal: **no** for v1. Free-form JSONB. Revisit after first design partner reports a typo'd dimension caused a billing miss.
 2. **Should pricing rules support time-windowed match?** Proposal: **no**. Period boundary is the only window for v1.
-3. **How do we handle events whose `value` is zero?** Proposal: ingest, count for `count` mode, sum to zero for `sum` mode (no special case).
+3. **How do we handle events whose `quantity` is zero?** Proposal: ingest, count for `count` mode, sum to zero for `sum` mode (no special case).
 4. **Decimal precision — `NUMERIC(38, 12)` sufficient?** Proposal: **yes**. Tokens are integer; GPU-hours need 4–6 decimals; 12 is generous.
 5. **Cap on dimension count per event?** Proposal: **16 keys, soft limit**. Reject events with >16 dimension keys to bound JSONB size and avoid pathological tenants.
 6. **Do existing `usage_events.quantity` BIGINT values need any migration data work?** Proposal: **no**. Widening cast is lossless; max BIGINT (≈9.2 × 10¹⁸) fits NUMERIC(38, 12) trivially.
@@ -304,12 +313,12 @@ Per memory `feedback_prefer_battle_tested_libs`: use `shopspring/decimal`, do no
 Tracking via the 90-day plan; this is the canonical breakdown:
 
 - [ ] Migration `0054_multi_dim_meters.{up,down}.sql` (allocate number from `origin/main`)
-- [ ] `domain.UsageEvent.Quantity` → `decimal.Decimal` (rename to `Value` if cleaner; one-time refactor)
+- [ ] `domain.UsageEvent.Quantity` → `decimal.Decimal` (one-time refactor; field name stays `Quantity`)
 - [ ] `domain.MeterPricingRule` struct
 - [ ] `usage.Store.UpsertPricingRule(...)`, `ListPricingRulesByMeter(...)`, `DeletePricingRule(...)`
-- [ ] `usage.Service.IngestEvent(...)` accepts decimal value + dimensions
+- [ ] `usage.Service.IngestEvent(...)` accepts decimal quantity + dimensions
 - [ ] `usage.Service.AggregateForBillingPeriod(...)` resolves rules with priority + dimension match
-- [ ] HTTP handlers: `POST /v1/usage_events`, `POST/GET/LIST/DELETE /v1/meters/{id}/pricing_rules`
+- [ ] HTTP handlers: `POST /v1/usage-events`, `POST/GET/LIST/DELETE /v1/meters/{id}/pricing-rules`
 - [ ] `GET /v1/customers/{id}/usage` (powers Week 5 cost dashboard)
 - [ ] Unit tests: ingest, aggregation per mode, subset-match, priority-claim
 - [ ] Integration tests: real Postgres, RLS-isolated tenants, decimal precision, idempotency

--- a/docs/design-multi-dim-meters.md
+++ b/docs/design-multi-dim-meters.md
@@ -99,8 +99,12 @@ CREATE INDEX idx_meter_pricing_rules_lookup
     ON meter_pricing_rules (tenant_id, meter_id, priority DESC);
 
 ALTER TABLE meter_pricing_rules ENABLE ROW LEVEL SECURITY;
-CREATE POLICY meter_pricing_rules_tenant_isolation ON meter_pricing_rules
-    USING (tenant_id = current_setting('velox.tenant_id', true));
+ALTER TABLE meter_pricing_rules FORCE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON meter_pricing_rules FOR ALL USING (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR tenant_id = current_setting('app.tenant_id', true)
+);
+GRANT ALL ON TABLE meter_pricing_rules TO velox_app;
 ```
 
 ### Why a new table instead of extending `meters`

--- a/docs/design-recipes.md
+++ b/docs/design-recipes.md
@@ -1,0 +1,547 @@
+# Pricing Recipes — Technical Design
+
+> **Status:** Draft v1
+> **Owner:** Track A
+> **Last revised:** 2026-04-25
+> **Implementation window:** Week 3 of `docs/90-day-plan.md` (May 9–15)
+> **Related:** `docs/design-multi-dim-meters.md` (Week 2 dependency), `docs/positioning.md` (pillar 1.3), ADR-002 (per-domain), ADR-003 (RLS)
+
+## Motivation
+
+Stripe Billing's onboarding for an AI-native product is a multi-day chore: you create N Meters by hand (one per `model × operation × cached` combination), wire each into a Plan, attach a webhook, configure dunning retry logic, then mock the whole thing for QA. The first invoice is a week away. Buyers leave.
+
+Velox's wedge (per `docs/positioning.md` pillar 1) includes **pricing recipes**: a single API call, ~30 seconds, walks away with a working `anthropic_style` setup — products, prices, meters, multi-dim pricing rules, dunning, webhook endpoint, sample data. The picker UI in the dashboard means a non-technical CS rep can do the same thing.
+
+This is the developer-experience flagship that turns the AI-native pillar from a slide into a 5-minute quickstart. Without it, the multi-dim meter machinery from Week 2 is invisible: no prospect builds a 12-rule `anthropic_style` setup by hand to evaluate it. With recipes, evaluation collapses to one POST.
+
+This design ships in Week 3 and depends on Week 2 multi-dim meters being merged.
+
+## Goals
+
+- **One-call instantiation.** `POST /v1/recipes/instantiate` atomically creates the full surface area for a given recipe key (products, prices, meters, multi-dim pricing rules, dunning policy, webhook endpoint placeholder, optional sample data). All-or-nothing transaction.
+- **Five built-ins shipping in v1:** `anthropic_style`, `openai_style`, `replicate_style`, `b2b_saas_pro`, `marketplace_gmv`. Each represents a real-world pricing pattern Velox-class buyers actually use.
+- **Preview before commit.** `POST /v1/recipes/{key}/preview` returns the full graph of objects that *would* be created, with no DB writes. Powers the "review and instantiate" dialog in the dashboard.
+- **Embedded YAML, no DB recipe table.** Recipes are versioned with the binary (`internal/recipe/recipes/*.yaml`, `embed.FS`). Tenants don't author them in v1; built-ins only.
+- **Per-instantiation overrides.** Currency, customer-facing names, base prices accept overrides at instantiate time. Changes must round-trip through preview.
+- **Idempotency at the recipe-instance level.** Re-running a recipe by `(tenant_id, recipe_key)` returns the existing instance, no duplicates. Forced re-instantiation is a separate `force=true` flag for ops use.
+- **Dashboard UI: pick → preview → instantiate.** Track B owns the React surface; this design IS the API contract Track B mocks against.
+- **Documented at `/docs/recipes` with copy-pasteable curl.** Each recipe gets a one-pager describing the resulting object graph in plain English.
+
+## Non-goals (deferred)
+
+- **Tenant-authored recipes.** Defer until a paying tenant asks. The maintenance cost of a tenant-recipe registry, validation, version migration, and security review (a recipe is arbitrary infra-as-code) is steep and unwarranted before product/market fit.
+- **Recipe upgrades / migrations across versions.** A recipe is instantiated once. If Velox ships `anthropic_style` v2, instantiating it on an existing tenant either no-ops (idempotency match by key) or overwrites (force flag). No "upgrade my v1 instance to v2" path. Defer until the API stabilizes.
+- **Marketplace / shared recipes from third parties.** Phase 4+. Security model alone (signing, sandboxing) is its own design.
+- **Cross-tenant recipe templates.** Each tenant gets its own copy. No shared product/price catalog across tenants by design — RLS isolation is the whole point.
+- **Recipes that span Stripe configuration** (tax codes per region, payment method preferences). Defer; the tenant's own `tenantstripe` settings already cover this.
+
+## Today's surface (in repo)
+
+- `internal/pricing.Service.CreateMeter`, `CreateRatingRule`, `CreatePlan` — narrow per-domain creates, no atomic-graph helper exists yet.
+- `internal/dunning.Service.UpsertPolicy` — per-tenant retry schedule.
+- `internal/webhook.Service.CreateEndpoint` — registers a webhook URL, returns the signing secret.
+- `internal/usage.Store.UpsertPricingRule` (Week 2) — multi-dim rule per meter.
+- No coordinator. Today, building `anthropic_style` by hand is ~30 HTTP calls with manual ID-passing between them. Recipes collapse this to one.
+
+## Proposed schema changes — migration `00XX_recipe_instances`
+
+> **Migration number caveat:** pick at PR-open time from `origin/main`, not local branch (per memory `feedback_migration_numbering`). Placeholder used here.
+
+```sql
+-- 00XX_recipe_instances.up.sql
+
+-- Tracks which recipes have been instantiated for which tenant. The
+-- objects themselves live in their normal tables (plans, meters,
+-- pricing rules, etc.); this table is a thin index that lets us:
+--   (a) idempotency-check on (tenant_id, recipe_key)
+--   (b) show the dashboard "anthropic_style instantiated 3 days ago"
+--   (c) clean up an instance via cascade if force-re-instantiated
+CREATE TABLE recipe_instances (
+    id                TEXT PRIMARY KEY DEFAULT 'vlx_rec_' || encode(gen_random_bytes(12), 'hex'),
+    tenant_id         TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    recipe_key        TEXT NOT NULL,         -- e.g. 'anthropic_style'
+    recipe_version    TEXT NOT NULL,         -- e.g. '1.0.0' (from YAML frontmatter)
+    overrides         JSONB NOT NULL DEFAULT '{}',  -- redacted operator-supplied overrides
+    created_object_ids JSONB NOT NULL DEFAULT '{}', -- map of role → entity ID for cleanup
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by        TEXT,                  -- operator user ID or "api"
+    UNIQUE (tenant_id, recipe_key)            -- idempotency anchor
+);
+
+CREATE INDEX idx_recipe_instances_tenant
+    ON recipe_instances (tenant_id, created_at DESC);
+
+ALTER TABLE recipe_instances ENABLE ROW LEVEL SECURITY;
+CREATE POLICY recipe_instances_tenant_isolation ON recipe_instances
+    USING (tenant_id = current_setting('app.tenant_id', true)
+        OR current_setting('app.bypass_rls', true) = 'true');
+
+GRANT ALL ON TABLE recipe_instances TO velox_app;
+```
+
+Storing only the index and the `created_object_ids` map keeps the design boring: the canonical entities are in their own tables and obey their own constraints. If a tenant deletes a meter that came from a recipe, the recipe instance is unaffected — this is intentional. Cascading recipe deletion is a `force=true` operator flow, not a default.
+
+## API surface
+
+> **Wire-contract conventions** (consistent with `/v1/*`):
+>
+> - **Paths use hyphens:** `/v1/recipes`, `/v1/recipes/{key}/preview`, `/v1/recipes/instantiate`.
+> - **Recipe identity is the `key` string** (e.g. `anthropic_style`), not an opaque ID. Keys are stable across versions; `version` field surfaces the underlying YAML revision.
+> - **Overrides are a flat JSON object** (`{"currency": "EUR", "plan_name": "Inference Pro"}`), keys defined per recipe. Unknown override keys for a given recipe → 400.
+
+### `GET /v1/recipes` — list available
+
+```http
+GET /v1/recipes
+Authorization: Bearer <secret_key>
+```
+
+Response `200`:
+```json
+{
+  "data": [
+    {
+      "key": "anthropic_style",
+      "version": "1.0.0",
+      "name": "Anthropic-style AI inference",
+      "summary": "Per-token billing across model × operation × cached. 12 pricing rules, 1 multi-dim meter, monthly billing.",
+      "creates": {
+        "meters": 1,
+        "pricing_rules": 12,
+        "plans": 1,
+        "products": 1,
+        "rating_rules": 12,
+        "dunning_policies": 1,
+        "webhook_endpoints": 1
+      },
+      "overridable": ["currency", "plan_name", "plan_code"],
+      "instantiated": {
+        "id": "vlx_rec_abc",
+        "instantiated_at": "2026-04-22T10:00:00Z"
+      }
+    },
+    { "key": "openai_style", "...": "..." },
+    { "key": "replicate_style", "...": "..." },
+    { "key": "b2b_saas_pro", "...": "..." },
+    { "key": "marketplace_gmv", "...": "..." }
+  ]
+}
+```
+
+`instantiated` is `null` (or omitted) for recipes the tenant has not yet instantiated. The `creates` summary lets the picker UI render "12 pricing rules · 1 meter · monthly" without a separate preview call.
+
+### `GET /v1/recipes/{key}` — recipe detail
+
+```http
+GET /v1/recipes/anthropic_style
+Authorization: Bearer <secret_key>
+```
+
+Response `200`: same shape as one entry from `GET /v1/recipes`, plus a long-form `description` (markdown) and the full `overridable_schema` (per-key type + default + bounds).
+
+### `POST /v1/recipes/{key}/preview` — dry-run
+
+```http
+POST /v1/recipes/anthropic_style/preview
+Authorization: Bearer <secret_key>
+
+{
+  "overrides": {
+    "currency": "USD",
+    "plan_name": "AI API"
+  }
+}
+```
+
+Response `200`:
+```json
+{
+  "key": "anthropic_style",
+  "version": "1.0.0",
+  "objects": {
+    "products": [{ "code": "ai_api", "name": "AI API", "description": "..." }],
+    "meters": [{ "key": "tokens", "name": "Tokens", "unit": "tokens", "aggregation": "sum" }],
+    "rating_rules": [
+      { "rule_key": "gpt4_input_uncached", "mode": "flat", "currency": "USD", "flat_amount_cents": 30 },
+      { "rule_key": "gpt4_input_cached",   "mode": "flat", "currency": "USD", "flat_amount_cents": 3  },
+      "..."
+    ],
+    "pricing_rules": [
+      {
+        "meter_key": "tokens",
+        "rating_rule_key": "gpt4_input_uncached",
+        "dimension_match": { "model": "gpt-4", "operation": "input", "cached": false },
+        "aggregation_mode": "sum",
+        "priority": 100
+      },
+      "..."
+    ],
+    "plans": [{ "code": "ai_api_pro", "name": "AI API", "currency": "USD", "billing_interval": "monthly", "base_amount_cents": 0, "meter_keys": ["tokens"] }],
+    "dunning_policies": [{ "name": "AI default retry", "max_retries": 4, "intervals_hours": [24, 72, 168, 336] }],
+    "webhook_endpoints": [{ "url": "https://example.com/webhooks/velox", "events": ["invoice.finalized", "invoice.paid", "subscription.updated"], "_placeholder": true }]
+  },
+  "warnings": []
+}
+```
+
+`warnings` surfaces non-fatal conditions ("currency override `EUR` requires Stripe account in EUR mode", "webhook URL is a placeholder — set a real URL post-instantiate"). The dashboard renders these inline.
+
+### `POST /v1/recipes/instantiate` — commit
+
+```http
+POST /v1/recipes/instantiate
+Authorization: Bearer <secret_key>
+Idempotency-Key: <key>
+
+{
+  "key": "anthropic_style",
+  "overrides": { "currency": "USD", "plan_name": "AI API" },
+  "seed_sample_data": false,
+  "force": false
+}
+```
+
+Response `201`:
+```json
+{
+  "id": "vlx_rec_abc",
+  "key": "anthropic_style",
+  "version": "1.0.0",
+  "tenant_id": "vlx_ten_...",
+  "created_at": "2026-04-25T12:34:56Z",
+  "created_objects": {
+    "product_ids": ["vlx_prd_..."],
+    "meter_ids": ["vlx_mtr_..."],
+    "rating_rule_ids": ["vlx_rrv_..."],
+    "pricing_rule_ids": ["vlx_mpr_...", "..."],
+    "plan_ids": ["vlx_pln_..."],
+    "dunning_policy_id": "vlx_dpc_...",
+    "webhook_endpoint_id": "vlx_whk_..."
+  }
+}
+```
+
+Response `409` if the recipe is already instantiated and `force=false`:
+```json
+{
+  "error": "recipe_already_instantiated",
+  "instance": { "id": "vlx_rec_abc", "created_at": "..." },
+  "hint": "Pass force=true to delete the existing instance and re-instantiate."
+}
+```
+
+`seed_sample_data=true` additionally creates one demo customer + one trialing subscription against the new plan, so the tenant immediately sees usage flow. Default false; the dashboard's onboarding wizard sets it true on first-time install.
+
+`force=true` deletes the prior `recipe_instances` row plus all entities listed in its `created_object_ids` map (cascade-style cleanup), then runs the recipe fresh. Behind a separate operator-only API key scope (`platform`); secret keys cannot force.
+
+### `DELETE /v1/recipes/instances/{id}` — uninstall
+
+```http
+DELETE /v1/recipes/instances/vlx_rec_abc
+Authorization: Bearer <platform_key>
+```
+
+Removes all entities listed in `created_object_ids` (best-effort; foreign-key blocks return 409 with the list of dependent objects, e.g. "plan still has 3 active subscriptions"). Platform-key only. Manual recipe cleanup for tenants whose recipe choice didn't pan out.
+
+## Recipe definition format
+
+Recipes are YAML files in `internal/recipe/recipes/`, embedded into the binary via `embed.FS`. One file per recipe. Schema validated at boot — a malformed recipe panics at startup, not at first instantiation.
+
+### `internal/recipe/recipes/anthropic_style.yaml` (excerpt)
+
+```yaml
+key: anthropic_style
+version: 1.0.0
+name: Anthropic-style AI inference
+summary: |
+  Per-token billing across model × operation × cached.
+  12 pricing rules, 1 multi-dim meter, monthly billing.
+description: |
+  Models the public Anthropic pricing page as of 2026-04: 4 models
+  (claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet),
+  2 operations (input, output), with cache discounts on input.
+  ...
+
+overridable:
+  - key: currency
+    type: string
+    default: USD
+    enum: [USD, EUR, GBP, INR]
+  - key: plan_name
+    type: string
+    default: AI API
+    max_length: 80
+  - key: plan_code
+    type: string
+    default: ai_api_pro
+    pattern: '^[a-z0-9_]+$'
+
+products:
+  - code: ai_api
+    name: '{{ .plan_name }}'
+    description: Token-based AI inference billing
+
+meters:
+  - key: tokens
+    name: Tokens
+    unit: tokens
+    aggregation: sum  # default for unclaimed events; per-rule modes override
+
+rating_rules:
+  - key: claude35_input_uncached
+    name: Claude 3.5 Sonnet input (uncached)
+    mode: flat
+    currency: '{{ .currency }}'
+    flat_amount_cents: 30
+  - key: claude35_input_cached
+    mode: flat
+    currency: '{{ .currency }}'
+    flat_amount_cents: 3
+  # ... 10 more
+
+pricing_rules:
+  - meter: tokens
+    rating_rule: claude35_input_uncached
+    dimension_match: { model: claude-3.5-sonnet, operation: input, cached: false }
+    aggregation_mode: sum
+    priority: 100
+  - meter: tokens
+    rating_rule: claude35_input_cached
+    dimension_match: { model: claude-3.5-sonnet, operation: input, cached: true }
+    aggregation_mode: sum
+    priority: 100
+  # ... 10 more
+
+plans:
+  - code: '{{ .plan_code }}'
+    name: '{{ .plan_name }}'
+    currency: '{{ .currency }}'
+    billing_interval: monthly
+    base_amount_cents: 0
+    meters: [tokens]
+
+dunning:
+  policy:
+    name: AI default retry
+    max_retries: 4
+    intervals_hours: [24, 72, 168, 336]
+    final_action: void
+
+webhook:
+  events:
+    - invoice.finalized
+    - invoice.paid
+    - invoice.payment_failed
+    - subscription.updated
+    - subscription.canceled
+  url_placeholder: 'https://example.com/webhooks/velox'
+
+sample_data:
+  customer:
+    external_id: demo-customer
+    display_name: Demo Customer
+    email: demo@example.com
+  subscription:
+    plan: '{{ .plan_code }}'
+    trial_days: 14
+```
+
+### Templating
+
+`{{ .currency }}` etc. are resolved against the merged override map (defaults + per-instantiate overrides) using Go's `text/template`. No conditionals, no functions, no loops in v1 — just substitution. Validated at YAML load time: every `{{ .X }}` must resolve to a declared `overridable` key.
+
+### Versioning
+
+`version` field is semver. The version is recorded on `recipe_instances.recipe_version` so an operator can see which iteration their tenant ran. Velox does not migrate existing instances when a recipe's YAML changes — the canonical entities live in their own tables and the operator owns them once they exist.
+
+## Internals
+
+### Package layout
+
+New per-domain package: `internal/recipe/` with the canonical store/service/handler trio.
+
+```
+internal/recipe/
+    recipes/                  # embedded YAML
+        anthropic_style.yaml
+        openai_style.yaml
+        replicate_style.yaml
+        b2b_saas_pro.yaml
+        marketplace_gmv.yaml
+    embed.go                  # embed.FS + Load() at boot
+    parse.go                  # YAML → domain.Recipe; validation
+    template.go               # override merge + text/template render
+    service.go                # Preview, Instantiate, Uninstall
+    handler.go                # HTTP routes
+    store.go                  # recipe_instances CRUD only
+    postgres.go               # store impl
+```
+
+`Service` depends on:
+- `pricing.Service` for plan + product + meter + rating rule creation
+- `dunning.Service` for policy upsert
+- `webhook.Service` for endpoint creation
+- `usage.Service` for `MeterPricingRule` upsert (Week 2 dependency)
+- `customer.Service` + `subscription.Service` for `seed_sample_data`
+
+The dependencies inject as narrow interfaces so the recipe package owns no cross-domain state. Same pattern as `internal/billing/engine`.
+
+### Atomicity
+
+`Instantiate` runs in a single `BeginTx(ctx, postgres.TxTenant, tenantID)`. All `Service.Create*` calls accept a `*sql.Tx` (already the convention via `ExecContext` on a transaction). Failure at any step rolls back the whole graph — no half-instantiated tenants.
+
+```go
+// service.go (sketch)
+func (s *Service) Instantiate(ctx context.Context, tenantID, recipeKey string, overrides map[string]any, opts InstantiateOptions) (domain.RecipeInstance, error) {
+    recipe, err := s.registry.Load(recipeKey)
+    if err != nil { return domain.RecipeInstance{}, err }
+
+    if err := recipe.ValidateOverrides(overrides); err != nil { return domain.RecipeInstance{}, err }
+
+    rendered, err := recipe.Render(overrides)
+    if err != nil { return domain.RecipeInstance{}, err }
+
+    tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+    if err != nil { return domain.RecipeInstance{}, err }
+    defer postgres.Rollback(tx)
+
+    // Idempotency check first — avoids partial work if the row already exists.
+    if existing, err := s.store.GetByKeyTx(ctx, tx, tenantID, recipeKey); err == nil && !opts.Force {
+        return domain.RecipeInstance{}, errs.ErrAlreadyInstantiated
+    }
+    if opts.Force {
+        if err := s.deleteInstanceTx(ctx, tx, tenantID, recipeKey); err != nil { return domain.RecipeInstance{}, err }
+    }
+
+    objs := domain.CreatedObjects{}
+
+    // Create in dependency order. Each Create* takes the tx so the
+    // graph is one atomic unit.
+    for _, p := range rendered.Products {
+        id, err := s.pricing.CreateProductTx(ctx, tx, tenantID, p)
+        if err != nil { return domain.RecipeInstance{}, err }
+        objs.ProductIDs = append(objs.ProductIDs, id)
+    }
+    // meters → rating_rules → pricing_rules → plans → dunning → webhook → sample_data
+    // ... (~150 lines of similar)
+
+    inst, err := s.store.CreateTx(ctx, tx, domain.RecipeInstance{
+        TenantID: tenantID, RecipeKey: recipeKey, RecipeVersion: recipe.Version,
+        Overrides: overrides, CreatedObjects: objs,
+    })
+    if err != nil { return domain.RecipeInstance{}, err }
+
+    if err := tx.Commit(); err != nil { return domain.RecipeInstance{}, err }
+    return inst, nil
+}
+```
+
+Where today's `Service.Create*` methods don't accept a `*sql.Tx` (most don't), Week 3 work adds the `*Tx` variant alongside the existing method. Both delegate to the same SQL — no dual code paths.
+
+### Preview (no-DB)
+
+`Preview` reuses `recipe.Render(overrides)` and returns the in-memory graph. No DB writes, no `BeginTx`. Cheap; safe to call on every dialog open.
+
+### Built-in recipes — content shape
+
+The five v1 recipes are calibrated against real public pricing pages for the wedge-aligned customer profile:
+
+| Recipe | Models / Pattern | Pricing rules | Use case |
+|---|---|---|---|
+| `anthropic_style` | claude-3.5-sonnet, claude-3-opus, claude-3-sonnet, claude-3-haiku × {input, output} × {cached, uncached} | 12 | LLM API resellers / inference platforms |
+| `openai_style` | gpt-4-turbo, gpt-4o, gpt-3.5-turbo × {input, output, embedding} × {cached, uncached} | 14 | LLM API resellers / inference platforms |
+| `replicate_style` | per-second GPU billing across {a100, a40, t4, cpu} with `last_during_period` for spot duration | 4 | GPU-time platforms |
+| `b2b_saas_pro` | seat-based with `last_ever` aggregation + per-seat overage | 2 | Vanilla SaaS that needs Velox for compliance, not AI |
+| `marketplace_gmv` | percentage-of-volume with min/max, monthly settle | 1 plus `count` for transaction count | Marketplaces using Velox without Connect |
+
+Each recipe gets a one-pager at `/docs/recipes/{key}.md` (Track B's `/docs/recipes` content surface) with copy-pasteable curl, a screenshot of the resulting dashboard, and a pricing page comparison.
+
+## Tests
+
+### Unit tests
+
+- YAML load + validate: each of the 5 built-ins parses cleanly at boot. Malformed test fixtures return clear errors.
+- Override validation: unknown keys → 400; type mismatches → 400; defaults applied when omitted.
+- Templating: `{{ .currency }}` substitutes; missing template variable returns a clear error at load time, not at render.
+
+### Integration tests (real Postgres)
+
+- `Instantiate(anthropic_style)` produces a tenant with: 1 product, 1 meter, 12 rating rules, 12 pricing rules, 1 plan, 1 dunning policy, 1 webhook endpoint. Verify object counts via direct SQL.
+- `Instantiate` twice without `force` → second call returns 409 with the existing instance ID.
+- `Instantiate` twice with `force=true` → second call returns a fresh instance, the first instance's objects are gone.
+- Atomicity: inject a failing `pricing.CreatePlan` mid-instantiation; verify zero objects exist post-rollback (no orphan products / meters / rules).
+- RLS: instantiate `anthropic_style` for tenant A; tenant B's `GET /v1/recipes` shows `anthropic_style` with `instantiated: null`.
+- `Preview` on tenant A produces an identical object graph to what `Instantiate` then creates (modulo the IDs).
+
+### End-to-end test (against the running stack)
+
+`cmd/velox-recipes-e2e/main.go`: instantiate `anthropic_style`, post 1000 usage events through the new meter, run the cycle scan, assert the resulting invoice line items match the recipe's expected line breakdown. Catches contract drift between this design and the multi-dim meter implementation.
+
+## Migrations
+
+- `00XX_recipe_instances` — new table per the schema section above.
+
+## Decimal & numeric considerations
+
+Recipes inherit Week 2's `NUMERIC(38, 12)` quantity type; no recipe-specific changes. All amount fields are integer cents per ADR-005. Currency conversion is the operator's responsibility (Stripe handles the actual settlement).
+
+## Performance
+
+- `GET /v1/recipes` is a constant-time read of `embed.FS` + one indexed `recipe_instances` query. Cheap.
+- `Preview` is pure in-memory render; no DB.
+- `Instantiate` is a single transaction with ~30 INSERTs for the largest recipe (`openai_style`). Well under 500ms on dev hardware. No batching needed — instantiation is rare per tenant.
+- Recipe registry loads once at boot; no per-request file I/O.
+
+## Open questions
+
+1. **Should `instantiate` accept inline overrides for `pricing_rules.dimension_match` keys?** Proposal: **no** for v1. Recipe authors choose dimension shapes; tenants override prices but not dimension structure. Revisit if a design partner wants `gpt-4-turbo` pricing on the `anthropic_style` recipe.
+2. **Should `seed_sample_data` create a `test_clock`?** Proposal: **no**. Sample sub starts with `trial_days=14` real-time; ops can attach a clock manually if they want to fast-forward. Keeps `seed_sample_data` semantics simple.
+3. **Should `force=true` cascade-delete subscriptions that reference the recipe's plan?** Proposal: **no**. 409 with the dependents list, force the operator to migrate or cancel subscriptions first. Auto-cascade on subscriptions risks losing real billing data.
+4. **Where do recipe webhook endpoints get their real URL?** Proposal: created with `url_placeholder` from YAML (`https://example.com/webhooks/velox`), plus an `is_placeholder=true` flag. Dashboard surfaces a "set webhook URL" prompt next to the instantiated recipe. Endpoint stays inactive (no events dispatched) until URL is updated and `is_placeholder` cleared. **Open:** does inactive-endpoint surface need a new column on `webhook_endpoints`, or do we reuse `enabled=false`? Lean toward `enabled=false` — same observable behavior, no schema delta.
+5. **Should preview be cacheable?** Proposal: **no for v1**. Reads happen at most a few times per tenant. Cache invalidation across YAML version bumps + override permutations is its own problem.
+6. **Recipe ordering in `GET /v1/recipes` — is there a "featured" notion?** Proposal: **alphabetical, no featuring v1**. The picker UI (Track B) can apply its own ordering; backend doesn't pick favorites.
+7. **Should built-in recipes ship with `webhook.events` set or empty?** Proposal: **set per recipe**. `anthropic_style` and `openai_style` get the AI-relevant events (`invoice.finalized`, `usage.threshold_crossed` once Week 5 ships); `b2b_saas_pro` gets the SaaS-classic ones (`subscription.created`, `subscription.canceled`). Concrete defaults beat empty-and-let-the-tenant-figure-it-out.
+
+## Implementation checklist (Week 3)
+
+Tracking via the 90-day plan; this is the canonical breakdown:
+
+- [ ] Migration `00XX_recipe_instances.{up,down}.sql` (allocate number from `origin/main`)
+- [ ] `domain.RecipeInstance` struct, `domain.Recipe` (parsed YAML), `domain.CreatedObjects`
+- [ ] `internal/recipe/embed.go` — `embed.FS` and registry
+- [ ] `internal/recipe/parse.go` — YAML schema + validation
+- [ ] `internal/recipe/template.go` — override merge + `text/template` render
+- [ ] `internal/recipe/store.go` + `postgres.go` — `recipe_instances` CRUD
+- [ ] `internal/recipe/service.go` — `Preview`, `Instantiate`, `Uninstall`
+- [ ] HTTP handlers: `GET /v1/recipes`, `GET /v1/recipes/{key}`, `POST /v1/recipes/{key}/preview`, `POST /v1/recipes/instantiate`, `DELETE /v1/recipes/instances/{id}`
+- [ ] `*Tx` variants on `pricing.Service`, `dunning.Service`, `webhook.Service`, `usage.Service` for transactional graph creation
+- [ ] 5 built-in recipes in `internal/recipe/recipes/*.yaml`
+- [ ] Per-recipe one-pagers in `docs/recipes/*.md` (Track B owns rendering at `/docs/recipes`)
+- [ ] Unit tests: YAML parse, override validation, template render
+- [ ] Integration tests: instantiate / preview / force / RLS / atomicity rollback
+- [ ] `cmd/velox-recipes-e2e/main.go` + assertion against multi-dim meter pricing
+- [ ] OpenAPI spec update (`docs/openapi.yaml`)
+- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B, after coordinating)
+
+## Track B unblock
+
+Track B can scaffold the recipe-picker UI against this design today. The contract Track B should mock:
+
+- `GET /v1/recipes` → list with `key`, `name`, `summary`, `creates`, `overridable`, `instantiated`
+- `GET /v1/recipes/{key}` → detail with markdown `description`
+- `POST /v1/recipes/{key}/preview` body `{ overrides: {} }` → object graph
+- `POST /v1/recipes/instantiate` body `{ key, overrides, seed_sample_data, force }` → 201 with `id` + `created_objects`
+
+The picker UI shape Track B should aim at:
+- Card grid of recipes (hero name + summary + creates-count badges)
+- Click → detail drawer with description + override form (per `overridable_schema`)
+- "Preview" button → preview modal showing the object graph (collapsible per type)
+- "Instantiate" button → confirmation → success state with deep-links into the created plan / meter / webhook detail pages
+
+Track B can ship the UI against a mocked API (e.g. MSW handlers) before Track A finishes the backend, then swap to the real API at integration time. This is the parallel-work pattern (`docs/parallel-work.md` § "Design-first / RFC pattern").
+
+## Review status
+
+- **Track A author:** drafted 2026-04-25
+- **Track B review:** pending — Track B can scaffold the picker UI against this design without waiting for implementation
+- **Human review:** pending — please flag any open question to resolve before Week 3 starts (May 9)

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -29,3 +29,31 @@
 
 ### Track B
 - _(no entries yet — this row created by Track A as a placeholder; Track B fills it in on first turn)_
+
+---
+
+## 2026-04-25 (Sat) — second update, Track A end-of-Week-2
+
+### Track A
+- **Shipped (Week 2 multi-dim meters):**
+  - Migration `0054_multi_dim_meters` (decimal `NUMERIC(38,12)` quantity, GIN on `properties`, `meter_pricing_rules` table)
+  - Decimal-quantity refactor across `domain.UsageEvent` + pricing/billing path
+  - `pricing` package: `meter_pricing_rules` store + service
+  - `usage`: dimensions on `properties` + JSONB superset contract test
+  - `usage.Store.AggregateByPricingRules` — priority+claim resolution across all 5 aggregation modes (period-bounded query for sum/count/max/last_during_period; separate query for last_ever)
+  - `cmd/velox-bench` ingest benchmark — baselines ~2.5k events/sec on local dev hardware. The 50k/sec target needs cloud-grade Postgres + batched INSERTs (both follow-up); the harness itself is the deliverable for Week 2.
+  - Wire-contract alignment in `docs/design-multi-dim-meters.md`: hyphen paths (`/v1/usage-events`, `/v1/meters/{id}/pricing-rules`), `quantity` as the canonical field both directions (no `value` alias), `external_customer_id` + `event_name` on input.
+  - Lint fixes (gofmt + errcheck) so PR #20 CI is green.
+  - CHANGELOG entry for the multi-dim meters foundation.
+- **Shipped (Week 3 prep):**
+  - `docs/design-recipes.md` — RFC-style design for Week 3 pricing recipes work (5 built-in recipes, `POST /v1/recipes/instantiate` atomic graph creation, YAML format embedded via `embed.FS`, idempotency at the recipe-instance level, 7 open questions). Track B can scaffold the picker UI against this design today.
+- **PR review (Track B's PR #19, Week 1 README + blog):** posted comment at https://github.com/sagarsuperuser/velox/pull/19#issuecomment-4320248289 listing 5 drift points (path conventions × 2, field names × 3, `quantity` stance) to keep Week 1 docs aligned with the corrected design doc.
+- **Track A's PR #20 status:** lint fixed in latest push (df80d3d, 6a9fdca), CI rerunning. Was test+frontend+docker green, lint failing on 3 gofmt + 1 errcheck — all fixed.
+- **Blocking Track B on:** nothing.
+- **Track B can start:**
+  - **Week 3 picker UI scaffold against `docs/design-recipes.md`** — contract is fully spec'd; mock the 5 endpoints with MSW and ship the picker grid + detail drawer + override form + preview modal.
+  - Multi-dim meter dashboard surfaces (MeterDetail.tsx, UsageEvents.tsx) light-up verification once PR #20 merges.
+- **Open for human review:**
+  - Open questions 1–7 in `docs/design-recipes.md` — flag any to resolve before Week 3 implementation starts (May 9).
+  - Track B's quantity-vs-value question: resolved as `quantity` canonical, no `value` alias. Documented in `docs/design-multi-dim-meters.md` "Wire-contract conventions" callout.
+- **Next session (Track A):** depending on human direction — (a) drive PR #20 to merge once CI is green, then start Week 3 recipes implementation Monday; (b) Week 1 docs polish if human wants those locked first; (c) `create_preview` design doc for Week 5 if human wants the next RFC pre-staged for Track B.

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/signintech/gopdf v0.36.0 h1:/7gPwoLtlNv5tPNpYuo3T3z0mWgo62pTrCvVNAiOo2Q=
 github.com/signintech/gopdf v0.36.0/go.mod h1:d23eO35GpEliSrF22eJ4bsM3wVeQJTjXTHq5x5qGKjA=
 github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=

--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 	"github.com/sagarsuperuser/velox/internal/platform/clock"
@@ -152,10 +154,13 @@ type SubscriptionReader interface {
 	ActivateAfterTrial(ctx context.Context, tenantID, id string, at time.Time) (domain.Subscription, error)
 }
 
-// UsageAggregator aggregates usage events for a billing period.
+// UsageAggregator aggregates usage events for a billing period. Returns
+// decimal.Decimal so fractional AI-usage primitives (GPU-hours, cached-token
+// ratios) round-trip without precision loss; the engine converts to cents
+// at the multiplication step.
 type UsageAggregator interface {
-	AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]int64, error)
-	AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]int64, error)
+	AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error)
+	AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error)
 }
 
 // PricingReader reads plan, rating rule, and override data.
@@ -930,19 +935,20 @@ func (e *Engine) billSubscription(ctx context.Context, sub domain.Subscription) 
 		return false, fmt.Errorf("aggregate usage: %w", err)
 	}
 
-	// Enforce usage cap if configured (integer math only). Cap is a
-	// subscription-level total across all meters — it doesn't need to respect
-	// item boundaries because the cap is a container-level guardrail, not a
-	// per-plan constraint.
+	// Enforce usage cap if configured. Cap is a subscription-level total
+	// across all meters — a container-level guardrail, not a per-plan
+	// constraint. Cap stays integer (UsageCapUnits int64) because operators
+	// author it as a whole-unit ceiling; per-meter quantities are decimal
+	// and prorated proportionally if the cap fires.
 	if sub.UsageCapUnits != nil && *sub.UsageCapUnits > 0 && sub.OverageAction == "block" {
-		totalUsage := int64(0)
+		totalUsage := decimal.Zero
 		for _, qty := range usageTotals {
-			totalUsage += qty
+			totalUsage = totalUsage.Add(qty)
 		}
-		if totalUsage > *sub.UsageCapUnits {
-			cap := *sub.UsageCapUnits
+		capDec := decimal.NewFromInt(*sub.UsageCapUnits)
+		if totalUsage.GreaterThan(capDec) {
 			for mid, qty := range usageTotals {
-				usageTotals[mid] = qty * cap / totalUsage
+				usageTotals[mid] = qty.Mul(capDec).Div(totalUsage)
 			}
 		}
 	}
@@ -1002,7 +1008,7 @@ func (e *Engine) billSubscription(ctx context.Context, sub domain.Subscription) 
 			seenMeters[meterID] = struct{}{}
 
 			quantity, ok := usageTotals[meterID]
-			if !ok || quantity == 0 {
+			if !ok || quantity.IsZero() {
 				continue
 			}
 
@@ -1035,17 +1041,23 @@ func (e *Engine) billSubscription(ctx context.Context, sub domain.Subscription) 
 				return false, fmt.Errorf("compute amount for meter %s: %w", meterID, err)
 			}
 
-			unitAmount := int64(0)
-			if quantity > 0 {
-				unitAmount = money.RoundHalfToEven(amount, quantity)
-			}
+			// Per-unit amount on the invoice line is informational; the
+			// authoritative number is amount_cents from the rule. Compute as
+			// amount/quantity in decimal space, banker-round to int cents.
+			// Quantity here is decimal (fractional usage allowed) and cannot
+			// be zero — the IsZero check above already short-circuited.
+			unitAmount := decimal.NewFromInt(amount).Div(quantity).RoundBank(0).IntPart()
 
 			lineItems = append(lineItems, domain.InvoiceLineItem{
-				LineType:            domain.LineTypeUsage,
-				MeterID:             meterID,
-				Description:         fmt.Sprintf("%s (%s)", meter.Name, meter.Unit),
-				Quantity:            quantity,
-				UnitAmountCents:     unitAmount,
+				LineType: domain.LineTypeUsage,
+				MeterID:  meterID,
+				Description: fmt.Sprintf("%s (%s)", meter.Name, meter.Unit),
+				// Quantity is truncated to int for the line item — fractional
+				// quantities (e.g. 1.5 GPU-hours) are supported in pricing
+				// math but the line item display column is still integer.
+				// Followup: widen InvoiceLineItem.Quantity to NUMERIC.
+				Quantity:        quantity.IntPart(),
+				UnitAmountCents: unitAmount,
 				AmountCents:         amount,
 				TotalAmountCents:    amount,
 				Currency:            invoiceCurrency,

--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -1049,15 +1049,15 @@ func (e *Engine) billSubscription(ctx context.Context, sub domain.Subscription) 
 			unitAmount := decimal.NewFromInt(amount).Div(quantity).RoundBank(0).IntPart()
 
 			lineItems = append(lineItems, domain.InvoiceLineItem{
-				LineType: domain.LineTypeUsage,
-				MeterID:  meterID,
+				LineType:    domain.LineTypeUsage,
+				MeterID:     meterID,
 				Description: fmt.Sprintf("%s (%s)", meter.Name, meter.Unit),
 				// Quantity is truncated to int for the line item — fractional
 				// quantities (e.g. 1.5 GPU-hours) are supported in pricing
 				// math but the line item display column is still integer.
 				// Followup: widen InvoiceLineItem.Quantity to NUMERIC.
-				Quantity:        quantity.IntPart(),
-				UnitAmountCents: unitAmount,
+				Quantity:            quantity.IntPart(),
+				UnitAmountCents:     unitAmount,
 				AmountCents:         amount,
 				TotalAmountCents:    amount,
 				Currency:            invoiceCurrency,

--- a/internal/billing/engine_integration_test.go
+++ b/internal/billing/engine_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/billing"
 	"github.com/sagarsuperuser/velox/internal/customer"
 	"github.com/sagarsuperuser/velox/internal/domain"
@@ -91,11 +93,11 @@ type usageStoreAdapter struct {
 	store *usage.PostgresStore
 }
 
-func (a *usageStoreAdapter) AggregateForBillingPeriod(ctx context.Context, tenantID, subID string, meterIDs []string, from, to time.Time) (map[string]int64, error) {
+func (a *usageStoreAdapter) AggregateForBillingPeriod(ctx context.Context, tenantID, subID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	return a.store.AggregateForBillingPeriod(ctx, tenantID, subID, meterIDs, from, to)
 }
 
-func (a *usageStoreAdapter) AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]int64, error) {
+func (a *usageStoreAdapter) AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	return a.store.AggregateForBillingPeriodByAgg(ctx, tenantID, customerID, meters, from, to)
 }
 
@@ -249,7 +251,7 @@ func TestFullBillingCycle_E2E(t *testing.T) {
 		ts := periodStart.Add(time.Duration(i) * 24 * time.Hour)
 		_, err := usageStore.Ingest(ctx, tenantID, domain.UsageEvent{
 			CustomerID: cust.ID, MeterID: apiMeter.ID, SubscriptionID: sub.ID,
-			Quantity: 300, Timestamp: ts,
+			Quantity: decimal.NewFromInt(300), Timestamp: ts,
 		})
 		if err != nil {
 			t.Fatalf("ingest api usage %d: %v", i, err)
@@ -259,7 +261,7 @@ func TestFullBillingCycle_E2E(t *testing.T) {
 
 	_, err = usageStore.Ingest(ctx, tenantID, domain.UsageEvent{
 		CustomerID: cust.ID, MeterID: storageMeter.ID, SubscriptionID: sub.ID,
-		Quantity: 50, Timestamp: periodStart.Add(48 * time.Hour),
+		Quantity: decimal.NewFromInt(50), Timestamp: periodStart.Add(48 * time.Hour),
 	})
 	if err != nil {
 		t.Fatalf("ingest storage usage: %v", err)

--- a/internal/billing/engine_test.go
+++ b/internal/billing/engine_test.go
@@ -1899,8 +1899,8 @@ func TestRunCycle_PauseCollection_AutoResumesWhenResumesAtPasses(t *testing.T) {
 // has not yet elapsed. No invoice generated; next_billing_at advances.
 func TestRunCycle_Trial_Active_SkipsBillingAndAdvancesCycle(t *testing.T) {
 	periodStart := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-	periodEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)        // past, so cycle scan picks it up
-	trialEnd := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)         // far-future: trial still active at scan time
+	periodEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC) // past, so cycle scan picks it up
+	trialEnd := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)  // far-future: trial still active at scan time
 
 	subs := &mockSubs{
 		subs: map[string]domain.Subscription{
@@ -1948,8 +1948,8 @@ func TestRunCycle_Trial_Active_SkipsBillingAndAdvancesCycle(t *testing.T) {
 // normally.
 func TestRunCycle_Trial_Ended_AutoActivatesAndBills(t *testing.T) {
 	periodStart := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
-	periodEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)        // past, so cycle scan picks it up
-	trialEnd := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)        // past: trial elapsed before now
+	periodEnd := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC) // past, so cycle scan picks it up
+	trialEnd := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC) // past: trial elapsed before now
 
 	subs := &mockSubs{
 		subs: map[string]domain.Subscription{
@@ -2013,4 +2013,3 @@ func TestRunCycle_Trial_Ended_AutoActivatesAndBills(t *testing.T) {
 		t.Errorf("triggered_by: got %v, want schedule", trialEndedEvent["triggered_by"])
 	}
 }
-

--- a/internal/billing/engine_test.go
+++ b/internal/billing/engine_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 	"github.com/sagarsuperuser/velox/internal/platform/clock"
@@ -160,24 +162,24 @@ func (m *mockSubs) ApplyDuePendingItemPlansAtomic(_ context.Context, _, id strin
 }
 
 type mockUsage struct {
-	totals map[string]int64 // meterID -> quantity
+	totals map[string]int64 // meterID -> quantity (test inputs stay int for readability)
 }
 
-func (m *mockUsage) AggregateForBillingPeriod(_ context.Context, _, _ string, meterIDs []string, _, _ time.Time) (map[string]int64, error) {
-	result := make(map[string]int64)
+func (m *mockUsage) AggregateForBillingPeriod(_ context.Context, _, _ string, meterIDs []string, _, _ time.Time) (map[string]decimal.Decimal, error) {
+	result := make(map[string]decimal.Decimal)
 	for _, id := range meterIDs {
 		if qty, ok := m.totals[id]; ok {
-			result[id] = qty
+			result[id] = decimal.NewFromInt(qty)
 		}
 	}
 	return result, nil
 }
 
-func (m *mockUsage) AggregateForBillingPeriodByAgg(_ context.Context, _, _ string, meters map[string]string, _, _ time.Time) (map[string]int64, error) {
-	result := make(map[string]int64)
+func (m *mockUsage) AggregateForBillingPeriodByAgg(_ context.Context, _, _ string, meters map[string]string, _, _ time.Time) (map[string]decimal.Decimal, error) {
+	result := make(map[string]decimal.Decimal)
 	for id := range meters {
 		if qty, ok := m.totals[id]; ok {
-			result[id] = qty
+			result[id] = decimal.NewFromInt(qty)
 		}
 	}
 	return result, nil

--- a/internal/billing/preview.go
+++ b/internal/billing/preview.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
-	"github.com/sagarsuperuser/velox/internal/platform/money"
 )
 
 // PreviewLine represents one line in an invoice preview.
@@ -115,7 +116,7 @@ func (e *Engine) Preview(ctx context.Context, sub domain.Subscription) (PreviewR
 		rendered[meterID] = struct{}{}
 
 		quantity := usageTotals[meterID]
-		if quantity == 0 {
+		if quantity.IsZero() {
 			continue
 		}
 
@@ -139,16 +140,18 @@ func (e *Engine) Preview(ctx context.Context, sub domain.Subscription) (PreviewR
 			continue
 		}
 
-		unitAmount := int64(0)
-		if quantity > 0 {
-			unitAmount = money.RoundHalfToEven(amount, quantity)
-		}
+		// quantity is decimal here; the IsZero short-circuit above
+		// guarantees it is non-zero so unit-amount division is safe.
+		unitAmount := decimal.NewFromInt(amount).Div(quantity).RoundBank(0).IntPart()
 
 		result.Lines = append(result.Lines, PreviewLine{
-			LineType:        "usage",
-			Description:     fmt.Sprintf("%s - %d %s", meter.Name, quantity, meter.Unit),
+			LineType: "usage",
+			// Quantity column on previews is integer for now — fractional
+			// values are truncated in the human description but the
+			// AmountCents above is computed from the full decimal quantity.
+			Description:     fmt.Sprintf("%s - %s %s", meter.Name, quantity.String(), meter.Unit),
 			MeterID:         meterID,
-			Quantity:        quantity,
+			Quantity:        quantity.IntPart(),
 			UnitAmountCents: unitAmount,
 			AmountCents:     amount,
 			PricingMode:     string(rule.Mode),

--- a/internal/domain/pricing.go
+++ b/internal/domain/pricing.go
@@ -139,6 +139,20 @@ type MeterPricingRule struct {
 	UpdatedAt           time.Time       `json:"updated_at"`
 }
 
+// RuleAggregation is one row of the priority+claim resolution result: events
+// in a billing period that were claimed by a single pricing rule, rolled up
+// per the rule's aggregation_mode into a final billable quantity.
+//
+// RuleID == "" indicates the unclaimed bucket — events that matched no rule.
+// The caller falls back to meters.rating_rule_version_id with the meter's
+// own aggregation, preserving back-compat for tenants without any rules.
+type RuleAggregation struct {
+	RuleID              string          `json:"rule_id,omitempty"`
+	RatingRuleVersionID string          `json:"rating_rule_version_id,omitempty"`
+	AggregationMode     AggregationMode `json:"aggregation_mode"`
+	Quantity            decimal.Decimal `json:"quantity"`
+}
+
 var ErrInvalidPricingConfig = errors.New("invalid pricing config")
 
 // ErrAmountOverflow is returned when a pricing computation would exceed

--- a/internal/domain/pricing.go
+++ b/internal/domain/pricing.go
@@ -92,6 +92,53 @@ type Plan struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// AggregationMode is how a meter pricing rule rolls up the events it
+// claims into a single quantity for the period. The set is fixed at the
+// schema layer (CHECK constraint on meter_pricing_rules.aggregation_mode).
+//
+// Stripe Tier 1 parity: count, last_during_period, last_ever, max are
+// modes Stripe's Meter API supports that the prior single-mode meter
+// could not express. Hoisted into v1 of multi-dim meters.
+type AggregationMode string
+
+const (
+	AggSum              AggregationMode = "sum"
+	AggCount            AggregationMode = "count"
+	AggLastDuringPeriod AggregationMode = "last_during_period"
+	AggLastEver         AggregationMode = "last_ever"
+	AggMax              AggregationMode = "max"
+)
+
+// IsValid returns true if m is a recognised aggregation mode.
+func (m AggregationMode) IsValid() bool {
+	switch m {
+	case AggSum, AggCount, AggLastDuringPeriod, AggLastEver, AggMax:
+		return true
+	default:
+		return false
+	}
+}
+
+// MeterPricingRule binds a rating rule version to a subset of a meter's
+// events via a JSONB dimension match. At billing time, rules are walked
+// in priority-DESC order and each event is claimed by the highest-
+// priority matching rule (no double-count). The default rule for a
+// meter has dimension_match='{}' which matches every event; priority=0
+// keeps it last so specific rules win.
+//
+// See docs/design-multi-dim-meters.md for the resolution algorithm.
+type MeterPricingRule struct {
+	ID                  string          `json:"id"`
+	TenantID            string          `json:"tenant_id,omitempty"`
+	MeterID             string          `json:"meter_id"`
+	RatingRuleVersionID string          `json:"rating_rule_version_id"`
+	DimensionMatch      map[string]any  `json:"dimension_match"`
+	AggregationMode     AggregationMode `json:"aggregation_mode"`
+	Priority            int             `json:"priority"`
+	CreatedAt           time.Time       `json:"created_at"`
+	UpdatedAt           time.Time       `json:"updated_at"`
+}
+
 var ErrInvalidPricingConfig = errors.New("invalid pricing config")
 
 // ErrAmountOverflow is returned when a pricing computation would exceed

--- a/internal/domain/pricing.go
+++ b/internal/domain/pricing.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"math"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 type PricingMode string
@@ -97,29 +99,22 @@ var ErrInvalidPricingConfig = errors.New("invalid pricing config")
 // emit a negative invoice line in production.
 var ErrAmountOverflow = errors.New("amount overflow: exceeds int64 range")
 
-// mulNonNegative multiplies two non-negative int64 values and flags
-// overflow. Callers must validate inputs >= 0 before calling.
-func mulNonNegative(a, b int64) (int64, bool) {
-	if a == 0 || b == 0 {
-		return 0, false
-	}
-	if b > math.MaxInt64/a {
-		return 0, true
-	}
-	return a * b, false
-}
+// maxInt64Decimal caches a decimal copy of math.MaxInt64 for the overflow
+// guard at the int64-cents conversion boundary.
+var maxInt64Decimal = decimal.NewFromInt(math.MaxInt64)
 
-// addNonNegative adds two non-negative int64 values and flags overflow.
-// Callers must validate inputs >= 0 before calling.
-func addNonNegative(a, b int64) (int64, bool) {
-	if a > math.MaxInt64-b {
-		return 0, true
-	}
-	return a + b, false
-}
-
-func ComputeAmountCents(rule RatingRuleVersion, quantity int64) (int64, error) {
-	if quantity < 0 {
+// ComputeAmountCents prices a decimal quantity through the given rating rule
+// and returns the result rounded to whole cents. Quantity is decimal so that
+// fractional usage primitives (GPU-hours, cached-token ratios) round-trip
+// without precision loss. Tier boundaries (`up_to`, `package_size`) stay
+// integer because pricing config is authored that way; the math walks tiers
+// in decimal space and converts to int64 cents only at the final round.
+//
+// Rounding: half-to-even (banker's rounding) at the cent boundary. This is
+// the same convention used elsewhere in the engine (money.RoundHalfToEven)
+// and the IEEE 754 default — minimizes systematic bias on bulk invoices.
+func ComputeAmountCents(rule RatingRuleVersion, quantity decimal.Decimal) (int64, error) {
+	if quantity.IsNegative() {
 		return 0, ErrInvalidPricingConfig
 	}
 
@@ -128,14 +123,11 @@ func ComputeAmountCents(rule RatingRuleVersion, quantity int64) (int64, error) {
 		if rule.FlatAmountCents < 0 {
 			return 0, ErrInvalidPricingConfig
 		}
-		if quantity == 0 {
+		if quantity.IsZero() {
 			return 0, nil
 		}
-		total, overflow := mulNonNegative(quantity, rule.FlatAmountCents)
-		if overflow {
-			return 0, ErrAmountOverflow
-		}
-		return total, nil
+		total := quantity.Mul(decimal.NewFromInt(rule.FlatAmountCents))
+		return decimalToCents(total)
 
 	case PricingGraduated:
 		if len(rule.GraduatedTiers) == 0 {
@@ -143,24 +135,17 @@ func ComputeAmountCents(rule RatingRuleVersion, quantity int64) (int64, error) {
 		}
 		remaining := quantity
 		lastUpper := int64(0)
-		amount := int64(0)
+		amount := decimal.Zero
 		for i, tier := range rule.GraduatedTiers {
 			if tier.UnitAmountCents < 0 || tier.UpTo < 0 {
 				return 0, ErrInvalidPricingConfig
 			}
-			if remaining == 0 {
+			if remaining.IsZero() {
 				break
 			}
 			if tier.UpTo == 0 {
-				tierAmt, overflow := mulNonNegative(remaining, tier.UnitAmountCents)
-				if overflow {
-					return 0, ErrAmountOverflow
-				}
-				amount, overflow = addNonNegative(amount, tierAmt)
-				if overflow {
-					return 0, ErrAmountOverflow
-				}
-				remaining = 0
+				amount = amount.Add(remaining.Mul(decimal.NewFromInt(tier.UnitAmountCents)))
+				remaining = decimal.Zero
 				break
 			}
 			if tier.UpTo < lastUpper {
@@ -173,47 +158,47 @@ func ComputeAmountCents(rule RatingRuleVersion, quantity int64) (int64, error) {
 			if tierCapacity < 0 {
 				return 0, ErrInvalidPricingConfig
 			}
-			consumed := min(remaining, tierCapacity)
-			tierAmt, overflow := mulNonNegative(consumed, tier.UnitAmountCents)
-			if overflow {
-				return 0, ErrAmountOverflow
+			capDec := decimal.NewFromInt(tierCapacity)
+			consumed := remaining
+			if consumed.GreaterThan(capDec) {
+				consumed = capDec
 			}
-			amount, overflow = addNonNegative(amount, tierAmt)
-			if overflow {
-				return 0, ErrAmountOverflow
-			}
-			remaining -= consumed
+			amount = amount.Add(consumed.Mul(decimal.NewFromInt(tier.UnitAmountCents)))
+			remaining = remaining.Sub(consumed)
 			lastUpper = tier.UpTo
 		}
-		if remaining > 0 {
+		if remaining.IsPositive() {
 			return 0, ErrInvalidPricingConfig
 		}
-		return amount, nil
+		return decimalToCents(amount)
 
 	case PricingPackage:
 		if rule.PackageSize <= 0 || rule.PackageAmountCents < 0 || rule.OverageUnitAmountCents < 0 {
 			return 0, ErrInvalidPricingConfig
 		}
-		if quantity == 0 {
+		if quantity.IsZero() {
 			return 0, nil
 		}
-		fullPackages := quantity / rule.PackageSize
-		remainder := quantity % rule.PackageSize
-		packagesAmt, overflow := mulNonNegative(fullPackages, rule.PackageAmountCents)
-		if overflow {
-			return 0, ErrAmountOverflow
-		}
-		overageAmt, overflow := mulNonNegative(remainder, rule.OverageUnitAmountCents)
-		if overflow {
-			return 0, ErrAmountOverflow
-		}
-		total, overflow := addNonNegative(packagesAmt, overageAmt)
-		if overflow {
-			return 0, ErrAmountOverflow
-		}
-		return total, nil
+		pkgSize := decimal.NewFromInt(rule.PackageSize)
+		fullPackages := quantity.Div(pkgSize).Floor()
+		remainder := quantity.Sub(fullPackages.Mul(pkgSize))
+		total := fullPackages.Mul(decimal.NewFromInt(rule.PackageAmountCents)).
+			Add(remainder.Mul(decimal.NewFromInt(rule.OverageUnitAmountCents)))
+		return decimalToCents(total)
 
 	default:
 		return 0, ErrInvalidPricingConfig
 	}
+}
+
+// decimalToCents rounds a decimal cents value (potentially fractional after
+// quantity multiplication) to int64 using banker's rounding. Returns
+// ErrAmountOverflow if the rounded value would exceed int64 — silent wrap
+// would emit a negative invoice line in production, so this is fail-loud.
+func decimalToCents(d decimal.Decimal) (int64, error) {
+	rounded := d.RoundBank(0)
+	if rounded.GreaterThan(maxInt64Decimal) {
+		return 0, ErrAmountOverflow
+	}
+	return rounded.IntPart(), nil
 }

--- a/internal/domain/pricing_bench_test.go
+++ b/internal/domain/pricing_bench_test.go
@@ -1,12 +1,17 @@
 package domain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
 
 func BenchmarkComputeAmountCents_Flat(b *testing.B) {
 	rule := RatingRuleVersion{Mode: PricingFlat, FlatAmountCents: 500}
+	q := decimal.NewFromInt(1000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = ComputeAmountCents(rule, 1000)
+		_, _ = ComputeAmountCents(rule, q)
 	}
 }
 
@@ -21,9 +26,10 @@ func BenchmarkComputeAmountCents_Graduated_5Tiers(b *testing.B) {
 			{UpTo: 0, UnitAmountCents: 5},
 		},
 	}
+	q := decimal.NewFromInt(7500)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = ComputeAmountCents(rule, 7500)
+		_, _ = ComputeAmountCents(rule, q)
 	}
 }
 
@@ -34,8 +40,9 @@ func BenchmarkComputeAmountCents_Package(b *testing.B) {
 		PackageAmountCents:     2000,
 		OverageUnitAmountCents: 30,
 	}
+	q := decimal.NewFromInt(15750)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = ComputeAmountCents(rule, 15750)
+		_, _ = ComputeAmountCents(rule, q)
 	}
 }

--- a/internal/domain/pricing_test.go
+++ b/internal/domain/pricing_test.go
@@ -3,7 +3,17 @@ package domain
 import (
 	"math"
 	"testing"
+
+	"github.com/shopspring/decimal"
 )
+
+// computeInt is a test-only convenience wrapping ComputeAmountCents with
+// an int64 quantity input. The production signature takes decimal.Decimal
+// (fractional usage is supported); these table tests still express
+// quantity as int for readability so we wrap once at the call site.
+func computeInt(rule RatingRuleVersion, n int64) (int64, error) {
+	return ComputeAmountCents(rule, decimal.NewFromInt(n))
+}
 
 func TestComputeAmountCents_Flat(t *testing.T) {
 	rule := RatingRuleVersion{Mode: PricingFlat, FlatAmountCents: 500}
@@ -21,7 +31,7 @@ func TestComputeAmountCents_Flat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ComputeAmountCents(rule, tt.qty)
+			got, err := computeInt(rule, tt.qty)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
 			}
@@ -56,7 +66,7 @@ func TestComputeAmountCents_Graduated(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ComputeAmountCents(rule, tt.qty)
+			got, err := computeInt(rule, tt.qty)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -88,7 +98,7 @@ func TestComputeAmountCents_Package(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ComputeAmountCents(rule, tt.qty)
+			got, err := computeInt(rule, tt.qty)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -105,7 +115,7 @@ func TestComputeAmountCents_Package(t *testing.T) {
 
 func TestComputeAmountCents_Flat_NegativeUnitPrice(t *testing.T) {
 	rule := RatingRuleVersion{Mode: PricingFlat, FlatAmountCents: -1}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for negative flat price, got %v", err)
 	}
@@ -117,7 +127,7 @@ func TestComputeAmountCents_Flat_LargeQuantityOverflowCheck(t *testing.T) {
 	// the multiplication should still produce a valid result.
 	rule := RatingRuleVersion{Mode: PricingFlat, FlatAmountCents: 1000}
 	qty := int64(math.MaxInt64 / 1000) // largest safe quantity
-	got, err := ComputeAmountCents(rule, qty)
+	got, err := computeInt(rule, qty)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -131,7 +141,7 @@ func TestComputeAmountCents_Flat_OverflowDetected(t *testing.T) {
 	// Pathological input: qty * unit would wrap int64. Must be rejected,
 	// not silently produce a negative invoice line.
 	rule := RatingRuleVersion{Mode: PricingFlat, FlatAmountCents: 2}
-	_, err := ComputeAmountCents(rule, math.MaxInt64)
+	_, err := computeInt(rule, math.MaxInt64)
 	if err != ErrAmountOverflow {
 		t.Fatalf("expected ErrAmountOverflow, got %v", err)
 	}
@@ -145,7 +155,7 @@ func TestComputeAmountCents_Graduated_OverflowDetected(t *testing.T) {
 			{UpTo: 0, UnitAmountCents: math.MaxInt64 / 2},
 		},
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrAmountOverflow {
 		t.Fatalf("expected ErrAmountOverflow in catch-all tier, got %v", err)
 	}
@@ -160,7 +170,7 @@ func TestComputeAmountCents_Graduated_OverflowOnSum(t *testing.T) {
 			{UpTo: 0, UnitAmountCents: 10},
 		},
 	}
-	_, err := ComputeAmountCents(rule, 2)
+	_, err := computeInt(rule, 2)
 	if err != ErrAmountOverflow {
 		t.Fatalf("expected ErrAmountOverflow on tier sum, got %v", err)
 	}
@@ -174,7 +184,7 @@ func TestComputeAmountCents_Package_OverflowDetected(t *testing.T) {
 		PackageAmountCents:     math.MaxInt64 / 2,
 		OverageUnitAmountCents: 0,
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrAmountOverflow {
 		t.Fatalf("expected ErrAmountOverflow on package multiply, got %v", err)
 	}
@@ -188,7 +198,7 @@ func TestComputeAmountCents_Package_OverflowOnSum(t *testing.T) {
 		PackageAmountCents:     math.MaxInt64 - 5,
 		OverageUnitAmountCents: 10,
 	}
-	_, err := ComputeAmountCents(rule, 3) // 1 full package + 1 overage
+	_, err := computeInt(rule, 3) // 1 full package + 1 overage
 	if err != ErrAmountOverflow {
 		t.Fatalf("expected ErrAmountOverflow on package sum, got %v", err)
 	}
@@ -197,7 +207,7 @@ func TestComputeAmountCents_Package_OverflowOnSum(t *testing.T) {
 func TestComputeAmountCents_Flat_ZeroUnitPrice(t *testing.T) {
 	// Free tier: 0 cents per unit
 	rule := RatingRuleVersion{Mode: PricingFlat, FlatAmountCents: 0}
-	got, err := ComputeAmountCents(rule, 999999)
+	got, err := computeInt(rule, 999999)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -219,7 +229,7 @@ func TestComputeAmountCents_Graduated_ExactTierBoundary(t *testing.T) {
 		},
 	}
 	// Exactly at the first tier boundary
-	got, err := ComputeAmountCents(rule, 100)
+	got, err := computeInt(rule, 100)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -236,7 +246,7 @@ func TestComputeAmountCents_Graduated_OnlyUnlimitedTier(t *testing.T) {
 			{UpTo: 0, UnitAmountCents: 10},
 		},
 	}
-	got, err := ComputeAmountCents(rule, 5000)
+	got, err := computeInt(rule, 5000)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -253,7 +263,7 @@ func TestComputeAmountCents_Graduated_InsufficientTiers(t *testing.T) {
 			{UpTo: 100, UnitAmountCents: 50},
 		},
 	}
-	_, err := ComputeAmountCents(rule, 200)
+	_, err := computeInt(rule, 200)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for insufficient tiers, got %v", err)
 	}
@@ -264,7 +274,7 @@ func TestComputeAmountCents_Graduated_EmptyTiers(t *testing.T) {
 		Mode:           PricingGraduated,
 		GraduatedTiers: nil,
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for empty tiers, got %v", err)
 	}
@@ -277,7 +287,7 @@ func TestComputeAmountCents_Graduated_NegativeUnitPrice(t *testing.T) {
 			{UpTo: 100, UnitAmountCents: -5},
 		},
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for negative unit price in tier, got %v", err)
 	}
@@ -290,7 +300,7 @@ func TestComputeAmountCents_Graduated_NegativeUpTo(t *testing.T) {
 			{UpTo: -10, UnitAmountCents: 50},
 		},
 	}
-	_, err := ComputeAmountCents(rule, 5)
+	_, err := computeInt(rule, 5)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for negative UpTo, got %v", err)
 	}
@@ -304,7 +314,7 @@ func TestComputeAmountCents_Graduated_ZeroQuantity(t *testing.T) {
 			{UpTo: 0, UnitAmountCents: 25},
 		},
 	}
-	got, err := ComputeAmountCents(rule, 0)
+	got, err := computeInt(rule, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -337,7 +347,7 @@ func TestComputeAmountCents_Graduated_ThreeTiersExactBoundaries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ComputeAmountCents(rule, tt.qty)
+			got, err := computeInt(rule, tt.qty)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -360,7 +370,7 @@ func TestComputeAmountCents_Package_ExactMultiple(t *testing.T) {
 		OverageUnitAmountCents: 30,
 	}
 	// 150 = 3 * 50, no overage
-	got, err := ComputeAmountCents(rule, 150)
+	got, err := computeInt(rule, 150)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -377,7 +387,7 @@ func TestComputeAmountCents_Package_SingleUnitLargePackage(t *testing.T) {
 		OverageUnitAmountCents: 10,
 	}
 	// qty=1: 0 full packages, 1 overage unit
-	got, err := ComputeAmountCents(rule, 1)
+	got, err := computeInt(rule, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -393,7 +403,7 @@ func TestComputeAmountCents_Package_ZeroPackageSize(t *testing.T) {
 		PackageAmountCents:     1000,
 		OverageUnitAmountCents: 10,
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for zero package size, got %v", err)
 	}
@@ -406,7 +416,7 @@ func TestComputeAmountCents_Package_NegativePackageSize(t *testing.T) {
 		PackageAmountCents:     1000,
 		OverageUnitAmountCents: 10,
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for negative package size, got %v", err)
 	}
@@ -419,7 +429,7 @@ func TestComputeAmountCents_Package_NegativePackagePrice(t *testing.T) {
 		PackageAmountCents:     -500,
 		OverageUnitAmountCents: 10,
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for negative package price, got %v", err)
 	}
@@ -432,7 +442,7 @@ func TestComputeAmountCents_Package_NegativeOveragePrice(t *testing.T) {
 		PackageAmountCents:     1000,
 		OverageUnitAmountCents: -5,
 	}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for negative overage price, got %v", err)
 	}
@@ -446,7 +456,7 @@ func TestComputeAmountCents_Package_ZeroOveragePrice(t *testing.T) {
 		PackageAmountCents:     2000,
 		OverageUnitAmountCents: 0,
 	}
-	got, err := ComputeAmountCents(rule, 150)
+	got, err := computeInt(rule, 150)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -462,7 +472,7 @@ func TestComputeAmountCents_Package_ZeroOveragePrice(t *testing.T) {
 
 func TestComputeAmountCents_UnknownMode(t *testing.T) {
 	rule := RatingRuleVersion{Mode: "volume"}
-	_, err := ComputeAmountCents(rule, 10)
+	_, err := computeInt(rule, 10)
 	if err != ErrInvalidPricingConfig {
 		t.Fatalf("expected ErrInvalidPricingConfig for unknown mode, got %v", err)
 	}
@@ -488,7 +498,7 @@ func TestComputeAmountCents_NegativeQuantity_AllModes(t *testing.T) {
 	}
 	for _, m := range modes {
 		t.Run(m.name, func(t *testing.T) {
-			_, err := ComputeAmountCents(m.rule, -1)
+			_, err := computeInt(m.rule, -1)
 			if err != ErrInvalidPricingConfig {
 				t.Fatalf("expected ErrInvalidPricingConfig for negative quantity in %s mode, got %v", m.name, err)
 			}

--- a/internal/domain/subscription.go
+++ b/internal/domain/subscription.go
@@ -61,18 +61,18 @@ type SubscriptionItem struct {
 }
 
 type Subscription struct {
-	ID                        string                  `json:"id"`
-	TenantID                  string                  `json:"tenant_id,omitempty"`
-	Code                      string                  `json:"code"`
-	DisplayName               string                  `json:"display_name"`
-	CustomerID                string                  `json:"customer_id"`
-	Status                    SubscriptionStatus      `json:"status"`
-	BillingTime               SubscriptionBillingTime `json:"billing_time"`
-	TrialStartAt              *time.Time              `json:"trial_start_at,omitempty"`
-	TrialEndAt                *time.Time              `json:"trial_end_at,omitempty"`
-	StartedAt                 *time.Time              `json:"started_at,omitempty"`
-	ActivatedAt               *time.Time              `json:"activated_at,omitempty"`
-	CanceledAt                *time.Time              `json:"canceled_at,omitempty"`
+	ID           string                  `json:"id"`
+	TenantID     string                  `json:"tenant_id,omitempty"`
+	Code         string                  `json:"code"`
+	DisplayName  string                  `json:"display_name"`
+	CustomerID   string                  `json:"customer_id"`
+	Status       SubscriptionStatus      `json:"status"`
+	BillingTime  SubscriptionBillingTime `json:"billing_time"`
+	TrialStartAt *time.Time              `json:"trial_start_at,omitempty"`
+	TrialEndAt   *time.Time              `json:"trial_end_at,omitempty"`
+	StartedAt    *time.Time              `json:"started_at,omitempty"`
+	ActivatedAt  *time.Time              `json:"activated_at,omitempty"`
+	CanceledAt   *time.Time              `json:"canceled_at,omitempty"`
 	// CancelAt is a future timestamp at which the billing cycle should
 	// transition the subscription to canceled. Distinct from CanceledAt
 	// (past-tense, set only when the cancel has fired). Nil means no
@@ -90,13 +90,13 @@ type Subscription struct {
 	// GetDueBilling entirely). Nil means collection is running normally.
 	PauseCollection           *PauseCollection `json:"pause_collection,omitempty"`
 	CurrentBillingPeriodStart *time.Time       `json:"current_billing_period_start,omitempty"`
-	CurrentBillingPeriodEnd   *time.Time              `json:"current_billing_period_end,omitempty"`
-	NextBillingAt             *time.Time              `json:"next_billing_at,omitempty"`
-	UsageCapUnits             *int64                  `json:"usage_cap_units,omitempty"` // Max usage units per billing period (nil = unlimited)
-	OverageAction             string                  `json:"overage_action,omitempty"`  // "block" or "charge" (default: charge)
-	TestClockID               string                  `json:"test_clock_id,omitempty"`   // Test mode only — attached simulator clock
-	CreatedAt                 time.Time               `json:"created_at"`
-	UpdatedAt                 time.Time               `json:"updated_at"`
+	CurrentBillingPeriodEnd   *time.Time       `json:"current_billing_period_end,omitempty"`
+	NextBillingAt             *time.Time       `json:"next_billing_at,omitempty"`
+	UsageCapUnits             *int64           `json:"usage_cap_units,omitempty"` // Max usage units per billing period (nil = unlimited)
+	OverageAction             string           `json:"overage_action,omitempty"`  // "block" or "charge" (default: charge)
+	TestClockID               string           `json:"test_clock_id,omitempty"`   // Test mode only — attached simulator clock
+	CreatedAt                 time.Time        `json:"created_at"`
+	UpdatedAt                 time.Time        `json:"updated_at"`
 
 	// Items is populated by store reads that hydrate the subscription with
 	// its current priced lines. Writes through Store.Create require a

--- a/internal/domain/usage.go
+++ b/internal/domain/usage.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
 
 // UsageEventOrigin is the ingest path that produced a usage_events row.
 // 'api' covers real-time POST /usage-events (and /batch); 'backfill' covers
@@ -12,13 +16,18 @@ const (
 	UsageOriginBackfill UsageEventOrigin = "backfill"
 )
 
+// UsageEvent.Quantity is a NUMERIC(38, 12) decimal so AI usage primitives
+// (GPU-hours, cached-token ratios, partial KV-cache reads) round-trip
+// exactly. Maps to Stripe's quantity_decimal. JSON wire format is a string
+// ("0.50") on the response side; the unmarshaller accepts both number (5)
+// and string ("5.5") on the request side.
 type UsageEvent struct {
 	ID             string           `json:"id"`
 	TenantID       string           `json:"tenant_id,omitempty"`
 	CustomerID     string           `json:"customer_id"`
 	MeterID        string           `json:"meter_id"`
 	SubscriptionID string           `json:"subscription_id,omitempty"`
-	Quantity       int64            `json:"quantity"`
+	Quantity       decimal.Decimal  `json:"quantity"`
 	Properties     map[string]any   `json:"properties,omitempty"`
 	IdempotencyKey string           `json:"idempotency_key,omitempty"`
 	Timestamp      time.Time        `json:"timestamp"`

--- a/internal/platform/migrate/sql/0054_multi_dim_meters.down.sql
+++ b/internal/platform/migrate/sql/0054_multi_dim_meters.down.sql
@@ -1,0 +1,15 @@
+-- Down: revert multi-dim meter foundation.
+--
+-- Destructive on quantity revert: NUMERIC values with fractional parts will
+-- be truncated by the cast to BIGINT. Operators reconciling this in
+-- production must verify all live rows hold integer values before applying
+-- this down (SELECT count(*) FROM usage_events WHERE quantity != trunc(quantity)).
+-- Velox is pre-launch / local-only at this writing, so the down path is
+-- exercised only in dev/test environments.
+
+DROP TABLE IF EXISTS meter_pricing_rules;
+
+DROP INDEX IF EXISTS idx_usage_events_properties_gin;
+
+ALTER TABLE usage_events
+    ALTER COLUMN quantity TYPE BIGINT USING quantity::bigint;

--- a/internal/platform/migrate/sql/0054_multi_dim_meters.up.sql
+++ b/internal/platform/migrate/sql/0054_multi_dim_meters.up.sql
@@ -1,0 +1,70 @@
+-- Multi-dimensional meters: foundation for AI-native pricing.
+--
+-- Three coordinated changes per docs/design-multi-dim-meters.md:
+--
+--   1. usage_events.quantity becomes NUMERIC(38, 12).
+--      AI usage is intrinsically fractional (GPU-hours, cached-token
+--      ratios, partial KV-cache reads) and BIGINT can only express it via
+--      lossy unit-scaling at the application layer. NUMERIC(38, 12) gives
+--      the operator a quantity primitive that holds both whole counts and
+--      fractions without a per-tenant scale convention. Maps to Stripe's
+--      quantity_decimal (Tier 1 parity gap).
+--
+--   2. GIN index on usage_events.properties.
+--      Pricing-rule resolution is a JSONB subset-match (`properties @> {...}`)
+--      executed at finalize time across the period's events. GIN over JSONB
+--      is the canonical Postgres index for this; without it, every finalize
+--      becomes a sequential scan over the period.
+--
+--   3. New meter_pricing_rules table. N rules per meter, each carrying
+--      a dimension_match JSONB filter, an aggregation_mode, and a priority.
+--      Each event is claimed by the highest-priority matching rule (no
+--      double-count). Default rule has dimension_match='{}' which matches
+--      everything; priority=0 keeps it last so specific rules win first.
+--
+-- Backward compatibility:
+--   - meters.aggregation column is left in place but becomes advisory; the
+--     authoritative aggregation mode is now per-rule on meter_pricing_rules.
+--     A separate cleanup migration may deprecate it once all consumers move.
+--   - quantity column rename: BIGINT -> NUMERIC is a metadata-only change
+--     when no rows exist (pre-launch), and a rewrite when rows exist. We
+--     are pre-launch / local-only, so this is effectively free.
+
+ALTER TABLE usage_events
+    ALTER COLUMN quantity TYPE NUMERIC(38, 12) USING quantity::numeric;
+
+CREATE INDEX idx_usage_events_properties_gin
+    ON usage_events USING GIN (properties);
+
+CREATE TABLE meter_pricing_rules (
+    id                      TEXT PRIMARY KEY DEFAULT 'vlx_mpr_' || encode(gen_random_bytes(12), 'hex'),
+    tenant_id               TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    meter_id                TEXT NOT NULL REFERENCES meters(id) ON DELETE CASCADE,
+    rating_rule_version_id  TEXT NOT NULL REFERENCES rating_rule_versions(id) ON DELETE RESTRICT,
+    dimension_match         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    aggregation_mode        TEXT NOT NULL DEFAULT 'sum'
+                                CHECK (aggregation_mode IN ('sum', 'count', 'last_during_period', 'last_ever', 'max')),
+    priority                INT NOT NULL DEFAULT 0,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (tenant_id, meter_id, rating_rule_version_id)
+);
+
+-- Hot path: rule resolution iterates rules for a meter in priority order
+-- (highest first; default rule with priority=0 is last). The descending
+-- index sort matches the runtime sort and avoids in-memory ordering.
+CREATE INDEX idx_meter_pricing_rules_lookup
+    ON meter_pricing_rules (tenant_id, meter_id, priority DESC);
+
+-- Standard tenant-isolation pattern (see 0046 for prior art). FORCE makes
+-- the policy apply even to the table owner, so a misconfigured connection
+-- string can't accidentally bypass it.
+ALTER TABLE meter_pricing_rules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE meter_pricing_rules FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON meter_pricing_rules FOR ALL USING (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR tenant_id = current_setting('app.tenant_id', true)
+);
+
+GRANT ALL ON TABLE meter_pricing_rules TO velox_app;

--- a/internal/pricing/override.go
+++ b/internal/pricing/override.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
@@ -158,7 +160,7 @@ func (s *Service) CreateOverride(ctx context.Context, tenantID string, input Cre
 		PackageAmountCents:     input.PackageAmountCents,
 		OverageUnitAmountCents: input.OverageUnitAmountCents,
 	}
-	if _, err := domain.ComputeAmountCents(testRule, 1); err != nil {
+	if _, err := domain.ComputeAmountCents(testRule, decimal.NewFromInt(1)); err != nil {
 		return domain.CustomerPriceOverride{}, errs.Invalid("pricing", fmt.Sprintf("invalid pricing configuration: %v", err))
 	}
 

--- a/internal/pricing/postgres.go
+++ b/internal/pricing/postgres.go
@@ -564,7 +564,7 @@ func (s *PostgresStore) ListMeterPricingRulesByMeter(ctx context.Context, tenant
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var out []domain.MeterPricingRule
 	for rows.Next() {

--- a/internal/pricing/postgres.go
+++ b/internal/pricing/postgres.go
@@ -445,3 +445,184 @@ func joinClauses(parts []string) string {
 	}
 	return result
 }
+
+// ---------------------------------------------------------------------------
+// Meter Pricing Rules
+// ---------------------------------------------------------------------------
+
+// UpsertMeterPricingRule inserts or updates a pricing rule for a meter.
+// The unique key is (tenant_id, meter_id, rating_rule_version_id) — a
+// rule is identified by which rating rule it points at, so re-issuing
+// the same point-pair with new dimension_match / mode / priority
+// updates the existing row. ON CONFLICT keeps the original id and
+// created_at, and bumps updated_at.
+func (s *PostgresStore) UpsertMeterPricingRule(ctx context.Context, tenantID string, rule domain.MeterPricingRule) (domain.MeterPricingRule, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	id := rule.ID
+	if id == "" {
+		id = postgres.NewID("vlx_mpr")
+	}
+
+	dimMatch := rule.DimensionMatch
+	if dimMatch == nil {
+		dimMatch = map[string]any{}
+	}
+	matchJSON, err := json.Marshal(dimMatch)
+	if err != nil {
+		return domain.MeterPricingRule{}, fmt.Errorf("marshal dimension_match: %w", err)
+	}
+
+	now := time.Now().UTC()
+	var stored domain.MeterPricingRule
+	var storedMatch []byte
+	err = tx.QueryRowContext(ctx, `
+		INSERT INTO meter_pricing_rules
+			(id, tenant_id, meter_id, rating_rule_version_id, dimension_match,
+			 aggregation_mode, priority, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$8)
+		ON CONFLICT (tenant_id, meter_id, rating_rule_version_id) DO UPDATE
+		   SET dimension_match  = EXCLUDED.dimension_match,
+		       aggregation_mode = EXCLUDED.aggregation_mode,
+		       priority         = EXCLUDED.priority,
+		       updated_at       = EXCLUDED.updated_at
+		RETURNING id, tenant_id, meter_id, rating_rule_version_id,
+		          dimension_match, aggregation_mode, priority,
+		          created_at, updated_at
+	`, id, tenantID, rule.MeterID, rule.RatingRuleVersionID, matchJSON,
+		string(rule.AggregationMode), rule.Priority, now,
+	).Scan(
+		&stored.ID, &stored.TenantID, &stored.MeterID, &stored.RatingRuleVersionID,
+		&storedMatch, &stored.AggregationMode, &stored.Priority,
+		&stored.CreatedAt, &stored.UpdatedAt,
+	)
+	if err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+
+	if len(storedMatch) > 0 {
+		if err := json.Unmarshal(storedMatch, &stored.DimensionMatch); err != nil {
+			return domain.MeterPricingRule{}, fmt.Errorf("unmarshal dimension_match: %w", err)
+		}
+	}
+	if stored.DimensionMatch == nil {
+		stored.DimensionMatch = map[string]any{}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+	return stored, nil
+}
+
+func (s *PostgresStore) GetMeterPricingRule(ctx context.Context, tenantID, id string) (domain.MeterPricingRule, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	rule, err := scanMeterPricingRule(tx.QueryRowContext(ctx, `
+		SELECT id, tenant_id, meter_id, rating_rule_version_id,
+		       dimension_match, aggregation_mode, priority,
+		       created_at, updated_at
+		  FROM meter_pricing_rules
+		 WHERE id = $1
+	`, id))
+	if err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+	return rule, nil
+}
+
+// ListMeterPricingRulesByMeter returns all pricing rules for a meter
+// ordered by priority DESC, then created_at ASC. This matches the
+// runtime resolution order in design-multi-dim-meters.md so callers can
+// walk the slice top-down without re-sorting.
+func (s *PostgresStore) ListMeterPricingRulesByMeter(ctx context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer postgres.Rollback(tx)
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, tenant_id, meter_id, rating_rule_version_id,
+		       dimension_match, aggregation_mode, priority,
+		       created_at, updated_at
+		  FROM meter_pricing_rules
+		 WHERE meter_id = $1
+		 ORDER BY priority DESC, created_at ASC
+	`, meterID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []domain.MeterPricingRule
+	for rows.Next() {
+		rule, err := scanMeterPricingRule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rule)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) DeleteMeterPricingRule(ctx context.Context, tenantID, id string) error {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return err
+	}
+	defer postgres.Rollback(tx)
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM meter_pricing_rules WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return errs.ErrNotFound
+	}
+	return tx.Commit()
+}
+
+func scanMeterPricingRule(row rowScanner) (domain.MeterPricingRule, error) {
+	var r domain.MeterPricingRule
+	var matchJSON []byte
+	err := row.Scan(&r.ID, &r.TenantID, &r.MeterID, &r.RatingRuleVersionID,
+		&matchJSON, &r.AggregationMode, &r.Priority,
+		&r.CreatedAt, &r.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return domain.MeterPricingRule{}, errs.ErrNotFound
+	}
+	if err != nil {
+		return domain.MeterPricingRule{}, err
+	}
+	if len(matchJSON) > 0 {
+		if err := json.Unmarshal(matchJSON, &r.DimensionMatch); err != nil {
+			return domain.MeterPricingRule{}, fmt.Errorf("unmarshal dimension_match: %w", err)
+		}
+	}
+	if r.DimensionMatch == nil {
+		r.DimensionMatch = map[string]any{}
+	}
+	return r, nil
+}

--- a/internal/pricing/postgres_test.go
+++ b/internal/pricing/postgres_test.go
@@ -170,3 +170,165 @@ func TestPostgresStore_Plans(t *testing.T) {
 		t.Errorf("updated base: got %d", updated.BaseAmountCents)
 	}
 }
+
+// TestPostgresStore_MeterPricingRules covers the multi-dim meters
+// foundation: the (meter, rating-rule) UNIQUE key drives upsert, the
+// priority-DESC list ordering matches the runtime resolution order, the
+// JSONB dimension_match round-trips, and RLS isolates tenants.
+func TestPostgresStore_MeterPricingRules(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	store := pricing.NewPostgresStore(db)
+	ctx := context.Background()
+	tenantID := testutil.CreateTestTenant(t, db, "Multi-Dim Test")
+
+	// Seed: one meter, two rating rules.
+	rrv1, err := store.CreateRatingRule(ctx, tenantID, domain.RatingRuleVersion{
+		RuleKey: "tokens_default", Name: "Tokens default", Version: 1,
+		LifecycleState: domain.RatingRuleActive, Mode: domain.PricingFlat,
+		Currency: "USD", FlatAmountCents: 5,
+	})
+	if err != nil {
+		t.Fatalf("seed rrv1: %v", err)
+	}
+	rrv2, err := store.CreateRatingRule(ctx, tenantID, domain.RatingRuleVersion{
+		RuleKey: "tokens_cached", Name: "Tokens cached", Version: 1,
+		LifecycleState: domain.RatingRuleActive, Mode: domain.PricingFlat,
+		Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("seed rrv2: %v", err)
+	}
+	meter, err := store.CreateMeter(ctx, tenantID, domain.Meter{
+		Key: "tokens", Name: "Tokens", Unit: "tokens",
+		Aggregation: "sum", RatingRuleVersionID: rrv1.ID,
+	})
+	if err != nil {
+		t.Fatalf("seed meter: %v", err)
+	}
+
+	// Insert default rule (no dimension match, low priority).
+	defRule, err := store.UpsertMeterPricingRule(ctx, tenantID, domain.MeterPricingRule{
+		MeterID: meter.ID, RatingRuleVersionID: rrv1.ID,
+		DimensionMatch: map[string]any{}, AggregationMode: domain.AggSum, Priority: 0,
+	})
+	if err != nil {
+		t.Fatalf("upsert default: %v", err)
+	}
+	if defRule.ID == "" || defRule.CreatedAt.IsZero() {
+		t.Errorf("expected ID and created_at populated, got %+v", defRule)
+	}
+
+	// Insert specific rule, higher priority.
+	specRule, err := store.UpsertMeterPricingRule(ctx, tenantID, domain.MeterPricingRule{
+		MeterID: meter.ID, RatingRuleVersionID: rrv2.ID,
+		DimensionMatch:  map[string]any{"model": "gpt-4", "cached": true},
+		AggregationMode: domain.AggSum, Priority: 100,
+	})
+	if err != nil {
+		t.Fatalf("upsert specific: %v", err)
+	}
+
+	// List ordering: priority DESC (specific first, default last).
+	rules, err := store.ListMeterPricingRulesByMeter(ctx, tenantID, meter.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("got %d rules, want 2", len(rules))
+	}
+	if rules[0].ID != specRule.ID {
+		t.Errorf("priority ordering: got %s first, want %s (specific)", rules[0].ID, specRule.ID)
+	}
+	if rules[1].ID != defRule.ID {
+		t.Errorf("priority ordering: got %s last, want %s (default)", rules[1].ID, defRule.ID)
+	}
+	// Dimension match round-trip via JSONB.
+	if got := rules[0].DimensionMatch["model"]; got != "gpt-4" {
+		t.Errorf("dimension_match round-trip: got %v, want gpt-4", got)
+	}
+	if got := rules[0].DimensionMatch["cached"]; got != true {
+		t.Errorf("dimension_match bool round-trip: got %v, want true", got)
+	}
+
+	// Upsert idempotency: re-issuing the same (meter, rrv) pair updates
+	// the same row instead of inserting a duplicate.
+	updated, err := store.UpsertMeterPricingRule(ctx, tenantID, domain.MeterPricingRule{
+		MeterID: meter.ID, RatingRuleVersionID: rrv2.ID,
+		DimensionMatch:  map[string]any{"model": "gpt-4-turbo"},
+		AggregationMode: domain.AggMax, Priority: 200,
+	})
+	if err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	if updated.ID != specRule.ID {
+		t.Errorf("upsert created a new row instead of updating: first=%s now=%s", specRule.ID, updated.ID)
+	}
+	if updated.AggregationMode != domain.AggMax || updated.Priority != 200 {
+		t.Errorf("updated fields not persisted: mode=%s priority=%d", updated.AggregationMode, updated.Priority)
+	}
+
+	// Delete and verify.
+	if err := store.DeleteMeterPricingRule(ctx, tenantID, defRule.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	_, err = store.GetMeterPricingRule(ctx, tenantID, defRule.ID)
+	if err == nil || err != errs.ErrNotFound {
+		t.Errorf("expected ErrNotFound after delete, got %v", err)
+	}
+	left, _ := store.ListMeterPricingRulesByMeter(ctx, tenantID, meter.ID)
+	if len(left) != 1 {
+		t.Errorf("after delete: got %d rules, want 1", len(left))
+	}
+}
+
+// TestPostgresStore_MeterPricingRules_RLS verifies tenant A cannot see
+// or mutate tenant B's pricing rules.
+func TestPostgresStore_MeterPricingRules_RLS(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	store := pricing.NewPostgresStore(db)
+	ctx := context.Background()
+
+	tenantA := testutil.CreateTestTenant(t, db, "Tenant A")
+	tenantB := testutil.CreateTestTenant(t, db, "Tenant B")
+
+	// Seed minimal data in tenant A.
+	rrvA, _ := store.CreateRatingRule(ctx, tenantA, domain.RatingRuleVersion{
+		RuleKey: "a_rule", Name: "A", Version: 1,
+		LifecycleState: domain.RatingRuleActive, Mode: domain.PricingFlat,
+		Currency: "USD", FlatAmountCents: 5,
+	})
+	meterA, _ := store.CreateMeter(ctx, tenantA, domain.Meter{
+		Key: "tokens", Name: "Tokens", Unit: "tokens",
+		Aggregation: "sum", RatingRuleVersionID: rrvA.ID,
+	})
+	ruleA, err := store.UpsertMeterPricingRule(ctx, tenantA, domain.MeterPricingRule{
+		MeterID: meterA.ID, RatingRuleVersionID: rrvA.ID,
+		DimensionMatch: map[string]any{}, AggregationMode: domain.AggSum,
+	})
+	if err != nil {
+		t.Fatalf("seed tenant A rule: %v", err)
+	}
+
+	// Tenant B cannot see A's rule by id.
+	if _, err := store.GetMeterPricingRule(ctx, tenantB, ruleA.ID); err != errs.ErrNotFound {
+		t.Errorf("RLS: tenant B should not see tenant A's rule, got err=%v", err)
+	}
+
+	// Tenant B's list-by-meter must not include A's rule.
+	listed, err := store.ListMeterPricingRulesByMeter(ctx, tenantB, meterA.ID)
+	if err != nil {
+		t.Fatalf("list by meter under tenantB: %v", err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("RLS: tenantB saw %d rules under tenantA's meter, want 0", len(listed))
+	}
+
+	// Tenant B's delete must report not-found instead of removing it.
+	if err := store.DeleteMeterPricingRule(ctx, tenantB, ruleA.ID); err != errs.ErrNotFound {
+		t.Errorf("RLS: tenantB delete should be NotFound, got %v", err)
+	}
+	// And the rule still exists for tenant A.
+	if _, err := store.GetMeterPricingRule(ctx, tenantA, ruleA.ID); err != nil {
+		t.Errorf("rule must still exist for tenantA after RLS-blocked delete: %v", err)
+	}
+}

--- a/internal/pricing/service.go
+++ b/internal/pricing/service.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 )
@@ -71,7 +73,7 @@ func (s *Service) CreateRatingRule(ctx context.Context, tenantID string, input C
 	}
 
 	// Validate the pricing config by computing a test amount
-	if _, err := domain.ComputeAmountCents(rule, 1); err != nil {
+	if _, err := domain.ComputeAmountCents(rule, decimal.NewFromInt(1)); err != nil {
 		return domain.RatingRuleVersion{}, errs.Invalid("pricing", fmt.Sprintf("invalid pricing configuration: %v", err))
 	}
 

--- a/internal/pricing/service.go
+++ b/internal/pricing/service.go
@@ -319,3 +319,109 @@ func (s *Service) UpdatePlan(ctx context.Context, tenantID, id string, input Cre
 
 	return s.store.UpdatePlan(ctx, tenantID, existing)
 }
+
+// ---------------------------------------------------------------------------
+// Meter Pricing Rules — N-rules-per-meter dispatch.
+// ---------------------------------------------------------------------------
+
+// UpsertMeterPricingRuleInput is the public input shape. The combination
+// (meter_id, rating_rule_version_id) identifies the rule — re-issuing
+// the same point pair with new dimension_match / mode / priority
+// updates the existing rule (idempotent reconfigure).
+type UpsertMeterPricingRuleInput struct {
+	MeterID             string                 `json:"meter_id"`
+	RatingRuleVersionID string                 `json:"rating_rule_version_id"`
+	DimensionMatch      map[string]any         `json:"dimension_match"`
+	AggregationMode     domain.AggregationMode `json:"aggregation_mode"`
+	Priority            int                    `json:"priority"`
+}
+
+// maxDimensionKeys caps the size of the JSONB filter to keep aggregation
+// queries cheap and to bound pathological tenants. 16 dimensions is
+// generous for the AI use case (model × operation × cached × tier ≈ 4),
+// matches the open-question in the design doc, and is enforced here at
+// the service boundary so the store never has to deal with bloated
+// filters.
+const maxDimensionKeys = 16
+
+// UpsertMeterPricingRule validates the input and upserts the rule.
+// Concretely the validations are:
+//   - meter_id and rating_rule_version_id required
+//   - rating rule must exist for this tenant (404 surfaces as 400 to
+//     avoid leaking other tenants' IDs through the API surface)
+//   - meter must exist for this tenant (same reasoning)
+//   - aggregation_mode must be one of the five accepted values
+//   - dimension_match has ≤ maxDimensionKeys keys
+//   - dimension_match values are scalars (string / number / bool); object
+//     and array values are rejected — Postgres `@>` would still match
+//     them but the semantics aren't well-defined for v1
+func (s *Service) UpsertMeterPricingRule(ctx context.Context, tenantID string, input UpsertMeterPricingRuleInput) (domain.MeterPricingRule, error) {
+	meterID := strings.TrimSpace(input.MeterID)
+	rrvID := strings.TrimSpace(input.RatingRuleVersionID)
+	if meterID == "" {
+		return domain.MeterPricingRule{}, errs.Required("meter_id")
+	}
+	if rrvID == "" {
+		return domain.MeterPricingRule{}, errs.Required("rating_rule_version_id")
+	}
+
+	if _, err := s.store.GetMeter(ctx, tenantID, meterID); err != nil {
+		return domain.MeterPricingRule{}, errs.Invalid("meter_id", fmt.Sprintf("meter %q not found", meterID))
+	}
+	if _, err := s.store.GetRatingRule(ctx, tenantID, rrvID); err != nil {
+		return domain.MeterPricingRule{}, errs.Invalid("rating_rule_version_id", fmt.Sprintf("rating rule %q not found", rrvID))
+	}
+
+	mode := input.AggregationMode
+	if mode == "" {
+		mode = domain.AggSum
+	}
+	if !mode.IsValid() {
+		return domain.MeterPricingRule{}, errs.Invalid("aggregation_mode", fmt.Sprintf("must be one of sum, count, last_during_period, last_ever, max; got %q", mode))
+	}
+
+	match := input.DimensionMatch
+	if match == nil {
+		match = map[string]any{}
+	}
+	if len(match) > maxDimensionKeys {
+		return domain.MeterPricingRule{}, errs.Invalid("dimension_match", fmt.Sprintf("at most %d keys (got %d)", maxDimensionKeys, len(match)))
+	}
+	for k, v := range match {
+		switch v.(type) {
+		case string, bool, float64, float32, int, int32, int64, nil:
+			// scalar — fine.
+		default:
+			return domain.MeterPricingRule{}, errs.Invalid("dimension_match", fmt.Sprintf("key %q value must be a scalar (string/number/bool), got %T", k, v))
+		}
+	}
+
+	return s.store.UpsertMeterPricingRule(ctx, tenantID, domain.MeterPricingRule{
+		MeterID:             meterID,
+		RatingRuleVersionID: rrvID,
+		DimensionMatch:      match,
+		AggregationMode:     mode,
+		Priority:            input.Priority,
+	})
+}
+
+// GetMeterPricingRule fetches one rule by id.
+func (s *Service) GetMeterPricingRule(ctx context.Context, tenantID, id string) (domain.MeterPricingRule, error) {
+	return s.store.GetMeterPricingRule(ctx, tenantID, id)
+}
+
+// ListMeterPricingRulesByMeter returns rules in priority-DESC order; the
+// store already enforces the ordering so callers can iterate top-down.
+func (s *Service) ListMeterPricingRulesByMeter(ctx context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error) {
+	if strings.TrimSpace(meterID) == "" {
+		return nil, errs.Required("meter_id")
+	}
+	return s.store.ListMeterPricingRulesByMeter(ctx, tenantID, meterID)
+}
+
+// DeleteMeterPricingRule removes a rule. Pre-existing usage events are
+// not retroactively re-scored; deletion only affects future billing
+// finalize cycles.
+func (s *Service) DeleteMeterPricingRule(ctx context.Context, tenantID, id string) error {
+	return s.store.DeleteMeterPricingRule(ctx, tenantID, id)
+}

--- a/internal/pricing/service_test.go
+++ b/internal/pricing/service_test.go
@@ -10,16 +10,18 @@ import (
 )
 
 type memStore struct {
-	rules  map[string]domain.RatingRuleVersion
-	meters map[string]domain.Meter
-	plans  map[string]domain.Plan
+	rules      map[string]domain.RatingRuleVersion
+	meters     map[string]domain.Meter
+	plans      map[string]domain.Plan
+	meterRules map[string]domain.MeterPricingRule
 }
 
 func newMemStore() *memStore {
 	return &memStore{
-		rules:  make(map[string]domain.RatingRuleVersion),
-		meters: make(map[string]domain.Meter),
-		plans:  make(map[string]domain.Plan),
+		rules:      make(map[string]domain.RatingRuleVersion),
+		meters:     make(map[string]domain.Meter),
+		plans:      make(map[string]domain.Plan),
+		meterRules: make(map[string]domain.MeterPricingRule),
 	}
 }
 
@@ -160,6 +162,56 @@ func (m *memStore) GetOverride(_ context.Context, _, _, _ string) (domain.Custom
 
 func (m *memStore) ListOverrides(_ context.Context, _, _ string) ([]domain.CustomerPriceOverride, error) {
 	return nil, nil
+}
+
+func (m *memStore) UpsertMeterPricingRule(_ context.Context, tenantID string, r domain.MeterPricingRule) (domain.MeterPricingRule, error) {
+	if m.meterRules == nil {
+		m.meterRules = make(map[string]domain.MeterPricingRule)
+	}
+	// Dedup on (tenant_id, meter_id, rating_rule_version_id) — same
+	// UNIQUE key the Postgres schema enforces.
+	for id, existing := range m.meterRules {
+		if existing.TenantID == tenantID && existing.MeterID == r.MeterID && existing.RatingRuleVersionID == r.RatingRuleVersionID {
+			r.ID = id
+			r.TenantID = tenantID
+			r.CreatedAt = existing.CreatedAt
+			m.meterRules[id] = r
+			return r, nil
+		}
+	}
+	if r.ID == "" {
+		r.ID = fmt.Sprintf("vlx_mpr_%d", len(m.meterRules)+1)
+	}
+	r.TenantID = tenantID
+	m.meterRules[r.ID] = r
+	return r, nil
+}
+
+func (m *memStore) GetMeterPricingRule(_ context.Context, tenantID, id string) (domain.MeterPricingRule, error) {
+	r, ok := m.meterRules[id]
+	if !ok || r.TenantID != tenantID {
+		return domain.MeterPricingRule{}, errs.ErrNotFound
+	}
+	return r, nil
+}
+
+func (m *memStore) ListMeterPricingRulesByMeter(_ context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error) {
+	var out []domain.MeterPricingRule
+	for _, r := range m.meterRules {
+		if r.TenantID == tenantID && r.MeterID == meterID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (m *memStore) DeleteMeterPricingRule(_ context.Context, tenantID, id string) error {
+	r, ok := m.meterRules[id]
+	if !ok || r.TenantID != tenantID {
+		return errs.ErrNotFound
+	}
+	delete(m.meterRules, id)
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -382,5 +434,218 @@ func TestUpdatePlan(t *testing.T) {
 	}
 	if updated.BaseAmountCents != 5900 {
 		t.Errorf("got base_amount %d, want 5900", updated.BaseAmountCents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Meter Pricing Rules
+// ---------------------------------------------------------------------------
+
+// seedMeterAndRule seeds a meter and a rating rule into the in-memory
+// store so the meter_pricing_rules tests can reference them by ID
+// without going through the public Create paths (those have their own
+// validation tested elsewhere).
+func seedMeterAndRule(t *testing.T, svc *Service, tenantID string) (meterID, rrvID string) {
+	t.Helper()
+	rule, err := svc.CreateRatingRule(context.Background(), tenantID, CreateRatingRuleInput{
+		RuleKey: "tokens_in", Name: "Input tokens", Mode: domain.PricingFlat,
+		Currency: "USD", FlatAmountCents: 5,
+	})
+	if err != nil {
+		t.Fatalf("seed rating rule: %v", err)
+	}
+	meter, err := svc.CreateMeter(context.Background(), tenantID, CreateMeterInput{
+		Key: "tokens", Name: "Tokens", Unit: "tokens", Aggregation: "sum",
+		RatingRuleVersionID: rule.ID,
+	})
+	if err != nil {
+		t.Fatalf("seed meter: %v", err)
+	}
+	return meter.ID, rule.ID
+}
+
+func TestUpsertMeterPricingRule_Valid(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	rule, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID:             meterID,
+		RatingRuleVersionID: rrvID,
+		DimensionMatch:      map[string]any{"model": "gpt-4", "cached": false},
+		AggregationMode:     domain.AggSum,
+		Priority:            100,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.AggregationMode != domain.AggSum {
+		t.Errorf("agg mode: got %q, want sum", rule.AggregationMode)
+	}
+	if rule.Priority != 100 {
+		t.Errorf("priority: got %d, want 100", rule.Priority)
+	}
+	if rule.DimensionMatch["model"] != "gpt-4" {
+		t.Errorf("dimension_match did not round-trip: got %+v", rule.DimensionMatch)
+	}
+}
+
+func TestUpsertMeterPricingRule_DefaultModeIsSum(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	rule, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.AggregationMode != domain.AggSum {
+		t.Errorf("default agg mode: got %q, want sum", rule.AggregationMode)
+	}
+}
+
+func TestUpsertMeterPricingRule_RejectsBadMode(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	_, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID, AggregationMode: "average",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown aggregation mode")
+	}
+}
+
+func TestUpsertMeterPricingRule_RejectsTooManyDimensions(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	dims := map[string]any{}
+	for i := 0; i < maxDimensionKeys+1; i++ {
+		dims[fmt.Sprintf("k%d", i)] = "v"
+	}
+	_, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID, DimensionMatch: dims,
+	})
+	if err == nil {
+		t.Fatal("expected error for too many dimension keys")
+	}
+}
+
+func TestUpsertMeterPricingRule_RejectsNonScalarDimensionValue(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	_, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID,
+		DimensionMatch: map[string]any{"models": []string{"gpt-4", "claude"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for slice value in dimension_match")
+	}
+}
+
+func TestUpsertMeterPricingRule_RequiresMeterAndRule(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+
+	_, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{})
+	if err == nil {
+		t.Fatal("expected required-field error")
+	}
+}
+
+func TestUpsertMeterPricingRule_UnknownMeterRejected(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	_, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	_, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: "vlx_mtr_does_not_exist", RatingRuleVersionID: rrvID,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown meter")
+	}
+}
+
+func TestUpsertMeterPricingRule_TenantIsolation(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	// Tenant A seeds its own meter and rule; tenant B should not be able
+	// to bind a pricing rule to A's IDs.
+	meterID, rrvID := seedMeterAndRule(t, svc, "tenantA")
+
+	_, err := svc.UpsertMeterPricingRule(ctx, "tenantB", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID,
+	})
+	if err == nil {
+		t.Fatal("expected cross-tenant attempt to be rejected")
+	}
+}
+
+func TestListMeterPricingRulesByMeter(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	// Seed a second rating rule so we can attach two pricing rules.
+	rule2, err := svc.CreateRatingRule(ctx, "t1", CreateRatingRuleInput{
+		RuleKey: "tokens_cached", Name: "Cached", Mode: domain.PricingFlat,
+		Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("second rating rule: %v", err)
+	}
+
+	if _, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID,
+		DimensionMatch: map[string]any{}, Priority: 0,
+	}); err != nil {
+		t.Fatalf("default rule: %v", err)
+	}
+	if _, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rule2.ID,
+		DimensionMatch: map[string]any{"cached": true}, Priority: 100,
+	}); err != nil {
+		t.Fatalf("specific rule: %v", err)
+	}
+
+	rules, err := svc.ListMeterPricingRulesByMeter(ctx, "t1", meterID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("got %d rules, want 2", len(rules))
+	}
+}
+
+func TestUpsertMeterPricingRule_IsIdempotent(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	meterID, rrvID := seedMeterAndRule(t, svc, "t1")
+
+	first, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID, Priority: 10,
+	})
+	if err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	// Re-issuing with the same (meter, rule) pair must update, not create.
+	second, err := svc.UpsertMeterPricingRule(ctx, "t1", UpsertMeterPricingRuleInput{
+		MeterID: meterID, RatingRuleVersionID: rrvID, Priority: 50,
+	})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Errorf("upsert created a new row instead of updating: first=%s second=%s", first.ID, second.ID)
+	}
+	if second.Priority != 50 {
+		t.Errorf("priority not updated: got %d want 50", second.Priority)
 	}
 }

--- a/internal/pricing/store.go
+++ b/internal/pricing/store.go
@@ -29,6 +29,13 @@ type Store interface {
 	CreateOverride(ctx context.Context, tenantID string, o domain.CustomerPriceOverride) (domain.CustomerPriceOverride, error)
 	GetOverride(ctx context.Context, tenantID, customerID, ruleID string) (domain.CustomerPriceOverride, error)
 	ListOverrides(ctx context.Context, tenantID, customerID string) ([]domain.CustomerPriceOverride, error)
+
+	// Meter pricing rules — N-rules-per-meter dispatch via dimension_match.
+	// See docs/design-multi-dim-meters.md.
+	UpsertMeterPricingRule(ctx context.Context, tenantID string, rule domain.MeterPricingRule) (domain.MeterPricingRule, error)
+	GetMeterPricingRule(ctx context.Context, tenantID, id string) (domain.MeterPricingRule, error)
+	ListMeterPricingRulesByMeter(ctx context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error)
+	DeleteMeterPricingRule(ctx context.Context, tenantID, id string) error
 }
 
 type RatingRuleFilter struct {

--- a/internal/usage/aggregation_integration_test.go
+++ b/internal/usage/aggregation_integration_test.go
@@ -1,0 +1,409 @@
+package usage_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+	"github.com/sagarsuperuser/velox/internal/usage"
+)
+
+// TestAggregateByPricingRules is the runtime contract test for
+// docs/design-multi-dim-meters.md priority+claim resolution. Each
+// sub-test exercises one piece of the algorithm:
+//
+//   - per-mode aggregation: sum, count, max, last_during_period, last_ever
+//   - priority+claim: the top-priority matching rule wins, no double-count
+//   - subset-match: extra dimensions on the event do not disqualify it
+//   - default fallback: events matching no rule become the unclaimed bucket
+//   - decimal precision: NUMERIC(38,12) round-trips losslessly
+//
+// The same Postgres schema is shared across sub-tests, but each writes a
+// fresh tenant so RLS keeps them isolated and the priority counters can
+// be assigned freely.
+func TestAggregateByPricingRules(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store := usage.NewPostgresStore(db)
+
+	t.Run("sum mode aggregates claimed events", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg Sum")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_sum")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_sum", "tokens_sum")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_sum")
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"model": "gpt-4"}, domain.AggSum, 100)
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(20), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(99), map[string]any{"model": "claude"})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		want := map[string]decimal.Decimal{
+			rrvID: decimal.NewFromInt(30), // gpt-4 events
+			"":    decimal.NewFromInt(99), // unclaimed default
+		}
+		assertRuleAggregations(t, got, want)
+	})
+
+	t.Run("count mode counts claimed events", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg Count")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_cnt")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_cnt", "tokens_cnt")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_cnt")
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"model": "gpt-4"}, domain.AggCount, 100)
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(50), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(99), map[string]any{"model": "gpt-4"})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			rrvID: decimal.NewFromInt(3), // count, not sum
+		})
+	})
+
+	t.Run("max mode picks largest claimed quantity", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg Max")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_max")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_max", "tokens_max")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_max")
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"model": "gpt-4"}, domain.AggMax, 100)
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(50), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(25), map[string]any{"model": "gpt-4"})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			rrvID: decimal.NewFromInt(50),
+		})
+	})
+
+	t.Run("last_during_period picks latest event in window", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg LDP")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_ldp")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_ldp", "tokens_ldp")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_ldp")
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"model": "gpt-4"}, domain.AggLastDuringPeriod, 100)
+
+		now := time.Now()
+		from := now.Add(-2 * time.Hour)
+		to := now.Add(1 * time.Hour)
+
+		// Three in-period events at distinct timestamps; latest qty=42.
+		ts1 := now.Add(-90 * time.Minute)
+		ts2 := now.Add(-30 * time.Minute)
+		ts3 := now.Add(-5 * time.Minute)
+		ingestAt(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10), map[string]any{"model": "gpt-4"}, ts1)
+		ingestAt(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(99), map[string]any{"model": "gpt-4"}, ts2)
+		ingestAt(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(42), map[string]any{"model": "gpt-4"}, ts3)
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			rrvID: decimal.NewFromInt(42),
+		})
+	})
+
+	t.Run("last_ever ignores period bounds", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg LE")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_le")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_le", "tokens_le")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_le")
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"metric": "seats"}, domain.AggLastEver, 100)
+
+		now := time.Now()
+		// "Period" is the last hour, but the relevant event is 30 days
+		// ago. last_ever should still pick it up.
+		from := now.Add(-1 * time.Hour)
+		to := now.Add(1 * time.Hour)
+
+		oldTs := now.Add(-30 * 24 * time.Hour)
+		ingestAt(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(7), map[string]any{"metric": "seats"}, oldTs)
+		// One newer event NOT matching the rule — must not bleed in.
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(99), map[string]any{"metric": "other"})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		// last_ever rule sees the 30-day-old seat-count event; the
+		// other event ('metric=other') is unclaimed and rolls into the
+		// default sum bucket — but only events INSIDE the period are
+		// in that bucket, so unclaimed=99.
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			rrvID: decimal.NewFromInt(7),  // last_ever: 30d-old seats=7
+			"":    decimal.NewFromInt(99), // unclaimed in period
+		})
+	})
+
+	t.Run("priority claim prevents double-count when rules overlap", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg Priority")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_prio")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_prio", "tokens_prio")
+		highRRV := insertTestRatingRule(t, db, tenantID, "rate_high")
+		lowRRV := insertTestRatingRule(t, db, tenantID, "rate_low")
+
+		// Specific rule (priority 100): cached gpt-4 events at premium.
+		// Coarse rule (priority 50): all gpt-4 events at base rate.
+		// An event matching both must be claimed by the priority-100 rule.
+		insertTestPricingRule(t, db, tenantID, meterID, highRRV,
+			map[string]any{"model": "gpt-4", "cached": true}, domain.AggSum, 100)
+		insertTestPricingRule(t, db, tenantID, meterID, lowRRV,
+			map[string]any{"model": "gpt-4"}, domain.AggSum, 50)
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		// Cached gpt-4 → high-priority rule.
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10), map[string]any{"model": "gpt-4", "cached": true})
+		// Uncached gpt-4 → matches only low-priority rule.
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(20), map[string]any{"model": "gpt-4", "cached": false})
+		// Another cached gpt-4 → high.
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(5), map[string]any{"model": "gpt-4", "cached": true})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			highRRV: decimal.NewFromInt(15), // 10 + 5 cached gpt-4
+			lowRRV:  decimal.NewFromInt(20), // 20 uncached gpt-4
+		})
+	})
+
+	t.Run("subset match: extra event dimensions do not disqualify", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg Subset")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_subset")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_subset", "tokens_subset")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_subset")
+		// Rule asks for {model: gpt-4} only — events with extra
+		// dimensions (operation, cached, region) must still match.
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"model": "gpt-4"}, domain.AggSum, 100)
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10),
+			map[string]any{"model": "gpt-4", "operation": "input", "cached": false, "region": "us-east"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(20),
+			map[string]any{"model": "gpt-4", "operation": "output", "cached": true})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			rrvID: decimal.NewFromInt(30),
+		})
+	})
+
+	t.Run("no rules: every event lands in unclaimed bucket", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg NoRules")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_nor")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_nor", "tokens_nor")
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(40), map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(2), map[string]any{"model": "claude"})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			"": decimal.NewFromInt(42),
+		})
+	})
+
+	t.Run("decimal precision round-trips through aggregation", func(t *testing.T) {
+		tenantID := testutil.CreateTestTenant(t, db, "Agg Decimal")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_dec")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_dec", "tokens_dec")
+		rrvID := insertTestRatingRule(t, db, tenantID, "rate_dec")
+		insertTestPricingRule(t, db, tenantID, meterID, rrvID,
+			map[string]any{"model": "gpt-4"}, domain.AggSum, 100)
+
+		from := time.Now().Add(-1 * time.Hour)
+		to := time.Now().Add(1 * time.Hour)
+
+		// Use 12-decimal-place quantities — the column is NUMERIC(38, 12).
+		q1, _ := decimal.NewFromString("1234.567890123456")
+		q2, _ := decimal.NewFromString("0.000000000001")
+		want, _ := decimal.NewFromString("1234.567890123457")
+		ingest(t, ctx, store, tenantID, customerID, meterID, q1, map[string]any{"model": "gpt-4"})
+		ingest(t, ctx, store, tenantID, customerID, meterID, q2, map[string]any{"model": "gpt-4"})
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		var foundRule decimal.Decimal
+		for _, r := range got {
+			if r.RatingRuleVersionID == rrvID {
+				foundRule = r.Quantity
+			}
+		}
+		if !foundRule.Equal(want) {
+			t.Errorf("decimal precision: got %s, want %s", foundRule.String(), want.String())
+		}
+	})
+}
+
+// ---- helpers --------------------------------------------------------------
+
+func ingest(t *testing.T, ctx context.Context, store *usage.PostgresStore,
+	tenantID, customerID, meterID string, qty decimal.Decimal, props map[string]any,
+) {
+	t.Helper()
+	svc := usage.NewService(store)
+	if _, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
+		CustomerID: customerID, MeterID: meterID,
+		Quantity: qty, Properties: props,
+	}); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+}
+
+func ingestAt(t *testing.T, ctx context.Context, store *usage.PostgresStore,
+	tenantID, customerID, meterID string, qty decimal.Decimal, props map[string]any, ts time.Time,
+) {
+	t.Helper()
+	svc := usage.NewService(store)
+	if _, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
+		CustomerID: customerID, MeterID: meterID,
+		Quantity: qty, Properties: props, Timestamp: &ts,
+	}); err != nil {
+		t.Fatalf("ingestAt: %v", err)
+	}
+}
+
+func assertRuleAggregations(t *testing.T, got []domain.RuleAggregation, want map[string]decimal.Decimal) {
+	t.Helper()
+	gotByRRV := make(map[string]decimal.Decimal, len(got))
+	for _, r := range got {
+		// Key by rating_rule_version_id; "" is the unclaimed bucket.
+		gotByRRV[r.RatingRuleVersionID] = r.Quantity
+	}
+	if len(gotByRRV) != len(want) {
+		t.Errorf("aggregation count: got %d entries (%v), want %d (%v)",
+			len(gotByRRV), gotByRRV, len(want), want)
+	}
+	for rrv, exp := range want {
+		actual, ok := gotByRRV[rrv]
+		if !ok {
+			t.Errorf("missing rrv=%q in result; got %v", rrv, gotByRRV)
+			continue
+		}
+		if !actual.Equal(exp) {
+			t.Errorf("rrv=%q: got %s, want %s", rrv, actual.String(), exp.String())
+		}
+	}
+}
+
+// insertTestRatingRule creates a minimal flat-rate rating rule version so
+// pricing-rule rows have a valid FK target. The actual prices are not
+// exercised here — aggregation only cares about the rrv id.
+func insertTestRatingRule(t *testing.T, db *postgres.DB, tenantID, key string) string {
+	t.Helper()
+
+	id := postgres.NewID("vlx_rrv")
+	tx, err := db.BeginTx(context.Background(), postgres.TxTenant, tenantID)
+	if err != nil {
+		t.Fatalf("begin rrv: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	_, err = tx.ExecContext(context.Background(), `
+		INSERT INTO rating_rule_versions (id, tenant_id, rule_key, name, version, lifecycle_state, mode, currency, flat_amount_cents)
+		VALUES ($1, $2, $3, $4, 1, 'active', 'flat', 'USD', 100)
+	`, id, tenantID, key, key)
+	if err != nil {
+		t.Fatalf("insert rrv: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit rrv: %v", err)
+	}
+	return id
+}
+
+// insertTestPricingRule writes a row to meter_pricing_rules. We hit the
+// table directly rather than going through the pricing service because
+// these tests are scoped to the aggregation query — the service-layer
+// coverage already lives in pricing/service_test.go.
+func insertTestPricingRule(t *testing.T, db *postgres.DB,
+	tenantID, meterID, rrvID string,
+	dims map[string]any, mode domain.AggregationMode, priority int,
+) {
+	t.Helper()
+
+	tx, err := db.BeginTx(context.Background(), postgres.TxTenant, tenantID)
+	if err != nil {
+		t.Fatalf("begin mpr: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	dimsJSON, err := jsonbValue(dims)
+	if err != nil {
+		t.Fatalf("marshal dims: %v", err)
+	}
+
+	_, err = tx.ExecContext(context.Background(), `
+		INSERT INTO meter_pricing_rules
+		    (id, tenant_id, meter_id, rating_rule_version_id, dimension_match, aggregation_mode, priority)
+		VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
+	`, postgres.NewID("vlx_mpr"), tenantID, meterID, rrvID, dimsJSON, string(mode), priority)
+	if err != nil {
+		t.Fatalf("insert mpr: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit mpr: %v", err)
+	}
+}
+
+func jsonbValue(m map[string]any) (string, error) {
+	if len(m) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/usage/backfill_integration_test.go
+++ b/internal/usage/backfill_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
 	"github.com/sagarsuperuser/velox/internal/testutil"
@@ -29,7 +31,7 @@ func TestBackfill_PersistsOriginAndAggregates(t *testing.T) {
 
 	// Event 1: live API ingest — should default to origin='api'.
 	apiEvt, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
-		CustomerID: customerID, MeterID: meterID, Quantity: 10,
+		CustomerID: customerID, MeterID: meterID, Quantity: decimal.NewFromInt(10),
 	})
 	if err != nil {
 		t.Fatalf("api ingest: %v", err)
@@ -41,7 +43,7 @@ func TestBackfill_PersistsOriginAndAggregates(t *testing.T) {
 	// Event 2: backfill from 5 days ago.
 	past := time.Now().Add(-5 * 24 * time.Hour).UTC()
 	backfillEvt, err := svc.Backfill(ctx, tenantID, usage.IngestInput{
-		CustomerID: customerID, MeterID: meterID, Quantity: 100, Timestamp: &past,
+		CustomerID: customerID, MeterID: meterID, Quantity: decimal.NewFromInt(100), Timestamp: &past,
 	})
 	if err != nil {
 		t.Fatalf("backfill: %v", err)
@@ -57,8 +59,8 @@ func TestBackfill_PersistsOriginAndAggregates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("aggregate: %v", err)
 	}
-	if got, want := totals[meterID], int64(110); got != want {
-		t.Errorf("aggregate includes backfill+api: got %d, want %d (10 api + 100 backfill)", got, want)
+	if got, want := totals[meterID], decimal.NewFromInt(110); !got.Equal(want) {
+		t.Errorf("aggregate includes backfill+api: got %s, want %s (10 api + 100 backfill)", got.String(), want.String())
 	}
 
 	// Round-trip: read via List and verify Origin survives the scan.

--- a/internal/usage/dimensions_integration_test.go
+++ b/internal/usage/dimensions_integration_test.go
@@ -1,0 +1,128 @@
+package usage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+	"github.com/sagarsuperuser/velox/internal/usage"
+)
+
+// TestUsageEvents_DimensionsPersistAndJSONBSupersetMatch is the
+// end-to-end contract test for FEAT-week2 multi-dim meters. It writes
+// usage events with dimensions on the properties JSONB column, then
+// verifies:
+//
+//  1. Dimensions round-trip through the store (JSON marshal/scan).
+//  2. The Postgres `@>` superset operator finds events whose properties
+//     are a superset of the filter — this is the operator pricing-rule
+//     resolution will use at finalize time.
+//  3. The GIN index created in migration 0054 is the access path the
+//     planner picks for `@>` queries (sanity check that the index
+//     wasn't accidentally pruned).
+//
+// Without this test, a future schema change (e.g. dropping the GIN
+// index, switching JSONB → JSON) could silently regress the rule-
+// dispatch hot path.
+func TestUsageEvents_DimensionsPersistAndJSONBSupersetMatch(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	store := usage.NewPostgresStore(db)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tenantID := testutil.CreateTestTenant(t, db, "Dimensions Test")
+	customerID := insertTestCustomer(t, db, tenantID, "cus_dim_1")
+	meterID := insertTestMeter(t, db, tenantID, "mtr_dim_1", "tokens")
+
+	type evt struct {
+		props map[string]any
+		qty   int64
+	}
+	events := []evt{
+		{props: map[string]any{"model": "gpt-4", "operation": "input", "cached": false}, qty: 100},
+		{props: map[string]any{"model": "gpt-4", "operation": "input", "cached": true}, qty: 50},
+		{props: map[string]any{"model": "gpt-4", "operation": "output", "cached": false}, qty: 25},
+		{props: map[string]any{"model": "claude-3", "operation": "input", "cached": false}, qty: 200},
+	}
+
+	svc := usage.NewService(store)
+	for i, e := range events {
+		if _, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
+			CustomerID: customerID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(e.qty), Properties: e.props,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	// Direct JSONB superset query — the same shape pricing-rule
+	// resolution will use at finalize time. {model:gpt-4} should
+	// match the first three events but not the claude-3 one.
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	var count int
+	err = tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM usage_events
+		 WHERE meter_id = $1
+		   AND properties @> '{"model":"gpt-4"}'::jsonb
+	`, meterID).Scan(&count)
+	if err != nil {
+		t.Fatalf("count gpt-4: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("model=gpt-4 superset match: got %d, want 3", count)
+	}
+
+	// Refine the filter — both model and operation. Should match the
+	// two input events but not the output.
+	err = tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM usage_events
+		 WHERE meter_id = $1
+		   AND properties @> '{"model":"gpt-4","operation":"input"}'::jsonb
+	`, meterID).Scan(&count)
+	if err != nil {
+		t.Fatalf("count gpt-4 input: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("model=gpt-4 op=input superset match: got %d, want 2", count)
+	}
+
+	// Empty filter '{}' matches every event (this is what the default
+	// rule will use).
+	err = tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM usage_events
+		 WHERE meter_id = $1
+		   AND properties @> '{}'::jsonb
+	`, meterID).Scan(&count)
+	if err != nil {
+		t.Fatalf("count all: %v", err)
+	}
+	if count != len(events) {
+		t.Errorf("empty filter (default rule): got %d, want %d", count, len(events))
+	}
+
+	// Sanity-check the GIN index exists and is named as the migration
+	// declared. We don't assert it's used (planner choice depends on
+	// row count) — just that schema state matches the contract.
+	var idxName string
+	err = tx.QueryRowContext(ctx, `
+		SELECT indexname FROM pg_indexes
+		 WHERE schemaname = current_schema()
+		   AND tablename = 'usage_events'
+		   AND indexname = 'idx_usage_events_properties_gin'
+	`).Scan(&idxName)
+	if err != nil {
+		t.Fatalf("GIN index missing — was migration 0054 reverted? err=%v", err)
+	}
+}

--- a/internal/usage/handler.go
+++ b/internal/usage/handler.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
 
 	"github.com/sagarsuperuser/velox/internal/api/respond"
 	"github.com/sagarsuperuser/velox/internal/auth"
@@ -55,10 +56,12 @@ func (h *Handler) Backfill(w http.ResponseWriter, r *http.Request) {
 }
 
 // apiEvent is the public API input — developers send external identifiers.
+// Quantity accepts both number (5) and string ("5.5") forms via shopspring's
+// UnmarshalJSON; the response side serializes as a string for precision.
 type apiEvent struct {
 	ExternalCustomerID string           `json:"external_customer_id"`
 	EventName          string           `json:"event_name"`
-	Quantity           int64            `json:"quantity,omitempty"`
+	Quantity           decimal.Decimal  `json:"quantity,omitempty"`
 	Properties         map[string]any   `json:"properties,omitempty"`
 	IdempotencyKey     string           `json:"idempotency_key,omitempty"`
 	Timestamp          *json.RawMessage `json:"timestamp,omitempty"`

--- a/internal/usage/handler.go
+++ b/internal/usage/handler.go
@@ -58,11 +58,20 @@ func (h *Handler) Backfill(w http.ResponseWriter, r *http.Request) {
 // apiEvent is the public API input — developers send external identifiers.
 // Quantity accepts both number (5) and string ("5.5") forms via shopspring's
 // UnmarshalJSON; the response side serializes as a string for precision.
+//
+// Dimensions: per docs/design-multi-dim-meters.md, AI-native ingest uses
+// `dimensions` as the field name for the JSONB filter that pricing rules
+// dispatch on. Properties is the original name and is kept as an alias
+// for backward compatibility — if both are present, dimensions wins (it
+// is the documented v1 field; properties was an internal name leaked
+// into the wire). The two collapse onto the same usage_events.properties
+// column at the storage layer.
 type apiEvent struct {
 	ExternalCustomerID string           `json:"external_customer_id"`
 	EventName          string           `json:"event_name"`
 	Quantity           decimal.Decimal  `json:"quantity,omitempty"`
 	Properties         map[string]any   `json:"properties,omitempty"`
+	Dimensions         map[string]any   `json:"dimensions,omitempty"`
 	IdempotencyKey     string           `json:"idempotency_key,omitempty"`
 	Timestamp          *json.RawMessage `json:"timestamp,omitempty"`
 }
@@ -89,11 +98,17 @@ func (h *Handler) resolve(ctx context.Context, tenantID string, evt apiEvent) (I
 		return IngestInput{}, errs.Invalid("event_name", fmt.Sprintf("meter %q not found", eventName))
 	}
 
+	// dimensions takes precedence over properties — see apiEvent doc.
+	dims := evt.Dimensions
+	if dims == nil {
+		dims = evt.Properties
+	}
+
 	input := IngestInput{
 		CustomerID:     cust.ID,
 		MeterID:        meter.ID,
 		Quantity:       evt.Quantity,
-		Properties:     evt.Properties,
+		Properties:     dims,
 		IdempotencyKey: evt.IdempotencyKey,
 	}
 

--- a/internal/usage/postgres.go
+++ b/internal/usage/postgres.go
@@ -2,9 +2,12 @@ package usage
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/shopspring/decimal"
 
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
@@ -33,19 +36,24 @@ func (s *PostgresStore) Ingest(ctx context.Context, tenantID string, event domai
 		origin = string(domain.UsageOriginAPI)
 	}
 
+	props, err := propertiesJSON(event.Properties)
+	if err != nil {
+		return domain.UsageEvent{}, err
+	}
+
 	err = tx.QueryRowContext(ctx, `
 		INSERT INTO usage_events (id, tenant_id, customer_id, meter_id, subscription_id,
 			quantity, properties, idempotency_key, timestamp, origin)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 		RETURNING id, tenant_id, customer_id, meter_id, COALESCE(subscription_id,''),
-			quantity, COALESCE(idempotency_key,''), timestamp, origin
+			quantity, properties, COALESCE(idempotency_key,''), timestamp, origin
 	`, id, tenantID, event.CustomerID, event.MeterID,
 		postgres.NullableString(event.SubscriptionID), event.Quantity,
-		propertiesJSON(event.Properties), postgres.NullableString(event.IdempotencyKey),
+		props, postgres.NullableString(event.IdempotencyKey),
 		event.Timestamp, origin,
 	).Scan(&event.ID, &event.TenantID, &event.CustomerID, &event.MeterID,
-		&event.SubscriptionID, &event.Quantity, &event.IdempotencyKey, &event.Timestamp,
-		&event.Origin)
+		&event.SubscriptionID, &event.Quantity, propertiesScanner{&event.Properties},
+		&event.IdempotencyKey, &event.Timestamp, &event.Origin)
 
 	if err != nil {
 		if postgres.IsUniqueViolation(err) {
@@ -80,7 +88,7 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.U
 	}
 
 	query := `SELECT id, tenant_id, customer_id, meter_id, COALESCE(subscription_id,''),
-		quantity, COALESCE(idempotency_key,''), timestamp
+		quantity, properties, COALESCE(idempotency_key,''), timestamp
 		FROM usage_events` + where + ` ORDER BY timestamp DESC LIMIT $` + fmt.Sprintf("%d", len(args)+1) + ` OFFSET $` + fmt.Sprintf("%d", len(args)+2)
 	args = append(args, limit, filter.Offset)
 
@@ -94,7 +102,8 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.U
 	for rows.Next() {
 		var e domain.UsageEvent
 		if err := rows.Scan(&e.ID, &e.TenantID, &e.CustomerID, &e.MeterID,
-			&e.SubscriptionID, &e.Quantity, &e.IdempotencyKey, &e.Timestamp); err != nil {
+			&e.SubscriptionID, &e.Quantity, propertiesScanner{&e.Properties},
+			&e.IdempotencyKey, &e.Timestamp); err != nil {
 			return nil, 0, err
 		}
 		events = append(events, e)
@@ -102,20 +111,18 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.U
 	return events, total, rows.Err()
 }
 
-func (s *PostgresStore) AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]int64, error) {
+func (s *PostgresStore) AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {
 		return nil, err
 	}
 	defer postgres.Rollback(tx)
 
+	result := make(map[string]decimal.Decimal)
 	if len(meters) == 0 {
-		return map[string]int64{}, nil
+		return result, nil
 	}
 
-	result := make(map[string]int64)
-
-	// Query each meter individually with its correct aggregation function
 	for meterID, agg := range meters {
 		aggFunc := "SUM"
 		switch agg {
@@ -124,26 +131,25 @@ func (s *PostgresStore) AggregateForBillingPeriodByAgg(ctx context.Context, tena
 		case "count":
 			aggFunc = "COUNT"
 		case "last":
-			// "last" = most recent value; use a subquery
-			var val int64
+			var val decimal.Decimal
 			err := tx.QueryRowContext(ctx, `
 				SELECT COALESCE(quantity, 0) FROM usage_events
 				WHERE customer_id = $1 AND meter_id = $2 AND timestamp >= $3 AND timestamp < $4
 				ORDER BY timestamp DESC LIMIT 1
 			`, customerID, meterID, from, to).Scan(&val)
-			if err == nil && val > 0 {
+			if err == nil && val.IsPositive() {
 				result[meterID] = val
 			}
 			continue
 		}
 
-		var val int64
+		var val decimal.Decimal
 		err := tx.QueryRowContext(ctx,
 			fmt.Sprintf(`SELECT COALESCE(%s(quantity), 0) FROM usage_events
 				WHERE customer_id = $1 AND meter_id = $2 AND timestamp >= $3 AND timestamp < $4`,
 				aggFunc),
 			customerID, meterID, from, to).Scan(&val)
-		if err == nil && val > 0 {
+		if err == nil && val.IsPositive() {
 			result[meterID] = val
 		}
 	}
@@ -151,15 +157,16 @@ func (s *PostgresStore) AggregateForBillingPeriodByAgg(ctx context.Context, tena
 	return result, nil
 }
 
-func (s *PostgresStore) AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]int64, error) {
+func (s *PostgresStore) AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {
 		return nil, err
 	}
 	defer postgres.Rollback(tx)
 
+	result := make(map[string]decimal.Decimal)
 	if len(meterIDs) == 0 {
-		return map[string]int64{}, nil
+		return result, nil
 	}
 
 	placeholders := make([]string, len(meterIDs))
@@ -181,10 +188,9 @@ func (s *PostgresStore) AggregateForBillingPeriod(ctx context.Context, tenantID,
 	}
 	defer func() { _ = rows.Close() }()
 
-	result := make(map[string]int64)
 	for rows.Next() {
 		var meterID string
-		var total int64
+		var total decimal.Decimal
 		if err := rows.Scan(&meterID, &total); err != nil {
 			return nil, err
 		}
@@ -224,12 +230,49 @@ func buildUsageWhere(f ListFilter) (string, []any) {
 	return " WHERE " + strings.Join(clauses, " AND "), args
 }
 
-func propertiesJSON(props map[string]any) string {
-	if props == nil {
-		return "{}"
+// propertiesJSON serializes the event's free-form properties for the JSONB
+// column. This map is also the carrier for multi-dim meter dimensions
+// (model, operation, region, etc.) that pricing_rule.dimension_match runs
+// subset-match against — losing it here would silently drop dimension
+// information at ingest, so a marshal failure is treated as a hard error.
+func propertiesJSON(props map[string]any) (string, error) {
+	if len(props) == 0 {
+		return "{}", nil
 	}
-	// Simple inline marshal — no error possible for map[string]any
-	b, _ := fmt.Printf("%v", props)
-	_ = b
-	return "{}"
+	b, err := json.Marshal(props)
+	if err != nil {
+		return "", fmt.Errorf("marshal usage_event.properties: %w", err)
+	}
+	return string(b), nil
+}
+
+// propertiesScanner adapts a *map[string]any to sql.Scanner so SELECT
+// statements can read the JSONB column straight into the struct field.
+// The pgx driver hands JSONB to Scan as []byte (or string in some paths).
+type propertiesScanner struct{ dst *map[string]any }
+
+func (s propertiesScanner) Scan(src any) error {
+	if src == nil {
+		*s.dst = nil
+		return nil
+	}
+	var raw []byte
+	switch v := src.(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		return fmt.Errorf("unsupported scan type for properties: %T", src)
+	}
+	if len(raw) == 0 {
+		*s.dst = nil
+		return nil
+	}
+	m := map[string]any{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("unmarshal usage_event.properties: %w", err)
+	}
+	*s.dst = m
+	return nil
 }

--- a/internal/usage/postgres.go
+++ b/internal/usage/postgres.go
@@ -199,6 +199,159 @@ func (s *PostgresStore) AggregateForBillingPeriod(ctx context.Context, tenantID,
 	return result, rows.Err()
 }
 
+// AggregateByPricingRules implements the priority+claim resolution path
+// described in docs/design-multi-dim-meters.md. Strategy:
+//
+//  1. Rank meter_pricing_rules by (priority DESC, created_at ASC) so the
+//     deterministic ROW_NUMBER becomes the rule_rank we order claims by.
+//  2. LEFT JOIN LATERAL each in-period event against the ranked rules,
+//     keeping only the top-priority rule whose dimension_match is a
+//     subset of the event's properties. NULL rule means unclaimed.
+//  3. Aggregate per rule. The CASE inside the SELECT is safe because
+//     every event in a given (rule_id) group shares the rule's mode —
+//     we GROUP BY (rule_id, mode, rrv) so the CASE evaluates a constant
+//     within each group.
+//
+// last_ever needs a separate query because it ignores the period bounds.
+// We run it only if any of the meter's rules is last_ever, then merge.
+func (s *PostgresStore) AggregateByPricingRules(
+	ctx context.Context,
+	tenantID, customerID, meterID string,
+	defaultMode domain.AggregationMode,
+	from, to time.Time,
+) ([]domain.RuleAggregation, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer postgres.Rollback(tx)
+
+	// Period-bounded modes: sum, count, last_during_period, max, plus
+	// the unclaimed bucket (defaultMode is one of these — last_ever on
+	// the meter default is rejected at the service layer).
+	//
+	// last_during_period uses (array_agg ORDER BY ts DESC)[1] to pick
+	// the latest event's quantity per group — a standard Postgres trick
+	// that compiles down to a single sort over the group.
+	rows, err := tx.QueryContext(ctx, `
+		WITH ranked_rules AS (
+			SELECT id, dimension_match, aggregation_mode, rating_rule_version_id,
+			       ROW_NUMBER() OVER (ORDER BY priority DESC, created_at ASC) AS rule_rank
+			FROM meter_pricing_rules
+			WHERE tenant_id = $1 AND meter_id = $2
+		),
+		claims AS (
+			SELECT
+				e.id,
+				e.quantity,
+				e.timestamp,
+				rr.id                     AS rule_id,
+				rr.aggregation_mode       AS aggregation_mode,
+				rr.rating_rule_version_id AS rating_rule_version_id
+			FROM usage_events e
+			LEFT JOIN LATERAL (
+				SELECT id, aggregation_mode, rating_rule_version_id, rule_rank
+				FROM ranked_rules
+				WHERE e.properties @> ranked_rules.dimension_match
+				  AND ranked_rules.aggregation_mode <> 'last_ever'
+				ORDER BY rule_rank ASC
+				LIMIT 1
+			) rr ON TRUE
+			WHERE e.tenant_id  = $1
+			  AND e.meter_id   = $2
+			  AND e.customer_id = $3
+			  AND e.timestamp >= $4
+			  AND e.timestamp <  $5
+		)
+		SELECT
+			COALESCE(rule_id, '')                AS rule_id,
+			COALESCE(rating_rule_version_id, '') AS rating_rule_version_id,
+			COALESCE(aggregation_mode, $6)       AS aggregation_mode,
+			CASE COALESCE(aggregation_mode, $6)
+				WHEN 'sum'                THEN COALESCE(SUM(quantity), 0)
+				WHEN 'count'              THEN COUNT(*)::numeric
+				WHEN 'max'                THEN COALESCE(MAX(quantity), 0)
+				WHEN 'last_during_period' THEN (array_agg(quantity ORDER BY timestamp DESC))[1]
+				ELSE 0
+			END AS quantity
+		FROM claims
+		GROUP BY rule_id, rating_rule_version_id, aggregation_mode
+	`, tenantID, meterID, customerID, from, to, string(defaultMode))
+	if err != nil {
+		return nil, fmt.Errorf("aggregate by pricing rules (period): %w", err)
+	}
+
+	var out []domain.RuleAggregation
+	for rows.Next() {
+		var r domain.RuleAggregation
+		var mode string
+		if err := rows.Scan(&r.RuleID, &r.RatingRuleVersionID, &mode, &r.Quantity); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		r.AggregationMode = domain.AggregationMode(mode)
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	// last_ever pass — only if the meter has any last_ever rules. Each
+	// last_ever rule's quantity is the most recent event (across all
+	// time) claimed by it. The claim semantics are identical to the
+	// period-bounded path; the only difference is the missing time
+	// filter.
+	leverRows, err := tx.QueryContext(ctx, `
+		WITH ranked_rules AS (
+			SELECT id, dimension_match, aggregation_mode, rating_rule_version_id,
+			       ROW_NUMBER() OVER (ORDER BY priority DESC, created_at ASC) AS rule_rank
+			FROM meter_pricing_rules
+			WHERE tenant_id = $1 AND meter_id = $2
+		),
+		claims AS (
+			SELECT DISTINCT ON (e.id)
+				e.id,
+				e.quantity,
+				e.timestamp,
+				rr.id                     AS rule_id,
+				rr.rating_rule_version_id AS rating_rule_version_id
+			FROM usage_events e
+			JOIN ranked_rules rr ON e.properties @> rr.dimension_match
+			WHERE e.tenant_id   = $1
+			  AND e.meter_id    = $2
+			  AND e.customer_id = $3
+			  AND rr.aggregation_mode = 'last_ever'
+			ORDER BY e.id, rr.rule_rank ASC
+		)
+		SELECT DISTINCT ON (rule_id)
+			rule_id, rating_rule_version_id, quantity
+		FROM claims
+		ORDER BY rule_id, timestamp DESC
+	`, tenantID, meterID, customerID)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate by pricing rules (last_ever): %w", err)
+	}
+	defer func() { _ = leverRows.Close() }()
+
+	for leverRows.Next() {
+		var r domain.RuleAggregation
+		r.AggregationMode = domain.AggLastEver
+		if err := leverRows.Scan(&r.RuleID, &r.RatingRuleVersionID, &r.Quantity); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	if err := leverRows.Err(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func buildUsageWhere(f ListFilter) (string, []any) {
 	var clauses []string
 	var args []any

--- a/internal/usage/service.go
+++ b/internal/usage/service.go
@@ -2,6 +2,7 @@ package usage
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -59,12 +60,42 @@ func (s *Service) Backfill(ctx context.Context, tenantID string, input IngestInp
 	return s.ingest(ctx, tenantID, input, domain.UsageOriginBackfill)
 }
 
+// MaxPropertyKeys caps the size of the JSONB properties map on each
+// usage event. Properties feed pricing-rule dispatch via @> subset
+// matches at finalize time; bounding the per-event JSONB size protects
+// the GIN index from pathological tenants and matches the equivalent
+// cap on meter_pricing_rules.dimension_match (16 keys).
+const MaxPropertyKeys = 16
+
+// validateProperties enforces the v1 dimension contract: at most
+// MaxPropertyKeys keys, scalar values only (string, number, bool, nil).
+// Object/array values are rejected — Postgres `@>` would still match
+// them but the priority+claim semantics aren't well-defined for nested
+// containers in v1 (revisit if a design partner needs it).
+func validateProperties(props map[string]any) error {
+	if len(props) > MaxPropertyKeys {
+		return errs.Invalid("properties", fmt.Sprintf("at most %d keys (got %d)", MaxPropertyKeys, len(props)))
+	}
+	for k, v := range props {
+		switch v.(type) {
+		case nil, string, bool, float64, float32, int, int32, int64:
+			// Scalar — fine.
+		default:
+			return errs.Invalid("properties", fmt.Sprintf("key %q value must be a scalar (string/number/bool), got %T", k, v))
+		}
+	}
+	return nil
+}
+
 func (s *Service) ingest(ctx context.Context, tenantID string, input IngestInput, origin domain.UsageEventOrigin) (domain.UsageEvent, error) {
 	if strings.TrimSpace(input.CustomerID) == "" {
 		return domain.UsageEvent{}, errs.Required("customer_id")
 	}
 	if strings.TrimSpace(input.MeterID) == "" {
 		return domain.UsageEvent{}, errs.Required("meter_id")
+	}
+	if err := validateProperties(input.Properties); err != nil {
+		return domain.UsageEvent{}, err
 	}
 	if input.Quantity.IsZero() {
 		// Default quantity to 1 (count-based meters) when not explicitly provided.

--- a/internal/usage/service.go
+++ b/internal/usage/service.go
@@ -145,3 +145,30 @@ func (s *Service) List(ctx context.Context, filter ListFilter) ([]domain.UsageEv
 func (s *Service) AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	return s.store.AggregateForBillingPeriod(ctx, tenantID, customerID, meterIDs, from, to)
 }
+
+// AggregateByPricingRules resolves a single (customer, meter, period) into
+// per-rule aggregations using the priority+claim algorithm. The defaultMode
+// applies to events that match no rule; it must be one of the four
+// period-bounded modes (sum, count, max, last_during_period) — last_ever
+// as a meter-default is rejected because it would silently break the
+// "current state" semantics for unclaimed events.
+//
+// See docs/design-multi-dim-meters.md for the resolution semantics; this
+// method is the runtime entry point that billing-finalize will call.
+func (s *Service) AggregateByPricingRules(
+	ctx context.Context,
+	tenantID, customerID, meterID string,
+	defaultMode domain.AggregationMode,
+	from, to time.Time,
+) ([]domain.RuleAggregation, error) {
+	if defaultMode == "" {
+		defaultMode = domain.AggSum
+	}
+	switch defaultMode {
+	case domain.AggSum, domain.AggCount, domain.AggMax, domain.AggLastDuringPeriod:
+		// ok
+	default:
+		return nil, errs.Invalid("default_mode", fmt.Sprintf("must be one of sum/count/max/last_during_period, got %q", defaultMode))
+	}
+	return s.store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, defaultMode, from, to)
+}

--- a/internal/usage/service.go
+++ b/internal/usage/service.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 )
@@ -20,13 +22,13 @@ func NewService(store Store) *Service {
 // IngestInput is the internal service input — uses resolved internal IDs only.
 // The handler is responsible for resolving external identifiers before calling this.
 type IngestInput struct {
-	CustomerID     string         `json:"customer_id"`
-	MeterID        string         `json:"meter_id"`
-	SubscriptionID string         `json:"subscription_id,omitempty"`
-	Quantity       int64          `json:"quantity,omitempty"`
-	Properties     map[string]any `json:"properties,omitempty"`
-	IdempotencyKey string         `json:"idempotency_key,omitempty"`
-	Timestamp      *time.Time     `json:"timestamp,omitempty"`
+	CustomerID     string          `json:"customer_id"`
+	MeterID        string          `json:"meter_id"`
+	SubscriptionID string          `json:"subscription_id,omitempty"`
+	Quantity       decimal.Decimal `json:"quantity,omitempty"`
+	Properties     map[string]any  `json:"properties,omitempty"`
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	Timestamp      *time.Time      `json:"timestamp,omitempty"`
 }
 
 func (s *Service) Ingest(ctx context.Context, tenantID string, input IngestInput) (domain.UsageEvent, error) {
@@ -64,10 +66,10 @@ func (s *Service) ingest(ctx context.Context, tenantID string, input IngestInput
 	if strings.TrimSpace(input.MeterID) == "" {
 		return domain.UsageEvent{}, errs.Required("meter_id")
 	}
-	if input.Quantity == 0 {
+	if input.Quantity.IsZero() {
 		// Default quantity to 1 (count-based meters) when not explicitly provided.
 		// Negative values are allowed as usage corrections.
-		input.Quantity = 1
+		input.Quantity = decimal.NewFromInt(1)
 	}
 
 	ts := time.Now().UTC()
@@ -109,6 +111,6 @@ func (s *Service) List(ctx context.Context, filter ListFilter) ([]domain.UsageEv
 	return s.store.List(ctx, filter)
 }
 
-func (s *Service) AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]int64, error) {
+func (s *Service) AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	return s.store.AggregateForBillingPeriod(ctx, tenantID, customerID, meterIDs, from, to)
 }

--- a/internal/usage/service_test.go
+++ b/internal/usage/service_test.go
@@ -58,6 +58,10 @@ func (m *memStore) AggregateForBillingPeriodByAgg(_ context.Context, _, _ string
 	return map[string]decimal.Decimal{}, nil
 }
 
+func (m *memStore) AggregateByPricingRules(_ context.Context, _, _, _ string, _ domain.AggregationMode, _, _ time.Time) ([]domain.RuleAggregation, error) {
+	return nil, nil
+}
+
 func TestIngest(t *testing.T) {
 	svc := NewService(newMemStore())
 	ctx := context.Background()
@@ -166,6 +170,39 @@ func TestIngest(t *testing.T) {
 		})
 		if err == nil {
 			t.Fatal("expected error for slice value")
+		}
+	})
+}
+
+// TestAggregateByPricingRules_DefaultModeValidation guards the service-
+// level rule that the unclaimed-bucket fallback mode must be one of the
+// four period-bounded modes. last_ever as a default would silently break
+// "current state" semantics for events that match no rule, so the
+// service rejects it before the SQL ever runs.
+func TestAggregateByPricingRules_DefaultModeValidation(t *testing.T) {
+	svc := NewService(newMemStore())
+	ctx := context.Background()
+	from := time.Now().Add(-1 * time.Hour)
+	to := time.Now().Add(1 * time.Hour)
+
+	t.Run("rejects last_ever as default mode", func(t *testing.T) {
+		_, err := svc.AggregateByPricingRules(ctx, "t1", "c1", "m1", domain.AggLastEver, from, to)
+		if err == nil {
+			t.Fatal("expected default_mode=last_ever to be rejected")
+		}
+	})
+
+	t.Run("rejects unknown mode", func(t *testing.T) {
+		_, err := svc.AggregateByPricingRules(ctx, "t1", "c1", "m1", domain.AggregationMode("bogus"), from, to)
+		if err == nil {
+			t.Fatal("expected unknown mode to be rejected")
+		}
+	})
+
+	t.Run("empty mode defaults to sum", func(t *testing.T) {
+		_, err := svc.AggregateByPricingRules(ctx, "t1", "c1", "m1", "", from, to)
+		if err != nil {
+			t.Fatalf("empty mode should default to sum: %v", err)
 		}
 	})
 }

--- a/internal/usage/service_test.go
+++ b/internal/usage/service_test.go
@@ -129,6 +129,45 @@ func TestIngest(t *testing.T) {
 			t.Errorf("got origin %q, want %q", e.Origin, domain.UsageOriginAPI)
 		}
 	})
+
+	t.Run("dimensions persist on properties", func(t *testing.T) {
+		e, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "cus_dims", MeterID: "mtr_1", Quantity: dec(1),
+			Properties: map[string]any{"model": "gpt-4", "cached": false, "tier": int64(1)},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if e.Properties["model"] != "gpt-4" {
+			t.Errorf("model: got %v", e.Properties["model"])
+		}
+		if e.Properties["cached"] != false {
+			t.Errorf("cached: got %v", e.Properties["cached"])
+		}
+	})
+
+	t.Run("rejects too many dimension keys", func(t *testing.T) {
+		dims := map[string]any{}
+		for i := 0; i < MaxPropertyKeys+1; i++ {
+			dims[fmt.Sprintf("k%d", i)] = "v"
+		}
+		_, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "c", MeterID: "m", Quantity: dec(1), Properties: dims,
+		})
+		if err == nil {
+			t.Fatal("expected error for too many keys")
+		}
+	})
+
+	t.Run("rejects non-scalar dimension value", func(t *testing.T) {
+		_, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "c", MeterID: "m", Quantity: dec(1),
+			Properties: map[string]any{"models": []string{"gpt-4", "claude"}},
+		})
+		if err == nil {
+			t.Fatal("expected error for slice value")
+		}
+	})
 }
 
 // TestBackfill exercises the audit-path contract: past timestamp required,

--- a/internal/usage/service_test.go
+++ b/internal/usage/service_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 )
+
+func dec(n int64) decimal.Decimal { return decimal.NewFromInt(n) }
 
 type memStore struct {
 	events map[string]domain.UsageEvent
@@ -46,12 +50,12 @@ func (m *memStore) List(_ context.Context, filter ListFilter) ([]domain.UsageEve
 	return result, len(result), nil
 }
 
-func (m *memStore) AggregateForBillingPeriod(_ context.Context, _, _ string, _ []string, _, _ time.Time) (map[string]int64, error) {
-	return map[string]int64{}, nil
+func (m *memStore) AggregateForBillingPeriod(_ context.Context, _, _ string, _ []string, _, _ time.Time) (map[string]decimal.Decimal, error) {
+	return map[string]decimal.Decimal{}, nil
 }
 
-func (m *memStore) AggregateForBillingPeriodByAgg(_ context.Context, _, _ string, _ map[string]string, _, _ time.Time) (map[string]int64, error) {
-	return map[string]int64{}, nil
+func (m *memStore) AggregateForBillingPeriodByAgg(_ context.Context, _, _ string, _ map[string]string, _, _ time.Time) (map[string]decimal.Decimal, error) {
+	return map[string]decimal.Decimal{}, nil
 }
 
 func TestIngest(t *testing.T) {
@@ -60,13 +64,13 @@ func TestIngest(t *testing.T) {
 
 	t.Run("valid event", func(t *testing.T) {
 		e, err := svc.Ingest(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 42,
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(42),
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if e.Quantity != 42 {
-			t.Errorf("got quantity %d, want 42", e.Quantity)
+		if !e.Quantity.Equal(dec(42)) {
+			t.Errorf("got quantity %s, want 42", e.Quantity.String())
 		}
 		if e.TenantID != "t1" {
 			t.Errorf("got tenant_id %q, want t1", e.TenantID)
@@ -76,7 +80,7 @@ func TestIngest(t *testing.T) {
 	t.Run("custom timestamp", func(t *testing.T) {
 		ts := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 		e, err := svc.Ingest(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 1, Timestamp: &ts,
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(1), Timestamp: &ts,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -88,13 +92,13 @@ func TestIngest(t *testing.T) {
 
 	t.Run("idempotency", func(t *testing.T) {
 		_, err := svc.Ingest(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 1, IdempotencyKey: "key-1",
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(1), IdempotencyKey: "key-1",
 		})
 		if err != nil {
 			t.Fatalf("first ingest failed: %v", err)
 		}
 		_, err = svc.Ingest(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 1, IdempotencyKey: "key-1",
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(1), IdempotencyKey: "key-1",
 		})
 		if err == nil {
 			t.Fatal("expected duplicate error")
@@ -103,8 +107,8 @@ func TestIngest(t *testing.T) {
 
 	t.Run("validation", func(t *testing.T) {
 		cases := []IngestInput{
-			{MeterID: "m", Quantity: 1},    // missing customer_id
-			{CustomerID: "c", Quantity: 1}, // missing meter_id
+			{MeterID: "m", Quantity: dec(1)},    // missing customer_id
+			{CustomerID: "c", Quantity: dec(1)}, // missing meter_id
 		}
 		for _, input := range cases {
 			_, err := svc.Ingest(ctx, "t1", input)
@@ -116,7 +120,7 @@ func TestIngest(t *testing.T) {
 
 	t.Run("default origin is api", func(t *testing.T) {
 		e, err := svc.Ingest(ctx, "t1", IngestInput{
-			CustomerID: "cus_origin_api", MeterID: "mtr_1", Quantity: 1,
+			CustomerID: "cus_origin_api", MeterID: "mtr_1", Quantity: dec(1),
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -136,7 +140,7 @@ func TestBackfill(t *testing.T) {
 	t.Run("past timestamp is accepted and tagged backfill", func(t *testing.T) {
 		past := time.Now().Add(-24 * time.Hour)
 		e, err := svc.Backfill(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 7, Timestamp: &past,
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(7), Timestamp: &past,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -151,7 +155,7 @@ func TestBackfill(t *testing.T) {
 
 	t.Run("missing timestamp rejected", func(t *testing.T) {
 		_, err := svc.Backfill(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 1,
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(1),
 		})
 		if err == nil {
 			t.Fatal("expected timestamp-required error")
@@ -161,7 +165,7 @@ func TestBackfill(t *testing.T) {
 	t.Run("future timestamp rejected", func(t *testing.T) {
 		future := time.Now().Add(1 * time.Hour)
 		_, err := svc.Backfill(ctx, "t1", IngestInput{
-			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: 1, Timestamp: &future,
+			CustomerID: "cus_1", MeterID: "mtr_1", Quantity: dec(1), Timestamp: &future,
 		})
 		if err == nil {
 			t.Fatal("expected future-timestamp error")
@@ -171,7 +175,7 @@ func TestBackfill(t *testing.T) {
 	t.Run("one-second-ago accepted", func(t *testing.T) {
 		ts := time.Now().Add(-1 * time.Second)
 		_, err := svc.Backfill(ctx, "t1", IngestInput{
-			CustomerID: "cus_boundary", MeterID: "mtr_1", Quantity: 1, Timestamp: &ts,
+			CustomerID: "cus_boundary", MeterID: "mtr_1", Quantity: dec(1), Timestamp: &ts,
 		})
 		if err != nil {
 			t.Fatalf("one-second-ago backfill should be accepted: %v", err)
@@ -181,7 +185,7 @@ func TestBackfill(t *testing.T) {
 	t.Run("missing customer_id still caught", func(t *testing.T) {
 		past := time.Now().Add(-1 * time.Hour)
 		_, err := svc.Backfill(ctx, "t1", IngestInput{
-			MeterID: "mtr_1", Quantity: 1, Timestamp: &past,
+			MeterID: "mtr_1", Quantity: dec(1), Timestamp: &past,
 		})
 		if err == nil {
 			t.Fatal("expected missing customer_id error")

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -14,6 +14,16 @@ type Store interface {
 	List(ctx context.Context, filter ListFilter) ([]domain.UsageEvent, int, error)
 	AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error)
 	AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error)
+
+	// AggregateByPricingRules walks meter_pricing_rules in priority-DESC
+	// order and claims each in-period event to its top-priority matching
+	// rule (JSONB superset on properties), then aggregates per rule using
+	// the rule's aggregation_mode. Events that match no rule are returned
+	// as an unclaimed entry (RuleID=="") aggregated with defaultMode.
+	//
+	// last_ever rules ignore the period bounds and pick the latest event
+	// across all time (for "current state" billing like seat counts).
+	AggregateByPricingRules(ctx context.Context, tenantID, customerID, meterID string, defaultMode domain.AggregationMode, from, to time.Time) ([]domain.RuleAggregation, error)
 }
 
 type ListFilter struct {

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 )
 
 type Store interface {
 	Ingest(ctx context.Context, tenantID string, event domain.UsageEvent) (domain.UsageEvent, error)
 	List(ctx context.Context, filter ListFilter) ([]domain.UsageEvent, int, error)
-	AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]int64, error)
-	AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]int64, error)
+	AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error)
+	AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error)
 }
 
 type ListFilter struct {

--- a/internal/usage/summary.go
+++ b/internal/usage/summary.go
@@ -7,17 +7,18 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
 
 	"github.com/sagarsuperuser/velox/internal/auth"
 )
 
 // UsageSummary represents aggregated usage for a customer in a period.
 type UsageSummary struct {
-	CustomerID  string           `json:"customer_id"`
-	PeriodFrom  time.Time        `json:"period_from"`
-	PeriodTo    time.Time        `json:"period_to"`
-	Meters      map[string]int64 `json:"meters"` // meter_id → total quantity
-	TotalEvents int              `json:"total_events"`
+	CustomerID  string                     `json:"customer_id"`
+	PeriodFrom  time.Time                  `json:"period_from"`
+	PeriodTo    time.Time                  `json:"period_to"`
+	Meters      map[string]decimal.Decimal `json:"meters"` // meter_id -> total quantity
+	TotalEvents int                        `json:"total_events"`
 }
 
 // GetSummary aggregates usage for a customer in the current billing period.
@@ -33,9 +34,9 @@ func (s *Service) GetSummary(ctx context.Context, tenantID, customerID string, f
 		return UsageSummary{}, err
 	}
 
-	meters := make(map[string]int64)
+	meters := make(map[string]decimal.Decimal)
 	for _, e := range events {
-		meters[e.MeterID] += e.Quantity
+		meters[e.MeterID] = meters[e.MeterID].Add(e.Quantity)
 	}
 
 	return UsageSummary{


### PR DESCRIPTION
## Summary

The runtime engine for Velox's positioning bet (per `docs/positioning.md`): one meter receives events with arbitrary dimensions, many pricing rules pick out subsets at different rates. Closes the Stripe Tier 1 parity gap on aggregation modes (`count`, `last_during_period`, `last_ever`, `max`) and decimal quantities, and ships the AI-native dispatch primitive on top.

Implementation per `docs/design-multi-dim-meters.md`:

- **Migration `0054_multi_dim_meters`** — widens `usage_events.quantity` to `NUMERIC(38,12)`, adds GIN index over `properties`, introduces `meter_pricing_rules (dimension_match, aggregation_mode, priority)` with RLS + lookup index.
- **Decimal quantities** — `domain.UsageEvent.Quantity` becomes `decimal.Decimal` end-to-end (engine, preview, pricing, override). Existing int64 callsites adapted; rating-rule cents conversion preserves banker's rounding at the boundary.
- **`meter_pricing_rules` CRUD** — `pricing.Service` upserts/lists/deletes rules; idempotent on `(tenant, meter, rrv)`; validates 16-key scalar dimension match.
- **Ingest dimensions** — `dimensions` field accepted as the v1 wire name (alias for `properties`), capped at 16 scalar keys to match the rule-side limit.
- **Priority+claim aggregation** — `usage.Store.AggregateByPricingRules` uses `LATERAL JOIN` to claim each in-period event to its top-priority matching rule, then dispatches sum/count/max/last_during_period via a CASE on the per-group constant mode. `last_ever` runs separately and ignores period bounds for "current state" billing.
- **Benchmark harness** — `cmd/velox-bench` baselines ~2.5k events/sec on Mac+Docker; design doc's 50k/sec target requires cloud Postgres + batched INSERTs (follow-up).

HTTP endpoints for `meter_pricing_rules` CRUD and `Changelog.tsx` are intentionally deferred until the engine is in: ship the runtime first, surface it second.

## Test plan

- [x] `go test -short ./...` — all unit tests pass
- [x] `go test -p 1 -short=false ./internal/usage/... ./internal/pricing/... ./internal/billing/...` — full integration suite green
- [x] `TestAggregateByPricingRules` — 9 sub-tests covering all 5 modes, priority+claim non-overlap, subset match, no-rules fallback, and 12-decimal-place precision round-trip
- [x] `TestUsageEvents_DimensionsPersistAndJSONBSupersetMatch` — JSONB `@>` superset query + GIN index existence guard
- [x] `TestPostgresStore_MeterPricingRules*` — CRUD + JSONB round-trip + RLS tenant isolation
- [x] `velox-bench --workers 16 --duration 10s` — 2.5k events/sec baseline (50k target is cloud + batched, scoped as follow-up)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)