### PR TITLE
fix(api): register meter pricing-rules routes; rename properties→dimensions on output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ tmp/
 .env
 .env.local
 .DS_Store
-velox
-velox-bench
+/velox
+/velox-bench
 temp.txt
 MANUAL_TEST_BUGS.md

--- a/cmd/velox-bench/main.go
+++ b/cmd/velox-bench/main.go
@@ -93,7 +93,7 @@ func main() {
 				t0 := time.Now()
 				_, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
 					CustomerID: customerID, MeterID: meterID,
-					Quantity: qty, Properties: props,
+					Quantity: qty, Dimensions: props,
 				})
 				lat := time.Since(t0)
 				if err != nil {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -682,6 +682,13 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 			auth.Require(auth.PermCustomerWrite),
 		))
 		r.With(auth.Require(auth.PermPricingRead)).Mount("/meters", pricingH.MeterRoutes())
+		// Meter-scoped pricing rule subtree. Mounted as a sibling of
+		// /meters so reads (PermPricingRead) and writes (PermPricingWrite)
+		// can carry independent guards without nesting permission middleware.
+		r.Mount("/meters/{meter_id}/pricing-rules", pricingH.MeterPricingRuleRoutes(
+			auth.Require(auth.PermPricingRead),
+			auth.Require(auth.PermPricingWrite),
+		))
 		r.With(auth.Require(auth.PermPricingRead)).Mount("/plans", pricingH.PlanRoutes())
 		r.With(auth.Require(auth.PermPricingRead)).Mount("/rating-rules", pricingH.RatingRuleRoutes())
 		r.With(auth.Require(auth.PermSubscriptionRead)).Mount("/subscriptions", subH.Routes())

