### PR TITLE
feat(web): Track B Week 2 — multi-dim UI primitives, recipes picker, onboarding

### DIFF
--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -116,3 +116,35 @@ Continuing the same day. PR #19 (Week 1 docs) is open and unmerged; new branch `
 - **Next session (Track B):** rebase on `origin/main` once #19 merges, then either (a) extend with embeddable cost dashboard scaffold (Week 5 work, but its API contract is in the design doc as `GET /v1/customers/{id}/usage`), or (b) start the recipe-picker UI once Track A drops a recipes RFC. (a) is unblocked today; (b) waits for Track A.
 
 **Wall-clock duration:** Week 2 in-flight = 21:46 → 23:45 IST (≈ 2h 0m); cumulative for the day = 21:09 → 23:45 (≈ 2h 36m).
+
+#### Track A → Track B handoff received (late evening 2026-04-25)
+
+Track A resolved all five Track B asks in one pass. Summary of what was answered, with commit refs from `feat/backend-week2`:
+
+1. **Path convention:** **hyphens** everywhere (`/v1/usage-events`, `/v1/meters/{id}/pricing-rules`, `/v1/customers/{id}/usage?event_name=...`). Design doc updated in `df80d3d`. New "Wire-contract conventions" callout block at the top of the API surface section.
+2. **Quantity stance:** **`quantity` is canonical, both directions, JSON wire form is a string** for decimal precision. **No `value` alias.** Track B's `UsageEvent.value?: string` should be dropped.
+3. **Ingest input field renames:** `meter_key` → `event_name`, `customer_id` → `external_customer_id` (matches Stripe Meter Events convention).
+4. **Recipes RFC shipped:** `docs/design-recipes.md` (547 lines, commit `f0f0dcb`). 5 built-in recipes, atomic `POST /v1/recipes/instantiate`, embedded YAML, explicit Track B unblock section.
+5. **PR #19 review** posted with 5 drift points (paths/field names/value-alias).
+
+#### End-of-turn (Track B — Week 2 follow-up after Track A handoff)
+
+- **Shipped (3 commits on `feat/track-b-week2` plus 1 on `feat/track-b-week1`):**
+  - `cbecec3 docs: align README + blog to hyphen paths and quantity wire-contract` — on Week 1 branch. Fixed all 5 PR #19 drift points: `usage_events` → `usage-events`, `pricing_rules` → `pricing-rules`, `meter_key` → `event_name`, `customer_id` → `external_customer_id`, `value` → `quantity`. Stripe-side examples in the blog deliberately untouched (they describe Stripe's actual API). Pushed to PR #19; confirmation comment posted.
+  - `f631029 refactor(web): drop value alias; quantity is canonical decimal string` — `UsageEvent.quantity: number → string`, dropped `UsageEvent.value`, renamed `CustomerUsageBreakdown.meter_key → event_name` and the corresponding query param. Display preserves trailing-zero precision by rendering the raw string; chart math coerces with `Number()` and notes that authoritative money math stays server-side.
+  - `d38359f feat(web): /recipes picker + onboarding wizard wired to live recipes API` — new `/recipes` page (route added, lazy-loaded). Cards render the 5 built-in recipes with key/version/summary/creates-summary chips/installed badge. Configure dialog: overrides form rendered from `overridable_schema` (text/number/boolean), Preview button shows warnings + truncated object list, Install runs `POST /v1/recipes/instantiate` and navigates to the first created plan. Onboarding step 1 now fetches `/v1/recipes` live; cards deep-link to `/recipes`. Empty-state graceful when backend isn't deployed.
+- **New API client surface:**
+  - Types: `Recipe`, `RecipeDetail`, `RecipeOverrideSchema`, `RecipePreview`, `RecipeInstance`, `RecipeCreatesSummary`
+  - Methods: `listRecipes`, `getRecipe`, `previewRecipe`, `instantiateRecipe`, `deleteRecipeInstance`
+  - All paths hyphen-style; all field names match the RFC.
+- **Build verification:**
+  - `tsc -b` passes (only the two pre-existing errors on `HostedInvoice.tsx:512` and `Webhooks.tsx:243` remain — predate this branch)
+  - `vite build` ~600ms; new lazy chunk for `/recipes`
+  - Visual verification still deferred to next session (needs Postgres + Track A's PR #20 backend)
+- **Branch state:**
+  - `feat/track-b-week1` (PR #19): 5 commits, last is `cbecec3` (drift fix). Ready to merge.
+  - `feat/track-b-week2`: 7 commits, stacked on `feat/track-b-week1`. Will rebase to `main` after #19 merges. No PR opened yet — Week 2 arc continues with cost-dashboard scaffold next session.
+- **Blocking Track A on:** nothing. All earlier asks resolved.
+- **Next session (Track B):** with PR #19 + Track A's PR #20 merged, the natural next pieces are (a) embeddable cost-dashboard scaffold (Week 5; API contract in `docs/design-multi-dim-meters.md` as `GET /v1/customers/{id}/usage`) and (b) sidebar nav links for `/recipes` + `/onboarding` once they're polished. Also: changelog discipline — when multi-dim and recipes both land on `main`, both `CHANGELOG.md` and `web-v2/src/pages/Changelog.tsx` need entries (Track A on the engineering log; me on the customer-facing rollup).
+
+**Wall-clock duration (extended day):** initial Week 1 + Week 2 = 21:09 → 23:45 IST (≈ 2h 36m). Track A handoff + this round = 23:50 → 00:01 IST 2026-04-26 (≈ 11m active editing time, plus design-doc / RFC reading). Cumulative day total ≈ 2h 50m.

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -148,3 +148,40 @@ Track A resolved all five Track B asks in one pass. Summary of what was answered
 - **Next session (Track B):** with PR #19 + Track A's PR #20 merged, the natural next pieces are (a) embeddable cost-dashboard scaffold (Week 5; API contract in `docs/design-multi-dim-meters.md` as `GET /v1/customers/{id}/usage`) and (b) sidebar nav links for `/recipes` + `/onboarding` once they're polished. Also: changelog discipline — when multi-dim and recipes both land on `main`, both `CHANGELOG.md` and `web-v2/src/pages/Changelog.tsx` need entries (Track A on the engineering log; me on the customer-facing rollup).
 
 **Wall-clock duration (extended day):** initial Week 1 + Week 2 = 21:09 → 23:45 IST (≈ 2h 36m). Track A handoff + this round = 23:50 → 00:01 IST 2026-04-26 (≈ 11m active editing time, plus design-doc / RFC reading). Cumulative day total ≈ 2h 50m.
+
+---
+
+## 2026-04-26 (Sun) — post-PR-#20-merge
+
+### Track B — rebase + live smoke test
+
+Track A merged PR #20 (multi-dim backend, 12 commits) into `main` at 18:25:30Z. Cleanup pass on Track B's stacked branches plus first live API verification.
+
+- **Rebased both branches onto new main:**
+  - `feat/track-b-week1` rebased clean (handoff-log conflict resolved by keeping both Track A's "second update" and my Track B kickoff/end-of-turn — they describe the same date from two perspectives). Force-pushed to PR #19.
+  - `feat/track-b-week2` rebased via `git rebase --onto feat/track-b-week1 cbecec3 feat/track-b-week2` (skip the 6 Week-1 commits, replay only the 7 Week-2 unique commits). Force-pushed.
+- **Heads-up: Track B's "Week 3 picker UI scaffold" is already shipped.** Done in commit `0c719bd feat(web): /recipes picker + onboarding wizard wired to live recipes API` (and 6 sibling commits) on `feat/track-b-week2`. Per Track A's handoff message expecting Track B to "start" the picker — we got ahead of it Saturday night.
+- **Live smoke test against the merged backend (binary built from `main` HEAD on port :8090, fresh tenant + secret key):**
+  - `GET /v1/meters` ✓ — empty data, route works
+  - `POST /v1/meters` ✓ — created `vlx_mtr_d7mgm93majdkeceoujpg`
+  - `POST /v1/customers` ✓ — created `vlx_cus_...` with `external_id="acme"`
+  - `POST /v1/usage-events` with `{external_customer_id, event_name, quantity:"1234.567890123456", dimensions:{model,operation,cached}}` ✓ — accepted; response carries `quantity:"1234.567890123456"` (string-encoded decimal, matches my TS type) and the JSONB column round-trips intact.
+  - **Two real gaps surfaced:**
+    1. **`/v1/meters/{id}/pricing-rules` returns 404 on the chi router.** The store + service for `meter_pricing_rules` shipped in PR #20, but the HTTP handler / route registration did not. My UI's "Add rule" dialog and rules list will show empty state until Track A adds the handler. Caught by my UI's try/catch fallback so the page stays usable, but the feature is non-functional. Suggested follow-up commit: register `r.Post/Get/Delete` for `pricing-rules` under the existing `/v1/meters/{id}` subtree, calling `pricing.Service.UpsertMeterPricingRule` etc.
+    2. **Response-side returns `properties`, not `dimensions`.** Ingest accepts both (`dimensions` wins, per the apiEvent doc on `internal/usage/handler.go:74`), but the response keeps the legacy `properties` JSON field. My TS type expected `dimensions`. Patched in commit `af44730` — `UsageEvent.properties` added as optional alongside `dimensions`, new `eventDimensions()` helper reads whichever is present. Cleanest long-term fix: have Track A serialize as `dimensions` on responses too. Until then, my UI works against both.
+- **Recipes endpoints (`/v1/recipes*`):** correctly 404 — recipes are Track A's Week 3 work, not in PR #20. My `/recipes` page falls back to empty-state cleanly.
+- **Build:** `tsc -b` clean (only pre-existing errors); `vite build` ~600–740ms.
+- **Branch state pushed to origin:**
+  - `feat/track-b-week1`: 6 commits, ready to merge (PR #19 is up-to-date)
+  - `feat/track-b-week2`: 8 commits (7 from before + `af44730` patch), stacked on Week 1
+- **Messages for Track A (next-task copy):**
+  1. **Add the HTTP handler + routes for meter pricing rules.** Service already exists. Routes I'm calling: `POST/GET /v1/meters/{id}/pricing-rules`, `DELETE /v1/meters/{id}/pricing-rules/{rule_id}`. The Track B UI is already wired against these.
+  2. **Response-side wire alignment for `properties` vs `dimensions`.** Either rename to `dimensions` on the wire (cleanest) or leave as-is and document the alias in the wire-contract block. Track B side defensively reads both; Track A's choice.
+  3. **`GET /v1/customers/{id}/usage` (the breakdown endpoint).** Same gap as #1 — needed for the Week 5 cost dashboard. If the route doesn't exist yet, please add when adding pricing-rules routes (same handler file).
+  4. **Recipe RFC has 7 open questions** (per Track A's earlier handoff). When picking up Week 3 implementation, if any of those answers shift the API shape, ping Track B before changing the contract — my picker UI is already built against the doc-as-it-stands.
+- **Blocking Track A on:** nothing. Above are next-task asks, not blockers.
+- **Next session (Track B):**
+  - PR #19 hasn't merged yet — once it does, retire the Week 1 branch and rebase Week 2 directly onto main as the new base.
+  - Then either (a) embeddable cost-dashboard scaffold (Week 5, depends on `/v1/customers/{id}/usage` from Track A), or (b) sidebar nav entries + polish on `/recipes` + `/onboarding`. (b) is unblocked today.
+
+**Wall-clock for this round:** 00:05 → 00:30 IST 2026-04-26 (≈ 25m).

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -88,3 +88,31 @@
   - Open questions 1–7 in `docs/design-recipes.md` — flag any to resolve before Week 3 implementation starts (May 9).
   - Track B's quantity-vs-value question: resolved as `quantity` canonical, no `value` alias. Documented in `docs/design-multi-dim-meters.md` "Wire-contract conventions" callout.
 - **Next session (Track A):** depending on human direction — (a) drive PR #20 to merge once CI is green, then start Week 3 recipes implementation Monday; (b) Week 1 docs polish if human wants those locked first; (c) `create_preview` design doc for Week 5 if human wants the next RFC pre-staged for Track B.
+
+#### End-of-turn (Track B — Week 2 frontend, in-flight)
+Continuing the same day. PR #19 (Week 1 docs) is open and unmerged; new branch `feat/track-b-week2` is stacked on top of it. Will rebase to `main` once #19 lands.
+
+- **Shipped (3 commits on `feat/track-b-week2`):**
+  - `6cc492f feat(web): multi-dim pricing rules section on meter detail` — `MeterDetail.tsx` gets a "Dimension-matched rules" card with a chips-table of `priority / dimension_match / aggregation_mode / rating_rule / created`, an "Add rule" dialog (key/value dimension builder, rating-rule selector, all 5 aggregation modes), and typed-confirm delete. The original "Pricing Rule" card was renamed "Default pricing rule" with a copy clarifying it's the fallback for events not claimed by a higher-priority dimension-matched rule. Backed by new `api.{list,create,delete}MeterPricingRule` calls; falls back to empty list when the backend endpoint isn't deployed yet.
+  - `7d8260d feat(web): surface dimensions on usage events table + filter` — `UsageEvents.tsx` gets a conditional Dimensions column (only shows when at least one event in view carries them, or a filter is active), a `key=value` text filter bound to a `dimensions=` query param, and stats/breakdowns now read the new decimal `value` field with fallback to legacy integer `quantity`. CSV export includes the dimensions JSON column.
+  - `20059c4 feat(web): /onboarding wizard scaffold (5-step quickstart)` — new `/onboarding` route with a Stripe/Linear-style 5-step wizard skeleton: pick template → connect Stripe → tax → branding → send first invoice. Step state in `?step=`. Body content uses real deep-links into existing settings/customer/invoice pages so it's usable today; template picker wires up to recipes API in Week 3.
+- **API contract additions** (in `web-v2/src/lib/api.ts`):
+  - New types: `MeterPricingRule`, `MeterAggregationMode` (union of 5 modes), `CustomerUsageBreakdown`
+  - `UsageEvent.value?: string` (decimal string) and `UsageEvent.dimensions?: Record<string, string|number|boolean>` — both optional during the multi-dim transition
+  - New methods: `listMeterPricingRules`, `createMeterPricingRule`, `deleteMeterPricingRule`, `customerUsageBreakdown`
+- **Path-naming choice (worth flagging to Track A):** I went with **hyphens** for the new endpoints (`/v1/meters/{id}/pricing-rules`) for consistency with the rest of the API (`/v1/credit-notes`, `/v1/rating-rules`, `/v1/audit-log`). The design doc currently says underscores. If Track A is firm on underscores, they should rename existing endpoints too — anything else creates dual conventions in the same surface.
+- **Build verification:**
+  - `tsc -b` passes — only pre-existing errors on `HostedInvoice.tsx:512` (Button asChild prop) and `Webhooks.tsx:243` (setState narrowing). Both predate this branch — confirmed via diff against `origin/main`.
+  - `vite build` succeeds in ~600ms; no new bundles broke chunking.
+  - Visual verification not done — dev server requires Postgres + bootstrap; deferred to next session against Track A's actual multi-dim backend on May 8.
+- **Messages for Track A (scannable copy for the human to convey):**
+  1. Update `docs/design-multi-dim-meters.md` paths to **hyphens** (or rename existing endpoints to underscores). Pick one.
+  2. Pick a stance on `quantity` vs `value` in `UsageEvent` responses; document in design doc. I have both as optional — Stripe-style transition keeps both, response prefers `value`.
+  3. Start `docs/design-recipes.md` next so I can scaffold the recipe-picker UI in Week 3 against a real contract instead of mocking.
+  4. After multi-dim backend ships May 8, manually click through `/meters/:id` (Pricing Rules section) and `/usage` (Dimensions column) to confirm rules and event dimensions render.
+  5. Glance at PR #19 (README + blog) — examples lifted directly from the design doc; if implementation diverges, those copy fragments need follow-up.
+- **Blocking Track A on:** nothing
+- **Track A can pick up from this work:** OpenAPI spec update, recipe RFC, multi-dim backend implementation. Path/field naming feedback is the only thing I'd love resolved before Track A's PR opens.
+- **Next session (Track B):** rebase on `origin/main` once #19 merges, then either (a) extend with embeddable cost dashboard scaffold (Week 5 work, but its API contract is in the design doc as `GET /v1/customers/{id}/usage`), or (b) start the recipe-picker UI once Track A drops a recipes RFC. (a) is unblocked today; (b) waits for Track A.
+
+**Wall-clock duration:** Week 2 in-flight = 21:46 → 23:45 IST (≈ 2h 0m); cumulative for the day = 21:09 → 23:45 (≈ 2h 36m).

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -314,6 +314,21 @@ export const api = {
   revokeCustomerCoupon: (customerId: string) =>
     apiRequest<void>('DELETE', `/customers/${customerId}/coupon`),
 
+  // Recipes (pricing templates) — see docs/design-recipes.md
+  listRecipes: () => apiRequest<{ data: Recipe[] }>('GET', '/recipes'),
+  getRecipe: (key: string) => apiRequest<RecipeDetail>('GET', `/recipes/${key}`),
+  previewRecipe: (key: string, overrides: Record<string, string | number | boolean>) =>
+    apiRequest<RecipePreview>('POST', `/recipes/${key}/preview`, { overrides }),
+  instantiateRecipe: (data: {
+    key: string
+    overrides?: Record<string, string | number | boolean>
+    seed_sample_data?: boolean
+    force?: boolean
+    idempotency_key?: string
+  }) => apiRequest<RecipeInstance>('POST', '/recipes/instantiate', data),
+  deleteRecipeInstance: (id: string) =>
+    apiRequest<{ status: string }>('DELETE', `/recipes/instances/${id}`),
+
   // Audit Log
   listAuditLog: (params?: string) => apiRequest<{ data: AuditEntry[]; total: number }>('GET', `/audit-log${params ? '?' + params : ''}`),
   getAuditFilters: () => apiRequest<AuditFilterOptions>('GET', '/audit-log/filters'),
@@ -628,6 +643,76 @@ export interface CustomerUsageBreakdown {
     quantity: string
     projected_amount_cents: number
   }[]
+}
+
+export interface RecipeCreatesSummary {
+  meters: number
+  pricing_rules: number
+  plans: number
+  products: number
+  rating_rules: number
+  dunning_policies: number
+  webhook_endpoints: number
+}
+
+export interface Recipe {
+  key: string
+  version: string
+  name: string
+  summary: string
+  creates: RecipeCreatesSummary
+  overridable: string[]
+  instantiated?: { id: string; instantiated_at: string } | null
+}
+
+export interface RecipeOverrideSchema {
+  type: 'string' | 'number' | 'boolean'
+  default?: string | number | boolean
+  description?: string
+  enum?: (string | number)[]
+}
+
+export interface RecipeDetail extends Recipe {
+  description: string
+  overridable_schema: Record<string, RecipeOverrideSchema>
+}
+
+export interface RecipePreview {
+  key: string
+  version: string
+  objects: {
+    products?: { code: string; name: string; description?: string }[]
+    meters?: { key: string; name: string; unit: string; aggregation: string }[]
+    rating_rules?: { rule_key: string; mode: string; currency: string; flat_amount_cents?: number }[]
+    pricing_rules?: {
+      meter_key: string
+      rating_rule_key: string
+      dimension_match: Record<string, string | number | boolean>
+      aggregation_mode: MeterAggregationMode
+      priority: number
+    }[]
+    plans?: { code: string; name: string; currency: string; billing_interval: string; base_amount_cents: number; meter_keys: string[] }[]
+    dunning_policies?: { name: string; max_retries: number; intervals_hours: number[] }[]
+    webhook_endpoints?: { url: string; events: string[]; _placeholder?: boolean }[]
+  }
+  warnings: string[]
+}
+
+export interface RecipeInstance {
+  id: string
+  key: string
+  version: string
+  tenant_id: string
+  created_at: string
+  created_objects: {
+    product_ids: string[]
+    meter_ids: string[]
+    rating_rule_ids: string[]
+    pricing_rule_ids: string[]
+    plan_ids: string[]
+    dunning_policy_id: string
+    webhook_endpoint_id: string
+  }
 }
 
 export interface UsageSummary {

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -111,6 +111,33 @@ export const api = {
     apiRequest<Meter>('GET', `/meters/${id}`),
   createMeter: (data: { key: string; name: string; unit?: string; aggregation?: string; rating_rule_version_id?: string }) =>
     apiRequest<Meter>('POST', '/meters', data),
+  listMeterPricingRules: (meterId: string) =>
+    apiRequest<{ data: MeterPricingRule[] }>('GET', `/meters/${meterId}/pricing-rules`),
+  createMeterPricingRule: (
+    meterId: string,
+    data: {
+      rating_rule_version_id: string
+      dimension_match: Record<string, string | number | boolean>
+      aggregation_mode: MeterAggregationMode
+      priority: number
+    },
+  ) =>
+    apiRequest<MeterPricingRule>('POST', `/meters/${meterId}/pricing-rules`, data),
+  deleteMeterPricingRule: (meterId: string, ruleId: string) =>
+    apiRequest<{ status: string }>('DELETE', `/meters/${meterId}/pricing-rules/${ruleId}`),
+  customerUsageBreakdown: (
+    customerId: string,
+    params: { meter_key: string; period_start: string; period_end: string; group_by?: string[] },
+  ) => {
+    const qs = new URLSearchParams()
+    qs.set('meter_key', params.meter_key)
+    qs.set('period_start', params.period_start)
+    qs.set('period_end', params.period_end)
+    if (params.group_by && params.group_by.length > 0) {
+      qs.set('group_by', params.group_by.join(','))
+    }
+    return apiRequest<CustomerUsageBreakdown>('GET', `/customers/${customerId}/usage?${qs.toString()}`)
+  },
   listPlans: () =>
     apiRequest<{ data: Plan[] }>('GET', '/plans'),
   getPlan: (id: string) =>
@@ -562,8 +589,46 @@ export interface UsageEvent {
   meter_id: string
   subscription_id: string
   quantity: number
+  // String-encoded NUMERIC for decimal precision (GPU-hours, partial tokens).
+  // Optional until the multi-dim ingest endpoint replaces the integer-only one.
+  value?: string
+  // Free-form dimensions per docs/design-multi-dim-meters.md (subset-matched
+  // by pricing rules). Empty for events ingested before that endpoint.
+  dimensions?: Record<string, string | number | boolean>
   idempotency_key: string
   timestamp: string
+}
+
+export type MeterAggregationMode =
+  | 'sum'
+  | 'count'
+  | 'last_during_period'
+  | 'last_ever'
+  | 'max'
+
+export interface MeterPricingRule {
+  id: string
+  meter_id: string
+  rating_rule_version_id: string
+  dimension_match: Record<string, string | number | boolean>
+  aggregation_mode: MeterAggregationMode
+  priority: number
+  created_at: string
+}
+
+export interface CustomerUsageBreakdown {
+  customer_id: string
+  meter_key: string
+  period_start: string
+  period_end: string
+  group_by: string[]
+  buckets: {
+    dimensions: Record<string, string | number | boolean>
+    rule_id: string | null
+    aggregation_mode: MeterAggregationMode
+    quantity: string
+    projected_amount_cents: number
+  }[]
 }
 
 export interface UsageSummary {

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -607,10 +607,20 @@ export interface UsageEvent {
   // and partial tokens. Coerce via Number() / parseFloat() at display time.
   quantity: string
   // Free-form dimensions per docs/design-multi-dim-meters.md (subset-matched
-  // by pricing rules). Empty for events ingested before the multi-dim API.
+  // by pricing rules). Backend currently serializes the same JSONB column as
+  // `properties` on responses; UI reads either via `eventDimensions()`.
   dimensions?: Record<string, string | number | boolean>
+  properties?: Record<string, string | number | boolean>
   idempotency_key: string
   timestamp: string
+}
+
+export function eventDimensions(
+  e: UsageEvent,
+): Record<string, string | number | boolean> | undefined {
+  if (e.dimensions && Object.keys(e.dimensions).length > 0) return e.dimensions
+  if (e.properties && Object.keys(e.properties).length > 0) return e.properties
+  return undefined
 }
 
 export type MeterAggregationMode =

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -127,10 +127,10 @@ export const api = {
     apiRequest<{ status: string }>('DELETE', `/meters/${meterId}/pricing-rules/${ruleId}`),
   customerUsageBreakdown: (
     customerId: string,
-    params: { meter_key: string; period_start: string; period_end: string; group_by?: string[] },
+    params: { event_name: string; period_start: string; period_end: string; group_by?: string[] },
   ) => {
     const qs = new URLSearchParams()
-    qs.set('meter_key', params.meter_key)
+    qs.set('event_name', params.event_name)
     qs.set('period_start', params.period_start)
     qs.set('period_end', params.period_end)
     if (params.group_by && params.group_by.length > 0) {
@@ -588,12 +588,11 @@ export interface UsageEvent {
   customer_id: string
   meter_id: string
   subscription_id: string
-  quantity: number
-  // String-encoded NUMERIC for decimal precision (GPU-hours, partial tokens).
-  // Optional until the multi-dim ingest endpoint replaces the integer-only one.
-  value?: string
+  // String-encoded NUMERIC(38, 12) — decimal precision for fractional GPU-hours
+  // and partial tokens. Coerce via Number() / parseFloat() at display time.
+  quantity: string
   // Free-form dimensions per docs/design-multi-dim-meters.md (subset-matched
-  // by pricing rules). Empty for events ingested before that endpoint.
+  // by pricing rules). Empty for events ingested before the multi-dim API.
   dimensions?: Record<string, string | number | boolean>
   idempotency_key: string
   timestamp: string
@@ -618,7 +617,7 @@ export interface MeterPricingRule {
 
 export interface CustomerUsageBreakdown {
   customer_id: string
-  meter_key: string
+  event_name: string
   period_start: string
   period_end: string
   group_by: string[]

--- a/web-v2/src/main.tsx
+++ b/web-v2/src/main.tsx
@@ -138,6 +138,7 @@ const ChangelogPage = lazy(() => import('@/pages/Changelog'))
 const TermsPage = lazy(() => import('@/pages/Terms'))
 const PrivacyPage = lazy(() => import('@/pages/Privacy'))
 const DPAPage = lazy(() => import('@/pages/DPA'))
+const OnboardingPage = lazy(() => import('@/pages/Onboarding'))
 
 const App = () => (
   <ErrorBoundary>
@@ -158,6 +159,7 @@ const App = () => (
               <Route path="/reset-password" element={<ResetPasswordPage />} />
               <Route path="/accept-invite" element={<AcceptInvitePage />} />
               <Route path="/" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
+              <Route path="/onboarding" element={<ProtectedRoute><OnboardingPage /></ProtectedRoute>} />
               <Route path="/customers" element={<ProtectedRoute><CustomersPage /></ProtectedRoute>} />
               <Route path="/pricing" element={<ProtectedRoute><PricingPage /></ProtectedRoute>} />
               <Route path="/dunning" element={<ProtectedRoute><DunningPage /></ProtectedRoute>} />

--- a/web-v2/src/main.tsx
+++ b/web-v2/src/main.tsx
@@ -139,6 +139,7 @@ const TermsPage = lazy(() => import('@/pages/Terms'))
 const PrivacyPage = lazy(() => import('@/pages/Privacy'))
 const DPAPage = lazy(() => import('@/pages/DPA'))
 const OnboardingPage = lazy(() => import('@/pages/Onboarding'))
+const RecipesPage = lazy(() => import('@/pages/Recipes'))
 
 const App = () => (
   <ErrorBoundary>
@@ -160,6 +161,7 @@ const App = () => (
               <Route path="/accept-invite" element={<AcceptInvitePage />} />
               <Route path="/" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
               <Route path="/onboarding" element={<ProtectedRoute><OnboardingPage /></ProtectedRoute>} />
+              <Route path="/recipes" element={<ProtectedRoute><RecipesPage /></ProtectedRoute>} />
               <Route path="/customers" element={<ProtectedRoute><CustomersPage /></ProtectedRoute>} />
               <Route path="/pricing" element={<ProtectedRoute><PricingPage /></ProtectedRoute>} />
               <Route path="/dunning" element={<ProtectedRoute><DunningPage /></ProtectedRoute>} />

--- a/web-v2/src/pages/MeterDetail.tsx
+++ b/web-v2/src/pages/MeterDetail.tsx
@@ -1,25 +1,59 @@
+import { useState } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { api, formatCents, formatDateTime } from '@/lib/api'
+import type { MeterPricingRule, MeterAggregationMode, RatingRule } from '@/lib/api'
+import { showApiError } from '@/lib/formErrors'
 import { Layout } from '@/components/Layout'
 import { statusBadgeVariant } from '@/lib/status'
 
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { TypedConfirmDialog } from '@/components/TypedConfirmDialog'
 
-import { Loader2 } from 'lucide-react'
+import { Loader2, Plus, Trash2 } from 'lucide-react'
 import { CopyButton } from '@/components/CopyButton'
 import { DetailBreadcrumb } from '@/components/DetailBreadcrumb'
 
 const statusVariant = statusBadgeVariant
 
+const AGGREGATION_MODES: { value: MeterAggregationMode; label: string; help: string }[] = [
+  { value: 'sum', label: 'sum', help: 'Add all event values in the period.' },
+  { value: 'count', label: 'count', help: 'Count matching events; ignore values.' },
+  { value: 'last_during_period', label: 'last_during_period', help: 'Take the latest event in the period.' },
+  { value: 'last_ever', label: 'last_ever', help: 'Take the latest event across all time (state-style billing).' },
+  { value: 'max', label: 'max', help: 'Take the largest value in the period.' },
+]
+
 export default function MeterDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<MeterPricingRule | null>(null)
 
   const { data: meter, isLoading: meterLoading, error: meterError, refetch } = useQuery({
     queryKey: ['meter', id],
@@ -55,6 +89,27 @@ export default function MeterDetailPage() {
     enabled: !!id,
   })
 
+  // Multi-dimensional pricing rules. Falls back to an empty list when the
+  // backend endpoint isn't deployed yet — keeps the page usable on tenants
+  // running pre-multi-dim builds.
+  const { data: rules } = useQuery({
+    queryKey: ['meter-pricing-rules', id],
+    queryFn: async () => {
+      try {
+        const res = await api.listMeterPricingRules(id!)
+        return res.data ?? []
+      } catch {
+        return [] as MeterPricingRule[]
+      }
+    },
+    enabled: !!id,
+  })
+
+  const { data: ratingRules } = useQuery({
+    queryKey: ['rating-rules-all'],
+    queryFn: () => api.listRatingRules(),
+  })
+
   const loading = meterLoading
   const error = meterError instanceof Error ? meterError.message : meterError ? String(meterError) : null
 
@@ -68,6 +123,16 @@ export default function MeterDetailPage() {
     }
     return `Next ${(tier.up_to - prev).toLocaleString()} units`
   }
+
+  const deleteMutation = useMutation({
+    mutationFn: (ruleId: string) => api.deleteMeterPricingRule(id!, ruleId),
+    onSuccess: () => {
+      toast.success('Pricing rule deleted')
+      queryClient.invalidateQueries({ queryKey: ['meter-pricing-rules', id] })
+      setDeleteTarget(null)
+    },
+    onError: (err) => showApiError(err, 'Failed to delete pricing rule'),
+  })
 
   if (loading) {
     return (
@@ -135,7 +200,7 @@ export default function MeterDetailPage() {
               <span className="text-sm text-foreground">{meter.unit}</span>
             </div>
             <div className="flex items-center justify-between px-6 py-3">
-              <span className="text-sm text-muted-foreground">Aggregation</span>
+              <span className="text-sm text-muted-foreground">Default aggregation</span>
               <Badge variant="secondary">{meter.aggregation}</Badge>
             </div>
             <div className="flex items-center justify-between px-6 py-3">
@@ -153,14 +218,17 @@ export default function MeterDetailPage() {
         </CardContent>
       </Card>
 
-      {/* Pricing Rule */}
+      {/* Default pricing rule */}
       <Card className="mt-6">
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle className="text-sm">Pricing Rule</CardTitle>
+              <CardTitle className="text-sm">Default pricing rule</CardTitle>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Applies to events not claimed by a dimension-matched rule below.
+              </p>
               {ratingRule && (
-                <p className="text-sm text-muted-foreground mt-0.5">{ratingRule.name}</p>
+                <p className="text-sm text-muted-foreground mt-2">{ratingRule.name}</p>
               )}
             </div>
             {ratingRule && (
@@ -218,6 +286,93 @@ export default function MeterDetailPage() {
         </CardContent>
       </Card>
 
+      {/* Dimension-matched pricing rules (multi-dim) */}
+      <Card className="mt-6">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="text-sm">Dimension-matched rules</CardTitle>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Pricing rules that match a subset of event dimensions. Higher priority claims events first.
+              </p>
+            </div>
+            <Button size="sm" onClick={() => setCreateOpen(true)}>
+              <Plus size={14} className="mr-1.5" /> Add rule
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {rules && rules.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="text-xs font-medium w-20">Priority</TableHead>
+                  <TableHead className="text-xs font-medium">Dimension match</TableHead>
+                  <TableHead className="text-xs font-medium w-40">Aggregation</TableHead>
+                  <TableHead className="text-xs font-medium">Rating rule</TableHead>
+                  <TableHead className="text-xs font-medium w-44">Created</TableHead>
+                  <TableHead className="text-xs font-medium w-12 text-right" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rules.map(rule => {
+                  const ratingRuleName = ratingRules?.data.find(r => r.id === rule.rating_rule_version_id)?.name
+                  return (
+                    <TableRow key={rule.id}>
+                      <TableCell className="text-sm font-mono tabular-nums">{rule.priority}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {Object.entries(rule.dimension_match).length === 0 ? (
+                            <span className="text-xs text-muted-foreground italic">all events</span>
+                          ) : (
+                            Object.entries(rule.dimension_match).map(([k, v]) => (
+                              <span key={k} className="inline-flex items-center text-xs font-mono bg-muted px-1.5 py-0.5 rounded">
+                                {k}=<span className="text-foreground">{String(v)}</span>
+                              </span>
+                            ))
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className="font-mono text-xs">{rule.aggregation_mode}</Badge>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {ratingRuleName ? (
+                          <span title={rule.rating_rule_version_id}>{ratingRuleName}</span>
+                        ) : (
+                          <span className="font-mono text-xs">{rule.rating_rule_version_id.slice(0, 16)}…</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">{formatDateTime(rule.created_at)}</TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                          onClick={() => setDeleteTarget(rule)}
+                          aria-label="Delete pricing rule"
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="px-6 py-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                No dimension-matched rules. Every event uses the default pricing rule above.
+              </p>
+              <Button variant="outline" size="sm" className="mt-3" onClick={() => setCreateOpen(true)}>
+                <Plus size={14} className="mr-1.5" /> Add a rule
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Plans */}
       <Card className="mt-6">
         <CardHeader>
@@ -266,6 +421,210 @@ export default function MeterDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      {createOpen && (
+        <CreatePricingRuleDialog
+          meterId={meter.id}
+          ratingRules={ratingRules?.data ?? []}
+          onClose={() => setCreateOpen(false)}
+          onCreated={() => {
+            setCreateOpen(false)
+            queryClient.invalidateQueries({ queryKey: ['meter-pricing-rules', meter.id] })
+          }}
+        />
+      )}
+
+      {deleteTarget && (
+        <TypedConfirmDialog
+          open
+          onOpenChange={(open) => { if (!open) setDeleteTarget(null) }}
+          title="Delete pricing rule?"
+          description={
+            <>
+              This rule stops applying to new events at finalize time. Invoices
+              already finalized are unaffected. Type <span className="font-mono">delete</span> to confirm.
+            </>
+          }
+          confirmWord="delete"
+          confirmLabel="Delete rule"
+          onConfirm={() => deleteMutation.mutate(deleteTarget.id)}
+          loading={deleteMutation.isPending}
+        />
+      )}
     </Layout>
   )
+}
+
+interface DimensionRow {
+  key: string
+  value: string
+}
+
+function CreatePricingRuleDialog({
+  meterId,
+  ratingRules,
+  onClose,
+  onCreated,
+}: {
+  meterId: string
+  ratingRules: RatingRule[]
+  onClose: () => void
+  onCreated: () => void
+}) {
+  const [dimensions, setDimensions] = useState<DimensionRow[]>([{ key: '', value: '' }])
+  const [aggregation, setAggregation] = useState<MeterAggregationMode>('sum')
+  const [ratingRuleId, setRatingRuleId] = useState<string>('')
+  const [priority, setPriority] = useState<number>(100)
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      const dimMap: Record<string, string | number | boolean> = {}
+      for (const row of dimensions) {
+        const k = row.key.trim()
+        if (!k) continue
+        dimMap[k] = parseDimensionValue(row.value)
+      }
+      return api.createMeterPricingRule(meterId, {
+        rating_rule_version_id: ratingRuleId,
+        dimension_match: dimMap,
+        aggregation_mode: aggregation,
+        priority,
+      })
+    },
+    onSuccess: () => {
+      toast.success('Pricing rule created')
+      onCreated()
+    },
+    onError: (err) => showApiError(err, 'Failed to create pricing rule'),
+  })
+
+  const updateRow = (i: number, patch: Partial<DimensionRow>) => {
+    setDimensions(rows => rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+  }
+  const addRow = () => setDimensions(rows => [...rows, { key: '', value: '' }])
+  const removeRow = (i: number) => setDimensions(rows => rows.filter((_, idx) => idx !== i))
+
+  const canSubmit = !!ratingRuleId && !createMutation.isPending
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add dimension-matched pricing rule</DialogTitle>
+          <DialogDescription>
+            Match events whose dimensions are a superset of the keys below. Leave empty to match every event.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div>
+            <Label className="text-xs uppercase tracking-wide text-muted-foreground">Dimension match</Label>
+            <div className="space-y-2 mt-2">
+              {dimensions.map((row, i) => (
+                <div key={i} className="flex items-center gap-2">
+                  <Input
+                    placeholder="key (e.g. model)"
+                    value={row.key}
+                    onChange={(e) => updateRow(i, { key: e.target.value })}
+                    className="font-mono text-sm"
+                  />
+                  <span className="text-muted-foreground">=</span>
+                  <Input
+                    placeholder="value (e.g. gpt-4)"
+                    value={row.value}
+                    onChange={(e) => updateRow(i, { value: e.target.value })}
+                    className="font-mono text-sm"
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9 shrink-0 text-muted-foreground"
+                    onClick={() => removeRow(i)}
+                    disabled={dimensions.length === 1}
+                    aria-label="Remove dimension"
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+              ))}
+            </div>
+            <Button variant="outline" size="sm" className="mt-2" onClick={addRow}>
+              <Plus size={14} className="mr-1.5" /> Add dimension
+            </Button>
+            <p className="text-xs text-muted-foreground mt-2">
+              Values <span className="font-mono">true</span>, <span className="font-mono">false</span>, and numeric strings are coerced; everything else is treated as a string.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">Aggregation</Label>
+              <Select value={aggregation} onValueChange={(v) => setAggregation(v as MeterAggregationMode)}>
+                <SelectTrigger className="mt-2 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {AGGREGATION_MODES.map(m => (
+                    <SelectItem key={m.value} value={m.value}>
+                      <span className="font-mono">{m.label}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground mt-1">
+                {AGGREGATION_MODES.find(m => m.value === aggregation)?.help}
+              </p>
+            </div>
+            <div>
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">Priority</Label>
+              <Input
+                type="number"
+                value={priority}
+                onChange={(e) => setPriority(parseInt(e.target.value || '0', 10) || 0)}
+                className="mt-2 font-mono"
+              />
+              <p className="text-xs text-muted-foreground mt-1">Higher priority claims events first.</p>
+            </div>
+          </div>
+
+          <div>
+            <Label className="text-xs uppercase tracking-wide text-muted-foreground">Rating rule</Label>
+            <Select value={ratingRuleId} onValueChange={(v) => setRatingRuleId(v ?? '')}>
+              <SelectTrigger className="mt-2 w-full">
+                <SelectValue placeholder="Select rating rule…" />
+              </SelectTrigger>
+              <SelectContent>
+                {ratingRules.length === 0 ? (
+                  <div className="px-3 py-2 text-sm text-muted-foreground">No rating rules — create one first.</div>
+                ) : (
+                  ratingRules.map(rr => (
+                    <SelectItem key={rr.id} value={rr.id}>
+                      <span className="text-sm">{rr.name}</span>
+                      <span className="text-xs text-muted-foreground ml-2">{rr.mode} · v{rr.version}</span>
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button onClick={() => createMutation.mutate()} disabled={!canSubmit}>
+            {createMutation.isPending ? <Loader2 size={14} className="mr-1.5 animate-spin" /> : null}
+            Create rule
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function parseDimensionValue(raw: string): string | number | boolean {
+  const trimmed = raw.trim()
+  if (trimmed === 'true') return true
+  if (trimmed === 'false') return false
+  if (trimmed !== '' && !isNaN(Number(trimmed))) return Number(trimmed)
+  return raw
 }

--- a/web-v2/src/pages/Onboarding.tsx
+++ b/web-v2/src/pages/Onboarding.tsx
@@ -1,0 +1,220 @@
+import { useMemo } from 'react'
+import { useSearchParams, Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import { Check, ArrowRight } from 'lucide-react'
+
+interface Step {
+  key: string
+  title: string
+  description: string
+  body: React.ReactNode
+}
+
+const STEPS: Step[] = [
+  {
+    key: 'template',
+    title: 'Pick a pricing template',
+    description: 'Start from one of the recipes that match common usage-billing shapes — or skip and build from scratch.',
+    body: (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {[
+          { name: 'anthropic_style', tag: 'AI inference', detail: 'Multi-dim tokens (model × operation × cached) + base subscription' },
+          { name: 'openai_style', tag: 'AI inference', detail: 'Per-token rates per model with prompt-cache discount' },
+          { name: 'replicate_style', tag: 'AI inference', detail: 'Per-second compute billed by GPU class' },
+          { name: 'b2b_saas_pro', tag: 'SaaS', detail: 'Per-seat base + usage overage with credit grant' },
+          { name: 'marketplace_gmv', tag: 'Marketplace', detail: 'Take rate on GMV with platform-fee floor' },
+          { name: 'blank', tag: 'Custom', detail: 'Empty product catalog. Build it yourself in the dashboard.' },
+        ].map(r => (
+          <button
+            key={r.name}
+            className="text-left rounded-lg border border-input p-4 hover:border-primary/40 hover:bg-muted/30 transition-colors"
+            disabled
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-sm text-foreground">{r.name}</span>
+              <span className="text-xs text-muted-foreground">{r.tag}</span>
+            </div>
+            <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">{r.detail}</p>
+          </button>
+        ))}
+      </div>
+    ),
+  },
+  {
+    key: 'stripe',
+    title: 'Connect Stripe (test mode)',
+    description: 'Velox uses Stripe for card payments via PaymentIntents. We never store card data — Stripe does that under the hood. Test mode keys are fine to start.',
+    body: (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Connect Stripe in <Link to="/settings" className="underline underline-offset-2 hover:text-foreground">Settings → Payments</Link>. You can switch from test to live keys later from the same screen.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Velox supports the PaymentIntents API only. We deliberately don't use Stripe Billing or Stripe Invoices — the 0.5% fee disappears, and you own the invoice lifecycle.
+        </p>
+      </div>
+    ),
+  },
+  {
+    key: 'tax',
+    title: 'Tax mode',
+    description: 'Pick how your tenant computes tax. Velox is tax-neutral — your Stripe account holds the registration (OIDAR / domestic GST / VAT / etc.).',
+    body: (
+      <p className="text-sm text-muted-foreground">
+        Tax settings live in <Link to="/settings" className="underline underline-offset-2 hover:text-foreground">Settings → Tax</Link>. Default is "no automatic tax" — you can switch to Stripe Tax once your account is registered in the relevant jurisdictions.
+      </p>
+    ),
+  },
+  {
+    key: 'branding',
+    title: 'Branding',
+    description: 'Your logo and primary color appear on hosted invoices and dunning emails. Customers see your brand, not Velox.',
+    body: (
+      <p className="text-sm text-muted-foreground">
+        Configure logo, accent color, and from-address in <Link to="/settings" className="underline underline-offset-2 hover:text-foreground">Settings → Branding</Link>.
+      </p>
+    ),
+  },
+  {
+    key: 'first-invoice',
+    title: 'Send your first test invoice',
+    description: 'Create a customer, attach a subscription, ingest a usage event, and finalize. Should take under a minute end-to-end.',
+    body: (
+      <div className="space-y-3">
+        <ol className="text-sm text-muted-foreground space-y-2 list-decimal list-inside">
+          <li>Create a customer at <Link to="/customers" className="underline underline-offset-2 hover:text-foreground">/customers</Link>.</li>
+          <li>Attach a subscription to the plan you instantiated above.</li>
+          <li>Ingest a usage event via the API or upload a CSV.</li>
+          <li>Trigger a billing run from <Link to="/invoices" className="underline underline-offset-2 hover:text-foreground">/invoices</Link>.</li>
+          <li>Open the resulting draft, finalize, and send.</li>
+        </ol>
+        <p className="text-xs text-muted-foreground">
+          Curl-only path: see the <Link to="/docs/quickstart" className="underline underline-offset-2 hover:text-foreground">CLI quickstart</Link>.
+        </p>
+      </div>
+    ),
+  },
+]
+
+export default function OnboardingPage() {
+  const [params, setParams] = useSearchParams()
+  const stepParam = params.get('step') || STEPS[0].key
+  const stepIndex = useMemo(() => {
+    const i = STEPS.findIndex(s => s.key === stepParam)
+    return i === -1 ? 0 : i
+  }, [stepParam])
+  const step = STEPS[stepIndex]
+
+  const goTo = (i: number) => {
+    const target = STEPS[Math.max(0, Math.min(STEPS.length - 1, i))]
+    const next = new URLSearchParams(params)
+    next.set('step', target.key)
+    setParams(next, { replace: false })
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center px-4 py-12">
+      <div className="w-full max-w-2xl">
+        {/* Top bar */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Get started with Velox</p>
+            <p className="text-sm text-muted-foreground mt-0.5">Step {stepIndex + 1} of {STEPS.length}</p>
+          </div>
+          <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+            Skip for now
+          </Link>
+        </div>
+
+        {/* Progress indicator */}
+        <div className="flex items-center gap-2 mb-8">
+          {STEPS.map((s, i) => {
+            const done = i < stepIndex
+            const active = i === stepIndex
+            return (
+              <button
+                key={s.key}
+                onClick={() => goTo(i)}
+                className={cn(
+                  'flex-1 h-1.5 rounded-full transition-colors',
+                  done && 'bg-primary',
+                  active && 'bg-primary',
+                  !done && !active && 'bg-muted',
+                )}
+                aria-label={`Go to step ${i + 1}: ${s.title}`}
+              />
+            )
+          })}
+        </div>
+
+        {/* Card */}
+        <Card>
+          <CardContent className="p-8">
+            <h1 className="text-2xl font-semibold text-foreground">{step.title}</h1>
+            <p className="text-sm text-muted-foreground mt-2 leading-relaxed">{step.description}</p>
+            <div className="mt-6">{step.body}</div>
+          </CardContent>
+        </Card>
+
+        {/* Nav */}
+        <div className="flex items-center justify-between mt-6">
+          <Button
+            variant="ghost"
+            onClick={() => goTo(stepIndex - 1)}
+            disabled={stepIndex === 0}
+          >
+            Back
+          </Button>
+          {stepIndex < STEPS.length - 1 ? (
+            <Button onClick={() => goTo(stepIndex + 1)}>
+              Continue
+              <ArrowRight size={14} className="ml-1.5" />
+            </Button>
+          ) : (
+            <Link to="/">
+              <Button>
+                <Check size={14} className="mr-1.5" />
+                Done — open dashboard
+              </Button>
+            </Link>
+          )}
+        </div>
+
+        {/* Step list */}
+        <div className="mt-10">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground mb-3">All steps</p>
+          <ol className="space-y-1.5">
+            {STEPS.map((s, i) => {
+              const done = i < stepIndex
+              const active = i === stepIndex
+              return (
+                <li key={s.key}>
+                  <button
+                    onClick={() => goTo(i)}
+                    className={cn(
+                      'w-full text-left flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
+                      active && 'bg-muted text-foreground',
+                      !active && 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                    )}
+                  >
+                    <span className={cn(
+                      'flex h-5 w-5 items-center justify-center rounded-full text-xs',
+                      done && 'bg-primary text-primary-foreground',
+                      active && 'border border-primary text-primary',
+                      !done && !active && 'border border-muted-foreground/30 text-muted-foreground',
+                    )}>
+                      {done ? <Check size={11} /> : i + 1}
+                    </span>
+                    {s.title}
+                  </button>
+                </li>
+              )
+            })}
+          </ol>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web-v2/src/pages/Onboarding.tsx
+++ b/web-v2/src/pages/Onboarding.tsx
@@ -1,9 +1,12 @@
 import { useMemo } from 'react'
 import { useSearchParams, Link } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
-import { Check, ArrowRight } from 'lucide-react'
+import { Check, ArrowRight, ExternalLink, CheckCircle2 } from 'lucide-react'
 
 interface Step {
   key: string
@@ -12,35 +15,93 @@ interface Step {
   body: React.ReactNode
 }
 
+function TemplateStepBody() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['recipes'],
+    queryFn: async () => {
+      try {
+        return await api.listRecipes()
+      } catch {
+        return { data: [] }
+      }
+    },
+  })
+  const recipes = data?.data ?? []
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {[0, 1, 2, 3].map(i => (
+          <div key={i} className="h-24 rounded-lg border border-input bg-muted/30 animate-pulse" />
+        ))}
+      </div>
+    )
+  }
+
+  if (recipes.length === 0) {
+    return (
+      <div className="rounded-lg border border-input p-5 text-center">
+        <p className="text-sm text-muted-foreground">
+          Pricing recipes ship with the Week 3 release. You can configure pricing manually in the meantime — head to{' '}
+          <Link to="/pricing" className="underline underline-offset-2 hover:text-foreground">Pricing</Link> to create meters and rating rules.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {recipes.map(r => {
+          const c = r.creates
+          const installed = !!r.instantiated
+          return (
+            <Link
+              key={r.key}
+              to={`/recipes`}
+              className={cn(
+                'block text-left rounded-lg border p-4 hover:border-primary/40 hover:bg-muted/30 transition-colors',
+                installed ? 'border-primary/40' : 'border-input',
+              )}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-mono text-sm text-foreground truncate">{r.key}</span>
+                {installed ? (
+                  <Badge variant="success" className="shrink-0">
+                    <CheckCircle2 size={11} className="mr-1" />
+                    Installed
+                  </Badge>
+                ) : (
+                  <span className="text-xs text-muted-foreground">v{r.version}</span>
+                )}
+              </div>
+              <p className="text-sm text-foreground mt-1 leading-snug">{r.name}</p>
+              <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed line-clamp-2">{r.summary}</p>
+              <div className="flex flex-wrap gap-1 mt-2.5 text-xs text-muted-foreground">
+                <span>{c.meters} meter{c.meters !== 1 ? 's' : ''}</span>
+                <span>·</span>
+                <span>{c.pricing_rules} pricing rule{c.pricing_rules !== 1 ? 's' : ''}</span>
+                <span>·</span>
+                <span>{c.plans} plan{c.plans !== 1 ? 's' : ''}</span>
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+      <Link to="/recipes" className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 mt-3 inline-flex items-center">
+        Open full recipe picker
+        <ExternalLink size={11} className="ml-1" />
+      </Link>
+    </div>
+  )
+}
+
 const STEPS: Step[] = [
   {
     key: 'template',
     title: 'Pick a pricing template',
-    description: 'Start from one of the recipes that match common usage-billing shapes — or skip and build from scratch.',
-    body: (
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {[
-          { name: 'anthropic_style', tag: 'AI inference', detail: 'Multi-dim tokens (model × operation × cached) + base subscription' },
-          { name: 'openai_style', tag: 'AI inference', detail: 'Per-token rates per model with prompt-cache discount' },
-          { name: 'replicate_style', tag: 'AI inference', detail: 'Per-second compute billed by GPU class' },
-          { name: 'b2b_saas_pro', tag: 'SaaS', detail: 'Per-seat base + usage overage with credit grant' },
-          { name: 'marketplace_gmv', tag: 'Marketplace', detail: 'Take rate on GMV with platform-fee floor' },
-          { name: 'blank', tag: 'Custom', detail: 'Empty product catalog. Build it yourself in the dashboard.' },
-        ].map(r => (
-          <button
-            key={r.name}
-            className="text-left rounded-lg border border-input p-4 hover:border-primary/40 hover:bg-muted/30 transition-colors"
-            disabled
-          >
-            <div className="flex items-center justify-between">
-              <span className="font-mono text-sm text-foreground">{r.name}</span>
-              <span className="text-xs text-muted-foreground">{r.tag}</span>
-            </div>
-            <p className="text-xs text-muted-foreground mt-1.5 leading-relaxed">{r.detail}</p>
-          </button>
-        ))}
-      </div>
-    ),
+    description: 'Start from one of the recipes that match common usage-billing shapes — or skip and build from scratch in Pricing.',
+    body: <TemplateStepBody />,
   },
   {
     key: 'stripe',

--- a/web-v2/src/pages/Recipes.tsx
+++ b/web-v2/src/pages/Recipes.tsx
@@ -1,0 +1,397 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { useNavigate } from 'react-router-dom'
+import { api, formatDateTime } from '@/lib/api'
+import type { Recipe, RecipeDetail, RecipeOverrideSchema, RecipePreview } from '@/lib/api'
+import { showApiError } from '@/lib/formErrors'
+import { Layout } from '@/components/Layout'
+
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { EmptyState } from '@/components/EmptyState'
+import { TableSkeleton } from '@/components/ui/TableSkeleton'
+
+import { Box, Loader2, Eye, Sparkles, AlertTriangle, CheckCircle2 } from 'lucide-react'
+
+export default function RecipesPage() {
+  const [selected, setSelected] = useState<Recipe | null>(null)
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['recipes'],
+    queryFn: async () => {
+      try {
+        return await api.listRecipes()
+      } catch {
+        return { data: [] }
+      }
+    },
+  })
+
+  const recipes = data?.data ?? []
+
+  return (
+    <Layout>
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Pricing recipes</h1>
+          <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
+            Start from a built-in pricing template that mirrors a known billing shape — Anthropic-style multi-dim tokens, OpenAI per-token, Replicate per-second compute, B2B SaaS with seats + overage, marketplace GMV. Each recipe creates products, meters, pricing rules, plans, dunning, and a webhook placeholder atomically.
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <Card className="mt-6">
+          <CardContent className="p-8 text-center">
+            <p className="text-sm text-destructive mb-3">{(error as Error).message}</p>
+            <Button variant="outline" size="sm" onClick={() => refetch()}>Retry</Button>
+          </CardContent>
+        </Card>
+      ) : isLoading ? (
+        <Card className="mt-6">
+          <CardContent className="p-0">
+            <TableSkeleton columns={3} />
+          </CardContent>
+        </Card>
+      ) : recipes.length === 0 ? (
+        <Card className="mt-6">
+          <CardContent className="p-0">
+            <EmptyState
+              icon={Box}
+              title="No recipes available yet"
+              description="Pricing recipes ship with the v0.x release of the recipes API (Week 3). Check back after the next deploy, or follow docs/design-recipes.md for the contract."
+            />
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+          {recipes.map(r => (
+            <RecipeCard key={r.key} recipe={r} onConfigure={() => setSelected(r)} />
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <RecipeDialog
+          recipe={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </Layout>
+  )
+}
+
+function RecipeCard({ recipe, onConfigure }: { recipe: Recipe; onConfigure: () => void }) {
+  const c = recipe.creates
+  const installed = !!recipe.instantiated
+
+  return (
+    <Card className={installed ? 'border-primary/40' : ''}>
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-sm text-foreground">{recipe.key}</span>
+              <span className="text-xs text-muted-foreground">v{recipe.version}</span>
+            </div>
+            <h3 className="text-base font-semibold text-foreground mt-1">{recipe.name}</h3>
+          </div>
+          {installed && (
+            <Badge variant="success" className="shrink-0">
+              <CheckCircle2 size={12} className="mr-1" />
+              Installed
+            </Badge>
+          )}
+        </div>
+
+        <p className="text-sm text-muted-foreground mt-3 leading-relaxed">{recipe.summary}</p>
+
+        <div className="flex flex-wrap gap-1.5 mt-4">
+          {c.meters > 0 && <Chip n={c.meters} label="meter" />}
+          {c.pricing_rules > 0 && <Chip n={c.pricing_rules} label="pricing rule" />}
+          {c.plans > 0 && <Chip n={c.plans} label="plan" />}
+          {c.products > 0 && <Chip n={c.products} label="product" />}
+          {c.rating_rules > 0 && <Chip n={c.rating_rules} label="rating rule" />}
+          {c.dunning_policies > 0 && <Chip n={c.dunning_policies} label="dunning policy" />}
+          {c.webhook_endpoints > 0 && <Chip n={c.webhook_endpoints} label="webhook" />}
+        </div>
+
+        {recipe.instantiated && (
+          <p className="text-xs text-muted-foreground mt-3">
+            Installed {formatDateTime(recipe.instantiated.instantiated_at)} · <span className="font-mono">{recipe.instantiated.id}</span>
+          </p>
+        )}
+
+        <div className="mt-5 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">
+            {recipe.overridable.length} override{recipe.overridable.length !== 1 ? 's' : ''} available
+          </span>
+          <Button size="sm" variant={installed ? 'outline' : 'default'} onClick={onConfigure}>
+            {installed ? 'View' : 'Configure'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function Chip({ n, label }: { n: number; label: string }) {
+  return (
+    <span className="inline-flex items-center text-xs font-medium bg-muted text-foreground px-2 py-0.5 rounded">
+      {n} {label}{n !== 1 ? 's' : ''}
+    </span>
+  )
+}
+
+function RecipeDialog({ recipe, onClose }: { recipe: Recipe; onClose: () => void }) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const [overrides, setOverrides] = useState<Record<string, string | number | boolean>>({})
+  const [seedSample, setSeedSample] = useState(false)
+  const [preview, setPreview] = useState<RecipePreview | null>(null)
+
+  const detailQuery = useQuery({
+    queryKey: ['recipe', recipe.key],
+    queryFn: async () => {
+      try {
+        return await api.getRecipe(recipe.key)
+      } catch {
+        return null as RecipeDetail | null
+      }
+    },
+  })
+  const detail = detailQuery.data
+
+  const previewMutation = useMutation({
+    mutationFn: () => api.previewRecipe(recipe.key, overrides),
+    onSuccess: (res) => setPreview(res),
+    onError: (err) => showApiError(err, 'Preview failed'),
+  })
+
+  const installMutation = useMutation({
+    mutationFn: () =>
+      api.instantiateRecipe({
+        key: recipe.key,
+        overrides,
+        seed_sample_data: seedSample,
+        force: false,
+      }),
+    onSuccess: (res) => {
+      toast.success(`Installed ${recipe.name}`)
+      queryClient.invalidateQueries({ queryKey: ['recipes'] })
+      onClose()
+      // Send the operator straight to the catalog — the new plan is the
+      // most likely next thing they want to look at.
+      if (res.created_objects.plan_ids.length > 0) {
+        navigate(`/plans/${res.created_objects.plan_ids[0]}`)
+      } else {
+        navigate('/pricing')
+      }
+    },
+    onError: (err) => showApiError(err, 'Install failed'),
+  })
+
+  const setOverride = (k: string, v: string | number | boolean) => {
+    setOverrides(prev => ({ ...prev, [k]: v }))
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Sparkles size={16} className="text-primary" />
+            {recipe.name}
+          </DialogTitle>
+          <DialogDescription>{recipe.summary}</DialogDescription>
+        </DialogHeader>
+
+        {detail?.description && (
+          <div className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line border-l-2 border-muted pl-3">
+            {detail.description}
+          </div>
+        )}
+
+        {/* Overrides */}
+        <div>
+          <Label className="text-xs uppercase tracking-wide text-muted-foreground">Overrides</Label>
+          {detail?.overridable_schema && Object.keys(detail.overridable_schema).length > 0 ? (
+            <div className="space-y-3 mt-2">
+              {Object.entries(detail.overridable_schema).map(([key, schema]) => (
+                <OverrideField
+                  key={key}
+                  fieldKey={key}
+                  schema={schema}
+                  value={overrides[key] ?? schema.default ?? ''}
+                  onChange={(v) => setOverride(key, v)}
+                />
+              ))}
+            </div>
+          ) : recipe.overridable.length > 0 ? (
+            <div className="space-y-3 mt-2">
+              {recipe.overridable.map(key => (
+                <OverrideField
+                  key={key}
+                  fieldKey={key}
+                  schema={{ type: 'string' }}
+                  value={overrides[key] ?? ''}
+                  onChange={(v) => setOverride(key, v)}
+                />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground mt-2">No overrides for this recipe.</p>
+          )}
+        </div>
+
+        {/* Sample data toggle */}
+        <div className="flex items-start justify-between gap-3 rounded-lg border border-input p-3">
+          <div>
+            <p className="text-sm font-medium text-foreground">Seed sample data</p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Creates one demo customer + one trialing subscription so usage flows immediately. Off by default to keep the workspace clean.
+            </p>
+          </div>
+          <Switch checked={seedSample} onCheckedChange={setSeedSample} />
+        </div>
+
+        {/* Preview */}
+        {preview && (
+          <div className="rounded-lg border border-input p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-foreground">Preview</p>
+              <span className="text-xs text-muted-foreground">v{preview.version}</span>
+            </div>
+
+            {preview.warnings.length > 0 && (
+              <div className="rounded bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 p-3">
+                <div className="flex items-center gap-2 text-amber-700 dark:text-amber-300 text-xs font-medium mb-1.5">
+                  <AlertTriangle size={12} />
+                  {preview.warnings.length} warning{preview.warnings.length !== 1 ? 's' : ''}
+                </div>
+                <ul className="text-xs text-amber-700 dark:text-amber-300 space-y-1">
+                  {preview.warnings.map((w, i) => <li key={i}>· {w}</li>)}
+                </ul>
+              </div>
+            )}
+
+            <ObjectsList preview={preview} />
+          </div>
+        )}
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button
+            variant="outline"
+            onClick={() => previewMutation.mutate()}
+            disabled={previewMutation.isPending}
+          >
+            {previewMutation.isPending ? <Loader2 size={14} className="mr-1.5 animate-spin" /> : <Eye size={14} className="mr-1.5" />}
+            Preview
+          </Button>
+          <Button
+            onClick={() => installMutation.mutate()}
+            disabled={installMutation.isPending || !!recipe.instantiated}
+          >
+            {installMutation.isPending ? <Loader2 size={14} className="mr-1.5 animate-spin" /> : <Sparkles size={14} className="mr-1.5" />}
+            {recipe.instantiated ? 'Already installed' : 'Install recipe'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function OverrideField({
+  fieldKey,
+  schema,
+  value,
+  onChange,
+}: {
+  fieldKey: string
+  schema: RecipeOverrideSchema
+  value: string | number | boolean
+  onChange: (v: string | number | boolean) => void
+}) {
+  if (schema.type === 'boolean') {
+    return (
+      <div className="flex items-center justify-between">
+        <Label htmlFor={`override-${fieldKey}`} className="font-mono text-sm">{fieldKey}</Label>
+        <Switch
+          id={`override-${fieldKey}`}
+          checked={!!value}
+          onCheckedChange={onChange}
+        />
+      </div>
+    )
+  }
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <Label htmlFor={`override-${fieldKey}`} className="font-mono text-sm">{fieldKey}</Label>
+        {schema.description && <span className="text-xs text-muted-foreground">{schema.description}</span>}
+      </div>
+      <Input
+        id={`override-${fieldKey}`}
+        type={schema.type === 'number' ? 'number' : 'text'}
+        value={String(value)}
+        onChange={(e) => {
+          const raw = e.target.value
+          onChange(schema.type === 'number' ? Number(raw) : raw)
+        }}
+        className="mt-1.5 font-mono"
+      />
+    </div>
+  )
+}
+
+function ObjectsList({ preview }: { preview: RecipePreview }) {
+  const sections: { label: string; items: string[] }[] = []
+  if (preview.objects.products?.length) sections.push({ label: 'Products', items: preview.objects.products.map(p => p.name) })
+  if (preview.objects.meters?.length) sections.push({ label: 'Meters', items: preview.objects.meters.map(m => `${m.name} (${m.aggregation})`) })
+  if (preview.objects.rating_rules?.length) sections.push({ label: 'Rating rules', items: preview.objects.rating_rules.map(r => `${r.rule_key} · ${r.mode}`) })
+  if (preview.objects.pricing_rules?.length) sections.push({
+    label: 'Pricing rules',
+    items: preview.objects.pricing_rules.map(r => {
+      const dims = Object.entries(r.dimension_match).map(([k, v]) => `${k}=${v}`).join(', ')
+      return `${r.meter_key} → ${r.rating_rule_key} (${dims || 'all events'}, ${r.aggregation_mode}, p${r.priority})`
+    }),
+  })
+  if (preview.objects.plans?.length) sections.push({ label: 'Plans', items: preview.objects.plans.map(p => `${p.name} (${p.billing_interval}, ${p.currency})`) })
+  if (preview.objects.dunning_policies?.length) sections.push({ label: 'Dunning policies', items: preview.objects.dunning_policies.map(d => `${d.name} (${d.max_retries} retries)`) })
+  if (preview.objects.webhook_endpoints?.length) sections.push({ label: 'Webhook endpoints', items: preview.objects.webhook_endpoints.map(w => `${w.url}${w._placeholder ? ' (placeholder)' : ''}`) })
+
+  if (sections.length === 0) {
+    return <p className="text-xs text-muted-foreground">No objects to preview.</p>
+  }
+
+  return (
+    <div className="space-y-2.5">
+      {sections.map(s => (
+        <div key={s.label}>
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-1">{s.label}</p>
+          <ul className="text-xs text-foreground space-y-0.5 font-mono">
+            {s.items.slice(0, 5).map((it, i) => <li key={i}>· {it}</li>)}
+            {s.items.length > 5 && (
+              <li className="text-muted-foreground">… and {s.items.length - 5} more</li>
+            )}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web-v2/src/pages/UsageEvents.tsx
+++ b/web-v2/src/pages/UsageEvents.tsx
@@ -39,9 +39,10 @@ export default function UsageEventsPage() {
     meter: '',
     from: '',
     to: '',
+    dim: '',
     page: '1',
   })
-  const { customer: filterCustomer, meter: filterMeter, from: filterFrom, to: filterTo } = urlState
+  const { customer: filterCustomer, meter: filterMeter, from: filterFrom, to: filterTo, dim: filterDim } = urlState
   const page = Math.max(1, parseInt(urlState.page) || 1)
   const [events, setEvents] = useState<UsageEvent[]>([])
   const [total, setTotal] = useState(0)
@@ -84,18 +85,37 @@ export default function UsageEventsPage() {
     if (filterMeter) parts.push(`meter_id=${filterMeter}`)
     if (filterFrom) parts.push(`from=${new Date(filterFrom).toISOString()}`)
     if (filterTo) parts.push(`to=${new Date(filterTo + 'T23:59:59').toISOString()}`)
+    if (filterDim) parts.push(`dimensions=${encodeURIComponent(filterDim)}`)
     const params = parts.join('&')
     api.listUsageEvents(params)
       .then(res => { setEvents(res.data || []); setTotal(res.total || 0); setLoading(false) })
       .catch(err => { setError(err instanceof Error ? err.message : 'Failed to load usage events'); setEvents([]); setTotal(0); setLoading(false) })
-  }, [page, filterCustomer, filterMeter, filterFrom, filterTo])
+  }, [page, filterCustomer, filterMeter, filterFrom, filterTo, filterDim])
 
   useEffect(() => { loadEvents() }, [loadEvents])
+
+  // Prefer the decimal-precision `value` field once it lands (multi-dim meters
+  // ship May 8); fall back to the legacy integer `quantity` for older events.
+  const eventValue = (e: UsageEvent): number => {
+    if (e.value !== undefined && e.value !== null && e.value !== '') {
+      const n = Number(e.value)
+      if (!Number.isNaN(n)) return n
+    }
+    return e.quantity
+  }
+
+  // Show the dimensions column + filter only when at least one event in the
+  // current page actually carries dimensions, OR when a dimension filter is
+  // set. Pre-multi-dim tenants stay visually clean.
+  const hasDimensions = useMemo(
+    () => events.some(e => e.dimensions && Object.keys(e.dimensions).length > 0) || !!filterDim,
+    [events, filterDim],
+  )
 
   // Computed stats from current page data
   const stats = useMemo(() => {
     const totalEvents = total
-    const totalUnits = events.reduce((sum, e) => sum + e.quantity, 0)
+    const totalUnits = events.reduce((sum, e) => sum + eventValue(e), 0)
     const activeMeters = new Set(events.map(e => e.meter_id)).size
     const activeCustomers = new Set(events.map(e => e.customer_id)).size
     return { totalEvents, totalUnits, activeMeters, activeCustomers }
@@ -105,7 +125,7 @@ export default function UsageEventsPage() {
   const meterBreakdown = useMemo(() => {
     const grouped: Record<string, number> = {}
     for (const e of events) {
-      grouped[e.meter_id] = (grouped[e.meter_id] || 0) + e.quantity
+      grouped[e.meter_id] = (grouped[e.meter_id] || 0) + eventValue(e)
     }
     const grandTotal = Object.values(grouped).reduce((a, b) => a + b, 0)
     return Object.entries(grouped)
@@ -127,15 +147,17 @@ export default function UsageEventsPage() {
     if (filterMeter) parts.push(`meter_id=${filterMeter}`)
     if (filterFrom) parts.push(`from=${new Date(filterFrom).toISOString()}`)
     if (filterTo) parts.push(`to=${new Date(filterTo + 'T23:59:59').toISOString()}`)
+    if (filterDim) parts.push(`dimensions=${encodeURIComponent(filterDim)}`)
     const exportParams = parts.length > 0 ? parts.join('&') : undefined
     api.listUsageEvents(exportParams).then(res => {
       const rows = (res.data || []).map(ev => [
         formatDateTime(ev.timestamp),
         customerMap[ev.customer_id]?.display_name || ev.customer_id,
         meterMap[ev.meter_id]?.name || ev.meter_id,
-        String(ev.quantity),
+        ev.value ?? String(ev.quantity),
+        ev.dimensions && Object.keys(ev.dimensions).length > 0 ? JSON.stringify(ev.dimensions) : '',
       ])
-      downloadCSV('usage-events.csv', ['Timestamp', 'Customer', 'Meter', 'Quantity'], rows)
+      downloadCSV('usage-events.csv', ['Timestamp', 'Customer', 'Meter', 'Value', 'Dimensions'], rows)
     })
   }
 
@@ -195,6 +217,13 @@ export default function UsageEventsPage() {
           onChange={v => setUrlState({ to: v, page: '1' })}
           placeholder="To date"
           className="w-44"
+        />
+        <input
+          type="text"
+          value={filterDim}
+          onChange={(e) => setUrlState({ dim: e.target.value, page: '1' })}
+          placeholder="dimension (e.g. model=gpt-4)"
+          className="flex h-9 w-56 rounded-md border border-input bg-transparent px-3 py-1 text-sm font-mono shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring placeholder:text-muted-foreground placeholder:font-sans"
         />
       </div>
 
@@ -276,24 +305,45 @@ export default function UsageEventsPage() {
                     <TableHead className="text-xs font-medium">Timestamp</TableHead>
                     <TableHead className="text-xs font-medium">Customer</TableHead>
                     <TableHead className="text-xs font-medium">Meter</TableHead>
-                    <TableHead className="text-xs font-medium text-right">Quantity</TableHead>
+                    {hasDimensions && <TableHead className="text-xs font-medium">Dimensions</TableHead>}
+                    <TableHead className="text-xs font-medium text-right">Value</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {events.map(ev => (
-                    <TableRow key={ev.id}>
-                      <TableCell className="text-sm text-foreground">{formatDateTime(ev.timestamp)}</TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {customerMap[ev.customer_id]?.display_name || ev.customer_id.slice(0, 8) + '...'}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {meterMap[ev.meter_id]?.name || ev.meter_id.slice(0, 8) + '...'}
-                      </TableCell>
-                      <TableCell className={cn('text-sm font-medium text-right tabular-nums', ev.quantity < 0 ? 'text-destructive' : 'text-foreground')}>
-                        {ev.quantity < 0 ? '' : '+'}{ev.quantity.toLocaleString()}
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {events.map(ev => {
+                    const v = eventValue(ev)
+                    const display = ev.value ?? v.toLocaleString()
+                    const dims = ev.dimensions && Object.keys(ev.dimensions).length > 0 ? ev.dimensions : null
+                    return (
+                      <TableRow key={ev.id}>
+                        <TableCell className="text-sm text-foreground">{formatDateTime(ev.timestamp)}</TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {customerMap[ev.customer_id]?.display_name || ev.customer_id.slice(0, 8) + '...'}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {meterMap[ev.meter_id]?.name || ev.meter_id.slice(0, 8) + '...'}
+                        </TableCell>
+                        {hasDimensions && (
+                          <TableCell>
+                            {dims ? (
+                              <div className="flex flex-wrap gap-1">
+                                {Object.entries(dims).map(([k, val]) => (
+                                  <span key={k} className="inline-flex items-center text-xs font-mono bg-muted px-1.5 py-0.5 rounded">
+                                    {k}=<span className="text-foreground">{String(val)}</span>
+                                  </span>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                        )}
+                        <TableCell className={cn('text-sm font-medium text-right tabular-nums', v < 0 ? 'text-destructive' : 'text-foreground')}>
+                          {v < 0 ? '' : '+'}{display}
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
                 </TableBody>
               </Table>
 

--- a/web-v2/src/pages/UsageEvents.tsx
+++ b/web-v2/src/pages/UsageEvents.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { api, formatDateTime } from '@/lib/api'
+import { api, formatDateTime, eventDimensions } from '@/lib/api'
 import type { Customer, Meter, UsageEvent } from '@/lib/api'
 import { downloadCSV } from '@/lib/csv'
 import { Layout } from '@/components/Layout'
@@ -106,7 +106,7 @@ export default function UsageEventsPage() {
   // current page actually carries dimensions, OR when a dimension filter is
   // set. Pre-multi-dim tenants stay visually clean.
   const hasDimensions = useMemo(
-    () => events.some(e => e.dimensions && Object.keys(e.dimensions).length > 0) || !!filterDim,
+    () => events.some(e => eventDimensions(e) !== undefined) || !!filterDim,
     [events, filterDim],
   )
 
@@ -153,7 +153,7 @@ export default function UsageEventsPage() {
         customerMap[ev.customer_id]?.display_name || ev.customer_id,
         meterMap[ev.meter_id]?.name || ev.meter_id,
         ev.quantity,
-        ev.dimensions && Object.keys(ev.dimensions).length > 0 ? JSON.stringify(ev.dimensions) : '',
+        eventDimensions(ev) ? JSON.stringify(eventDimensions(ev)) : '',
       ])
       downloadCSV('usage-events.csv', ['Timestamp', 'Customer', 'Meter', 'Value', 'Dimensions'], rows)
     })
@@ -314,7 +314,7 @@ export default function UsageEventsPage() {
                     // — losing trailing zeros via toLocaleString hides the
                     // distinction between "1.5" and "1.500000000000".
                     const display = ev.quantity
-                    const dims = ev.dimensions && Object.keys(ev.dimensions).length > 0 ? ev.dimensions : null
+                    const dims = eventDimensions(ev) ?? null
                     return (
                       <TableRow key={ev.id}>
                         <TableCell className="text-sm text-foreground">{formatDateTime(ev.timestamp)}</TableCell>

--- a/web-v2/src/pages/UsageEvents.tsx
+++ b/web-v2/src/pages/UsageEvents.tsx
@@ -94,14 +94,12 @@ export default function UsageEventsPage() {
 
   useEffect(() => { loadEvents() }, [loadEvents])
 
-  // Prefer the decimal-precision `value` field once it lands (multi-dim meters
-  // ship May 8); fall back to the legacy integer `quantity` for older events.
-  const eventValue = (e: UsageEvent): number => {
-    if (e.value !== undefined && e.value !== null && e.value !== '') {
-      const n = Number(e.value)
-      if (!Number.isNaN(n)) return n
-    }
-    return e.quantity
+  // `quantity` is wire-encoded as a string (NUMERIC(38, 12)) for decimal
+  // precision; coerce to number for chart math + stats only. Authoritative
+  // money math stays server-side.
+  const eventQuantity = (e: UsageEvent): number => {
+    const n = Number(e.quantity)
+    return Number.isNaN(n) ? 0 : n
   }
 
   // Show the dimensions column + filter only when at least one event in the
@@ -115,7 +113,7 @@ export default function UsageEventsPage() {
   // Computed stats from current page data
   const stats = useMemo(() => {
     const totalEvents = total
-    const totalUnits = events.reduce((sum, e) => sum + eventValue(e), 0)
+    const totalUnits = events.reduce((sum, e) => sum + eventQuantity(e), 0)
     const activeMeters = new Set(events.map(e => e.meter_id)).size
     const activeCustomers = new Set(events.map(e => e.customer_id)).size
     return { totalEvents, totalUnits, activeMeters, activeCustomers }
@@ -125,7 +123,7 @@ export default function UsageEventsPage() {
   const meterBreakdown = useMemo(() => {
     const grouped: Record<string, number> = {}
     for (const e of events) {
-      grouped[e.meter_id] = (grouped[e.meter_id] || 0) + eventValue(e)
+      grouped[e.meter_id] = (grouped[e.meter_id] || 0) + eventQuantity(e)
     }
     const grandTotal = Object.values(grouped).reduce((a, b) => a + b, 0)
     return Object.entries(grouped)
@@ -154,7 +152,7 @@ export default function UsageEventsPage() {
         formatDateTime(ev.timestamp),
         customerMap[ev.customer_id]?.display_name || ev.customer_id,
         meterMap[ev.meter_id]?.name || ev.meter_id,
-        ev.value ?? String(ev.quantity),
+        ev.quantity,
         ev.dimensions && Object.keys(ev.dimensions).length > 0 ? JSON.stringify(ev.dimensions) : '',
       ])
       downloadCSV('usage-events.csv', ['Timestamp', 'Customer', 'Meter', 'Value', 'Dimensions'], rows)
@@ -311,8 +309,11 @@ export default function UsageEventsPage() {
                 </TableHeader>
                 <TableBody>
                   {events.map(ev => {
-                    const v = eventValue(ev)
-                    const display = ev.value ?? v.toLocaleString()
+                    const v = eventQuantity(ev)
+                    // Render the raw string to preserve full decimal precision
+                    // — losing trailing zeros via toLocaleString hides the
+                    // distinction between "1.5" and "1.500000000000".
+                    const display = ev.quantity
                     const dims = ev.dimensions && Object.keys(ev.dimensions).length > 0 ? ev.dimensions : null
                     return (
                       <TableRow key={ev.id}>


### PR DESCRIPTION
## Summary

Track B's Week 2 frontend work, rebased onto main after PR #19 + PR #21 landed.

- **MeterDetail page**: multi-dim pricing rules section (list/add/delete) wired to `/v1/meters/{id}/pricing-rules`
- **UsageEvents page**: surfaces `dimensions` column + filter
- **/recipes picker**: full recipes catalog UI wired to live recipes API (currently 404s — Week 3 backend work)
- **/onboarding wizard**: 5-step quickstart scaffold
- **Wire alignment**: drops legacy `value` alias; quantity is canonical decimal string
- **Defensive `properties` alias**: tolerates response-side `properties` for backward compat (will be dropped next slice now that PR #21 renamed to `dimensions`)
- **Handoff log**: Track B end-of-Week-2 + post-#20 smoke test findings

Frontend-only diff; no backend code touched.

## Test plan

- [x] Local rebase clean against current main (Week 1 commits auto-skipped as already applied)
- [x] `go build ./...` clean (no backend impact)
- [ ] CI green (frontend lint/typecheck)
- [ ] Live smoke test against backend after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)