### PR TITLE
feat(web): sidebar nav for /recipes + drop properties alias

### DIFF
--- a/web-v2/src/components/Layout.tsx
+++ b/web-v2/src/components/Layout.tsx
@@ -38,6 +38,7 @@ const billingNav = [
 
 const configNav = [
   { to: '/pricing', icon: Tag, label: 'Pricing' },
+  { to: '/recipes', icon: Sparkles, label: 'Recipes' },
   { to: '/coupons', icon: Ticket, label: 'Coupons' },
   { to: '/credits', icon: Wallet, label: 'Credits' },
   { to: '/credit-notes', icon: Receipt, label: 'Credit Notes' },

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -606,21 +606,11 @@ export interface UsageEvent {
   // String-encoded NUMERIC(38, 12) — decimal precision for fractional GPU-hours
   // and partial tokens. Coerce via Number() / parseFloat() at display time.
   quantity: string
-  // Free-form dimensions per docs/design-multi-dim-meters.md (subset-matched
-  // by pricing rules). Backend currently serializes the same JSONB column as
-  // `properties` on responses; UI reads either via `eventDimensions()`.
+  // Free-form dimensions per docs/design-multi-dim-meters.md, subset-matched
+  // by pricing rules.
   dimensions?: Record<string, string | number | boolean>
-  properties?: Record<string, string | number | boolean>
   idempotency_key: string
   timestamp: string
-}
-
-export function eventDimensions(
-  e: UsageEvent,
-): Record<string, string | number | boolean> | undefined {
-  if (e.dimensions && Object.keys(e.dimensions).length > 0) return e.dimensions
-  if (e.properties && Object.keys(e.properties).length > 0) return e.properties
-  return undefined
 }
 
 export type MeterAggregationMode =

--- a/web-v2/src/pages/UsageEvents.tsx
+++ b/web-v2/src/pages/UsageEvents.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { api, formatDateTime, eventDimensions } from '@/lib/api'
+import { api, formatDateTime } from '@/lib/api'
 import type { Customer, Meter, UsageEvent } from '@/lib/api'
 import { downloadCSV } from '@/lib/csv'
 import { Layout } from '@/components/Layout'
@@ -106,7 +106,7 @@ export default function UsageEventsPage() {
   // current page actually carries dimensions, OR when a dimension filter is
   // set. Pre-multi-dim tenants stay visually clean.
   const hasDimensions = useMemo(
-    () => events.some(e => eventDimensions(e) !== undefined) || !!filterDim,
+    () => events.some(e => e.dimensions && Object.keys(e.dimensions).length > 0) || !!filterDim,
     [events, filterDim],
   )
 
@@ -153,7 +153,7 @@ export default function UsageEventsPage() {
         customerMap[ev.customer_id]?.display_name || ev.customer_id,
         meterMap[ev.meter_id]?.name || ev.meter_id,
         ev.quantity,
-        eventDimensions(ev) ? JSON.stringify(eventDimensions(ev)) : '',
+        ev.dimensions && Object.keys(ev.dimensions).length > 0 ? JSON.stringify(ev.dimensions) : '',
       ])
       downloadCSV('usage-events.csv', ['Timestamp', 'Customer', 'Meter', 'Value', 'Dimensions'], rows)
     })
@@ -314,7 +314,7 @@ export default function UsageEventsPage() {
                     // — losing trailing zeros via toLocaleString hides the
                     // distinction between "1.5" and "1.500000000000".
                     const display = ev.quantity
-                    const dims = eventDimensions(ev) ?? null
+                    const dims = ev.dimensions && Object.keys(ev.dimensions).length > 0 ? ev.dimensions : null
                     return (
                       <TableRow key={ev.id}>
                         <TableCell className="text-sm text-foreground">{formatDateTime(ev.timestamp)}</TableCell>


### PR DESCRIPTION
## Summary

Two follow-ups on top of PR #22's Track B Week 2 work, both cleanups:

1. **Sidebar entry for /recipes** — the picker page shipped in PR #22 but had no discoverable entry point. Adds a "Recipes" nav item between Pricing and Coupons (Sparkles icon, Configuration group).
2. **Drop the properties→dimensions alias** — PR #21 made `dimensions` the canonical response field. The defensive `properties` alias and `eventDimensions()` helper added during the rename window are now dead code; removed both. UsageEvent carries a single canonical `dimensions` field both directions.

23 lines across 3 files. No backend changes.

## Test plan

- [ ] CI green (vite build + tsc -b)
- [ ] /recipes accessible from sidebar after merge
- [ ] UsageEvents page still renders dimensions on usage rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)