--- a/internal/domain/usage.go
+++ b/internal/domain/usage.go
@@ -28,7 +28,7 @@ type UsageEvent struct {
 	MeterID        string           `json:"meter_id"`
 	SubscriptionID string           `json:"subscription_id,omitempty"`
 	Quantity       decimal.Decimal  `json:"quantity"`
-	Properties     map[string]any   `json:"properties,omitempty"`
+	Dimensions     map[string]any   `json:"dimensions,omitempty"`
 	IdempotencyKey string           `json:"idempotency_key,omitempty"`
 	Timestamp      time.Time        `json:"timestamp"`
 	Origin         UsageEventOrigin `json:"origin,omitempty"`

--- a/internal/pricing/handler.go
+++ b/internal/pricing/handler.go
@@ -54,6 +54,19 @@ func (h *Handler) OverrideRoutes() chi.Router {
 	return r
 }
 
+// MeterPricingRuleRoutes is the sub-router for
+// /v1/meters/{meter_id}/pricing-rules. Reads use the read perm; upsert and
+// delete need write. Pattern mirrors coupon.CustomerAssignmentRoutes so
+// the router can compose perms in the same place — see router.go.
+func (h *Handler) MeterPricingRuleRoutes(requireRead, requireWrite func(http.Handler) http.Handler) chi.Router {
+	r := chi.NewRouter()
+	r.With(requireRead).Get("/", h.listMeterPricingRules)
+	r.With(requireWrite).Post("/", h.upsertMeterPricingRule)
+	r.With(requireRead).Get("/{id}", h.getMeterPricingRule)
+	r.With(requireWrite).Delete("/{id}", h.deleteMeterPricingRule)
+	return r
+}
+
 func (h *Handler) createOverride(w http.ResponseWriter, r *http.Request) {
 	tenantID := auth.TenantID(r.Context())
 
@@ -281,4 +294,79 @@ func (h *Handler) updatePlan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respond.JSON(w, r, http.StatusOK, plan)
+}
+
+// ---------------------------------------------------------------------------
+// Meter Pricing Rules — N-rules-per-meter dispatch.
+// ---------------------------------------------------------------------------
+
+// listMeterPricingRules returns every pricing rule attached to a meter,
+// sorted by priority-DESC / created-at-ASC (the store enforces the order).
+func (h *Handler) listMeterPricingRules(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	meterID := chi.URLParam(r, "meter_id")
+
+	rules, err := h.svc.ListMeterPricingRulesByMeter(r.Context(), tenantID, meterID)
+	if err != nil {
+		respond.FromError(w, r, err, "meter_pricing_rule")
+		return
+	}
+	if rules == nil {
+		rules = []domain.MeterPricingRule{}
+	}
+	respond.JSON(w, r, http.StatusOK, map[string]any{"data": rules})
+}
+
+// upsertMeterPricingRule creates or updates the rule identified by
+// (meter_id, rating_rule_version_id). The URL meter_id wins over any
+// meter_id in the body so the route surface is unambiguous.
+func (h *Handler) upsertMeterPricingRule(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	meterID := chi.URLParam(r, "meter_id")
+
+	var input UpsertMeterPricingRuleInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		respond.BadRequest(w, r, "invalid JSON body")
+		return
+	}
+	input.MeterID = meterID
+
+	rule, err := h.svc.UpsertMeterPricingRule(r.Context(), tenantID, input)
+	if err != nil {
+		respond.FromError(w, r, err, "meter_pricing_rule")
+		return
+	}
+	respond.JSON(w, r, http.StatusCreated, rule)
+}
+
+func (h *Handler) getMeterPricingRule(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	id := chi.URLParam(r, "id")
+
+	rule, err := h.svc.GetMeterPricingRule(r.Context(), tenantID, id)
+	if errors.Is(err, errs.ErrNotFound) {
+		respond.NotFound(w, r, "meter_pricing_rule")
+		return
+	}
+	if err != nil {
+		respond.InternalError(w, r)
+		slog.ErrorContext(r.Context(), "get meter pricing rule", "error", err)
+		return
+	}
+	respond.JSON(w, r, http.StatusOK, rule)
+}
+
+func (h *Handler) deleteMeterPricingRule(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	id := chi.URLParam(r, "id")
+
+	if err := h.svc.DeleteMeterPricingRule(r.Context(), tenantID, id); err != nil {
+		if errors.Is(err, errs.ErrNotFound) {
+			respond.NotFound(w, r, "meter_pricing_rule")
+			return
+		}
+		respond.FromError(w, r, err, "meter_pricing_rule")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/usage/aggregation_integration_test.go
+++ b/internal/usage/aggregation_integration_test.go
@@ -295,7 +295,7 @@ func ingest(t *testing.T, ctx context.Context, store *usage.PostgresStore,
 	svc := usage.NewService(store)
 	if _, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
 		CustomerID: customerID, MeterID: meterID,
-		Quantity: qty, Properties: props,
+		Quantity: qty, Dimensions: props,
 	}); err != nil {
 		t.Fatalf("ingest: %v", err)
 	}
@@ -308,7 +308,7 @@ func ingestAt(t *testing.T, ctx context.Context, store *usage.PostgresStore,
 	svc := usage.NewService(store)
 	if _, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
 		CustomerID: customerID, MeterID: meterID,
-		Quantity: qty, Properties: props, Timestamp: &ts,
+		Quantity: qty, Dimensions: props, Timestamp: &ts,
 	}); err != nil {
 		t.Fatalf("ingestAt: %v", err)
 	}

--- a/internal/usage/dimensions_integration_test.go
+++ b/internal/usage/dimensions_integration_test.go
@@ -53,7 +53,7 @@ func TestUsageEvents_DimensionsPersistAndJSONBSupersetMatch(t *testing.T) {
 	for i, e := range events {
 		if _, err := svc.Ingest(ctx, tenantID, usage.IngestInput{
 			CustomerID: customerID, MeterID: meterID,
-			Quantity: decimal.NewFromInt(e.qty), Properties: e.props,
+			Quantity: decimal.NewFromInt(e.qty), Dimensions: e.props,
 		}); err != nil {
 			t.Fatalf("ingest %d: %v", i, err)
 		}

--- a/internal/usage/handler.go
+++ b/internal/usage/handler.go
@@ -108,7 +108,7 @@ func (h *Handler) resolve(ctx context.Context, tenantID string, evt apiEvent) (I
 		CustomerID:     cust.ID,
 		MeterID:        meter.ID,
 		Quantity:       evt.Quantity,
-		Properties:     dims,
+		Dimensions:     dims,
 		IdempotencyKey: evt.IdempotencyKey,
 	}
 

--- a/internal/usage/postgres.go
+++ b/internal/usage/postgres.go
@@ -36,7 +36,7 @@ func (s *PostgresStore) Ingest(ctx context.Context, tenantID string, event domai
 		origin = string(domain.UsageOriginAPI)
 	}
 
-	props, err := propertiesJSON(event.Properties)
+	props, err := propertiesJSON(event.Dimensions)
 	if err != nil {
 		return domain.UsageEvent{}, err
 	}
@@ -52,7 +52,7 @@ func (s *PostgresStore) Ingest(ctx context.Context, tenantID string, event domai
 		props, postgres.NullableString(event.IdempotencyKey),
 		event.Timestamp, origin,
 	).Scan(&event.ID, &event.TenantID, &event.CustomerID, &event.MeterID,
-		&event.SubscriptionID, &event.Quantity, propertiesScanner{&event.Properties},
+		&event.SubscriptionID, &event.Quantity, propertiesScanner{&event.Dimensions},
 		&event.IdempotencyKey, &event.Timestamp, &event.Origin)
 
 	if err != nil {
@@ -102,7 +102,7 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.U
 	for rows.Next() {
 		var e domain.UsageEvent
 		if err := rows.Scan(&e.ID, &e.TenantID, &e.CustomerID, &e.MeterID,
-			&e.SubscriptionID, &e.Quantity, propertiesScanner{&e.Properties},
+			&e.SubscriptionID, &e.Quantity, propertiesScanner{&e.Dimensions},
 			&e.IdempotencyKey, &e.Timestamp); err != nil {
 			return nil, 0, err
 		}

--- a/internal/usage/service.go
+++ b/internal/usage/service.go
@@ -27,7 +27,7 @@ type IngestInput struct {
 	MeterID        string          `json:"meter_id"`
 	SubscriptionID string          `json:"subscription_id,omitempty"`
 	Quantity       decimal.Decimal `json:"quantity,omitempty"`
-	Properties     map[string]any  `json:"properties,omitempty"`
+	Dimensions     map[string]any  `json:"dimensions,omitempty"`
 	IdempotencyKey string          `json:"idempotency_key,omitempty"`
 	Timestamp      *time.Time      `json:"timestamp,omitempty"`
 }
@@ -60,28 +60,28 @@ func (s *Service) Backfill(ctx context.Context, tenantID string, input IngestInp
 	return s.ingest(ctx, tenantID, input, domain.UsageOriginBackfill)
 }
 
-// MaxPropertyKeys caps the size of the JSONB properties map on each
-// usage event. Properties feed pricing-rule dispatch via @> subset
+// MaxDimensionKeys caps the size of the JSONB dimensions map on each
+// usage event. Dimensions feed pricing-rule dispatch via @> subset
 // matches at finalize time; bounding the per-event JSONB size protects
 // the GIN index from pathological tenants and matches the equivalent
 // cap on meter_pricing_rules.dimension_match (16 keys).
-const MaxPropertyKeys = 16
+const MaxDimensionKeys = 16
 
-// validateProperties enforces the v1 dimension contract: at most
-// MaxPropertyKeys keys, scalar values only (string, number, bool, nil).
+// validateDimensions enforces the v1 dimension contract: at most
+// MaxDimensionKeys keys, scalar values only (string, number, bool, nil).
 // Object/array values are rejected — Postgres `@>` would still match
 // them but the priority+claim semantics aren't well-defined for nested
 // containers in v1 (revisit if a design partner needs it).
-func validateProperties(props map[string]any) error {
-	if len(props) > MaxPropertyKeys {
-		return errs.Invalid("properties", fmt.Sprintf("at most %d keys (got %d)", MaxPropertyKeys, len(props)))
+func validateDimensions(dims map[string]any) error {
+	if len(dims) > MaxDimensionKeys {
+		return errs.Invalid("dimensions", fmt.Sprintf("at most %d keys (got %d)", MaxDimensionKeys, len(dims)))
 	}
-	for k, v := range props {
+	for k, v := range dims {
 		switch v.(type) {
 		case nil, string, bool, float64, float32, int, int32, int64:
 			// Scalar — fine.
 		default:
-			return errs.Invalid("properties", fmt.Sprintf("key %q value must be a scalar (string/number/bool), got %T", k, v))
+			return errs.Invalid("dimensions", fmt.Sprintf("key %q value must be a scalar (string/number/bool), got %T", k, v))
 		}
 	}
 	return nil
@@ -94,7 +94,7 @@ func (s *Service) ingest(ctx context.Context, tenantID string, input IngestInput
 	if strings.TrimSpace(input.MeterID) == "" {
 		return domain.UsageEvent{}, errs.Required("meter_id")
 	}
-	if err := validateProperties(input.Properties); err != nil {
+	if err := validateDimensions(input.Dimensions); err != nil {
 		return domain.UsageEvent{}, err
 	}
 	if input.Quantity.IsZero() {
@@ -113,7 +113,7 @@ func (s *Service) ingest(ctx context.Context, tenantID string, input IngestInput
 		MeterID:        input.MeterID,
 		SubscriptionID: input.SubscriptionID,
 		Quantity:       input.Quantity,
-		Properties:     input.Properties,
+		Dimensions:     input.Dimensions,
 		IdempotencyKey: input.IdempotencyKey,
 		Timestamp:      ts,
 		Origin:         origin,

--- a/internal/usage/service_test.go
+++ b/internal/usage/service_test.go
@@ -134,29 +134,29 @@ func TestIngest(t *testing.T) {
 		}
 	})
 
-	t.Run("dimensions persist on properties", func(t *testing.T) {
+	t.Run("dimensions persist round-trip", func(t *testing.T) {
 		e, err := svc.Ingest(ctx, "t1", IngestInput{
 			CustomerID: "cus_dims", MeterID: "mtr_1", Quantity: dec(1),
-			Properties: map[string]any{"model": "gpt-4", "cached": false, "tier": int64(1)},
+			Dimensions: map[string]any{"model": "gpt-4", "cached": false, "tier": int64(1)},
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if e.Properties["model"] != "gpt-4" {
-			t.Errorf("model: got %v", e.Properties["model"])
+		if e.Dimensions["model"] != "gpt-4" {
+			t.Errorf("model: got %v", e.Dimensions["model"])
 		}
-		if e.Properties["cached"] != false {
-			t.Errorf("cached: got %v", e.Properties["cached"])
+		if e.Dimensions["cached"] != false {
+			t.Errorf("cached: got %v", e.Dimensions["cached"])
 		}
 	})
 
 	t.Run("rejects too many dimension keys", func(t *testing.T) {
 		dims := map[string]any{}
-		for i := 0; i < MaxPropertyKeys+1; i++ {
+		for i := 0; i < MaxDimensionKeys+1; i++ {
 			dims[fmt.Sprintf("k%d", i)] = "v"
 		}
 		_, err := svc.Ingest(ctx, "t1", IngestInput{
-			CustomerID: "c", MeterID: "m", Quantity: dec(1), Properties: dims,
+			CustomerID: "c", MeterID: "m", Quantity: dec(1), Dimensions: dims,
 		})
 		if err == nil {
 			t.Fatal("expected error for too many keys")
@@ -166,7 +166,7 @@ func TestIngest(t *testing.T) {
 	t.Run("rejects non-scalar dimension value", func(t *testing.T) {
 		_, err := svc.Ingest(ctx, "t1", IngestInput{
 			CustomerID: "c", MeterID: "m", Quantity: dec(1),
-			Properties: map[string]any{"models": []string{"gpt-4", "claude"}},
+			Dimensions: map[string]any{"models": []string{"gpt-4", "claude"}},
 		})
 		if err == nil {
 			t.Fatal("expected error for slice value")


### PR DESCRIPTION
## Summary

Two follow-ups from PR #20's multi-dim merge surfaced in Track B's live smoke test.

1. **`/v1/meters/{id}/pricing-rules` returned 404.** Store + service shipped in PR #20 but the HTTP handler/route was never registered. Wires GET / POST / GET-by-id / DELETE-by-id under PermPricingRead/Write, mirroring `coupon.CustomerAssignmentRoutes`.

2. **Response side serialized `properties`, not `dimensions`.** Input accepted both (dimensions wins) but `UsageEvent.Properties` json tag was the legacy name. Renames Go field → `Dimensions`, json tag → `dimensions`, `validateProperties`→`validateDimensions`, `MaxPropertyKeys`→`MaxDimensionKeys`. DB column stays `properties` (rename migration deferred).

Also tightens `.gitignore` to `/velox` and `/velox-bench` so the source tree isn't accidentally excluded by the binary-name pattern (this is why `cmd/velox-bench/main.go` initially refused to stage).

## Out of scope

OpenAPI doc has independent drift from PR #20 (still lists `customer_id` / `meter_id` / quantity-as-int). Will land in a separate openapi-sync PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/usage/... ./internal/pricing/... ./internal/api/... -short` green
- [ ] Track B re-runs smoke test against this branch — `/v1/meters/{id}/pricing-rules` returns 200 with `data: []`; POST creates a rule; usage event response includes `dimensions` not `properties`

🤖 Generated with [Claude Code](https://claude.com/claude-code)