### PR TITLE
fix(recipes): snake_case JSON + creates summary + preview wrapper, plus Week 5 RFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,36 @@ Two surfaces mirror this file:
 
 ### Fixed
 
+- **Recipes API wire shape — snake_case + creates summary + preview wrapper**
+  (2026-04-26) — three drifts between `docs/design-recipes.md` and the
+  Week 3 implementation surfaced during Track B's first integration
+  pass and are now fixed. `domain.Recipe` was missing `json:"…"` tags
+  on its top-level fields, so `GET /v1/recipes`, `GET
+  /v1/recipes/{key}`, and `POST /v1/recipes/{key}/preview` were
+  emitting PascalCase keys (`Key`, `Version`, `Meters`,
+  `RatingRules`, `DunningPolicy`, …) inconsistent with the rest of
+  `/v1/*`; tags added with `omitempty` on `description` /
+  `dunning_policy` / `webhook` to keep wire output tight when
+  recipes don't declare those sections. `SampleData` is now `json:"-"`
+  — it's a seed hint for `seed_sample_data=true`, not part of the
+  public API surface. `RecipeListItem` and the new
+  `RecipeDetail` wrapper carry a `creates: {meters, rating_rules,
+  pricing_rules, plans, dunning_policies, webhook_endpoints}` count
+  object so the picker UI renders summary chips ("1 meter · 9
+  pricing rules · monthly billing") without a follow-up preview
+  call. `Service.Preview` now returns
+  `PreviewResult{key, version, objects: {…}, warnings: []}` per the
+  design spec — previously it inlined every object array at the top
+  level. `objects.dunning_policies` and `objects.webhook_endpoints`
+  are 0-or-1-length slices for uniform iteration, all object slices
+  default to non-nil so JSON emits `[]` not `null`, and `warnings`
+  is the same shape recipes.preview spec'd for non-fatal conditions
+  (currency-vs-Stripe-account mismatch, placeholder webhook URLs) —
+  empty array in v1, slot in place. New `TestWireShape_SnakeCase`
+  unit test pins all three contracts so future regressions trip CI
+  before reaching the dashboard. No behavior change to
+  `Instantiate` / `Uninstall`; data shape only.
+
 - **Hosted invoice Checkout metadata** — `velox_invoice_id` is now
   propagated to both the Checkout Session and the underlying
   PaymentIntent, so `payment_intent.succeeded` webhooks route hosted-

--- a/docs/design-customer-usage.md
+++ b/docs/design-customer-usage.md
@@ -1,0 +1,261 @@
+# Customer Usage Endpoint — Technical Design
+
+> **Status:** Draft v1
+> **Owner:** Track A
+> **Last revised:** 2026-04-26
+> **Implementation window:** Week 5 of `docs/90-day-plan.md`
+> **Related:** `docs/design-multi-dim-meters.md` (Week 2 dependency), `docs/design-recipes.md` (Week 3 — same wire-contract conventions), `docs/positioning.md` pillar 1.4 (cost transparency)
+
+## Motivation
+
+A buyer evaluating Velox asks the same question on day one: "How do I show a customer their current usage and what they'll be charged?" Stripe Billing's answer is a hosted Customer Portal page — but that's locked to Stripe Billing, which Velox does not use (per ADR on PaymentIntent-only). Buyers self-hosting Velox today have no first-party answer; they hand-roll a SQL query against `usage_events` and pray the dimension-match logic stays in sync with their pricing rules.
+
+This is the second flagship developer-experience surface, alongside recipes. Where recipes collapse "set up billing" to one POST, **`GET /v1/customers/{id}/usage` collapses "show me what this customer used and owes" to one GET**. The Track B cost-dashboard scaffold (Week 5) is the in-product manifestation; the API itself unblocks every operator who needs the same data in their own portal, in Slack alerts, in CSV exports.
+
+The dimension-match-aware aggregation is the part that can't be hand-rolled: the rules-ranked LATERAL JOIN in `internal/usage/postgres.go:236–279` is non-trivial, and any external SQL would silently drift from canonical pricing the moment a tenant adds a `meter_pricing_rule`. This endpoint is the supported way to get the right answer.
+
+This design ships in Week 5 and depends on Week 2 multi-dim meters (schema + aggregation already shipped) plus Week 4 invoice-line-item fan-out (so we can distinguish billed vs. not-yet-billed usage).
+
+## Goals
+
+- **One call answers "what did this customer use?"** Per-meter aggregates over a caller-chosen window, with the same dimension-match → rating-rule binding the cycle scan uses. Operators read the same numbers their invoices will. No SQL drift.
+- **Cost transparency on the same response.** Each per-meter (and per-rule, for multi-dim) line includes the rated `amount_cents` so dashboards render `$12.34 — 1.2M tokens · gpt-4 input · uncached` without a second pricing call.
+- **Period defaults to current billing cycle.** With no query params, returns the live customer's current cycle so the obvious dashboard call is the cheapest one to write. `?from=…&to=…` overrides for historical / arbitrary windows (last-90d, audit, etc.).
+- **Subscription context co-emitted.** Response includes the plan(s) the customer is on plus the cycle boundaries, so a dashboard can render "Plan: AI API Pro · cycle Apr 1 → May 1 · 87% through" without follow-up calls.
+- **RLS-safe.** All queries scope through `BeginTx(ctx, postgres.TxTenant, tenantID)`; the response cannot leak across tenants even when an operator passes a customer ID from another tenant — the lookup just 404s.
+- **Cheap.** Constant-bounded SQL (one aggregate per meter on the customer's plans). No event-by-event scan in the hot path. Live dashboards refresh every few seconds without melting the DB.
+- **Documented contract Track B mocks against today.** This is the API Track B's cost-dashboard scaffold (Week 5) and the eventual portal surface call.
+
+## Non-goals (deferred)
+
+- **Time-series breakdown.** v1 returns aggregates over the window, not per-day buckets. The dashboard's first iteration is "current period total + last period total + plan boundary"; sparkline data lands in v2. Postgres aggregation by `date_trunc('day', timestamp)` is cheap when needed — we just don't wire it yet.
+- **Forecast / projection.** "At current rate, this customer will use 3.4M tokens by cycle end." Pure UI math on top of the v1 response. Punt.
+- **Cross-customer rollups.** No "top customers by usage" query. Use the `/v1/usage-events` list endpoint with appropriate filters; or, when a real user need shows up, design `GET /v1/usage/top-customers` separately. This endpoint is per-customer.
+- **Threshold alerts.** "Notify me when this customer hits 80% of plan cap." Webhook concern (`usage.threshold_crossed`) — owned by the dunning/notification surface, not this endpoint. Defer to Week 6+.
+- **Past-cycle line-item replay.** v1 returns aggregates, not the canonical `invoice_line_items` rows for closed cycles. The latter is what `GET /v1/invoices/{id}` already serves; no double-implementation here.
+- **Currency conversion.** Amounts are returned in the plan's currency. If a tenant has multi-currency plans, each line carries its own `currency` field; clients render whichever they need.
+
+## Today's surface (in repo)
+
+- `internal/usage/store.go::AggregateForBillingPeriod(ctx, tenantID, customerID, meterIDs, from, to)` — already returns `map[string]decimal.Decimal` per meter. Multi-dim aware via `meter_pricing_rules` LATERAL JOIN (`internal/usage/postgres.go:236–279`).
+- `internal/customer/store.go::Get(ctx, tenantID, id)` — RLS-safe customer lookup.
+- `internal/subscription/store.go::List(ctx, tenantID, filter)` — list active subs for a customer (filter by `customer_id`).
+- `internal/domain/pricing.go::ComputeAmountCents(rule RatingRuleVersion, quantity decimal.Decimal)` — pricing engine; same path the cycle scan calls.
+- `internal/billing/engine` — orchestrates cycle scan; reads the same store layer this endpoint composes from. The cycle scan is the canonical reference for "how to rate a customer's events", and this design intentionally reuses the same store calls.
+
+This endpoint is **composition, not new aggregation logic**. The hard SQL already exists. The win is exposing it on a stable wire contract so operators (and Track B's dashboard) don't reinvent it.
+
+## API surface
+
+> **Wire-contract conventions** (consistent with `/v1/*`, see `docs/design-recipes.md` § wire-contract):
+>
+> - **Snake-case JSON keys**, struct-tag enforced. Picker-side TS types match.
+> - **Customer identity is the customer ID** (`vlx_cus_…`), not external ID. Use `?external_id=` if you need external-ID lookup; defer for v2 or wrap as a separate endpoint.
+> - **Period bounds are RFC 3339** (`?from=2026-04-01T00:00:00Z&to=2026-05-01T00:00:00Z`). Both inclusive of `from`, exclusive of `to`. If only `from` is supplied → 400 (we don't guess "to=now"). If both omitted → defaults to the customer's current billing cycle.
+> - **Empty results are `[]`, never `null`.** Aligns with the existing list endpoints.
+
+### `GET /v1/customers/{id}/usage` — current cycle (default)
+
+```http
+GET /v1/customers/vlx_cus_abc123/usage
+Authorization: Bearer <secret_key>
+```
+
+Response `200`:
+```json
+{
+  "customer_id": "vlx_cus_abc123",
+  "period": {
+    "from": "2026-04-01T00:00:00Z",
+    "to": "2026-05-01T00:00:00Z",
+    "source": "current_billing_cycle"
+  },
+  "subscriptions": [
+    {
+      "id": "vlx_sub_xyz",
+      "plan_id": "vlx_pln_pro",
+      "plan_name": "AI API Pro",
+      "currency": "USD",
+      "current_period_start": "2026-04-01T00:00:00Z",
+      "current_period_end": "2026-05-01T00:00:00Z"
+    }
+  ],
+  "meters": [
+    {
+      "meter_id": "vlx_mtr_tokens",
+      "meter_key": "tokens",
+      "meter_name": "Tokens",
+      "unit": "tokens",
+      "currency": "USD",
+      "total_quantity": "1234567.000000000000",
+      "total_amount_cents": 3704,
+      "rules": [
+        {
+          "rating_rule_version_id": "vlx_rrv_gpt4_input_uncached",
+          "rule_key": "gpt4_input_uncached",
+          "dimension_match": { "model": "gpt-4", "operation": "input", "cached": false },
+          "quantity": "1000000.000000000000",
+          "amount_cents": 3000
+        },
+        {
+          "rating_rule_version_id": "vlx_rrv_gpt4_output",
+          "rule_key": "gpt4_output",
+          "dimension_match": { "model": "gpt-4", "operation": "output" },
+          "quantity": "234567.000000000000",
+          "amount_cents": 704
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "amount_cents": 3704,
+    "currency": "USD"
+  },
+  "warnings": []
+}
+```
+
+`rules` is the per-rule breakdown for multi-dim meters; for a flat single-rule meter the slice is length 1 with no `dimension_match`. `total_quantity` is the sum across rules; `total_amount_cents` is the sum across rules' `amount_cents`. Multi-currency plans (rare) emit one entry per currency under `meters` with `currency` set; `totals` becomes a list of `{currency, amount_cents}` rather than a scalar.
+
+`warnings` is the same shape as recipes' preview warnings — non-fatal conditions (a meter has events outside any rule's `dimension_match` and is falling through to the meter's default aggregation; a subscription is past its cycle end and a re-cycle hasn't run; `currency` mismatch between subscription and rating rule). Empty array in v1 if everything is clean.
+
+### `GET /v1/customers/{id}/usage?from=…&to=…` — explicit window
+
+```http
+GET /v1/customers/vlx_cus_abc123/usage?from=2026-01-01T00:00:00Z&to=2026-04-01T00:00:00Z
+Authorization: Bearer <secret_key>
+```
+
+Same response shape; `period.source` is `"explicit"`. `subscriptions` reflects whatever was active during any portion of the window; if the customer changed plans mid-window, both plans surface (sorted by `current_period_start` ascending).
+
+### Error shapes
+
+- `404 customer_not_found` — no customer with this ID for the tenant. Same shape as other `/v1/customers/{id}` 404s.
+- `400 invalid_period` — `from` after `to`, partial bounds (`from` without `to`), unparseable RFC 3339, or window > 1 year (sanity bound — overrideable via internal `?max_window=true` once we hit a real audit need).
+- `400 customer_has_no_subscription` — caller passed no period and the customer has zero active subscriptions, so there's no canonical "current cycle". Hint message: "Pass `?from=` and `?to=` to query usage outside a billing cycle."
+
+## Internals
+
+### Composition
+
+```go
+// internal/usage/service.go (sketch)
+func (s *Service) GetCustomerUsage(
+    ctx context.Context,
+    tenantID, customerID string,
+    period CustomerUsagePeriod,
+) (CustomerUsageResult, error) {
+    cust, err := s.customers.Get(ctx, tenantID, customerID)
+    if err != nil { return CustomerUsageResult{}, err } // 404 propagates
+
+    subs, err := s.subscriptions.ListActiveForCustomer(ctx, tenantID, customerID)
+    if err != nil { return CustomerUsageResult{}, err }
+
+    from, to, source, err := resolvePeriod(period, subs) // current cycle vs explicit
+    if err != nil { return CustomerUsageResult{}, err }
+
+    // Walk the union of meter IDs across the customer's subscribed plans.
+    meterIDs := collectMeterIDs(subs)
+    rated, err := s.usage.RateForCustomer(ctx, tenantID, customerID, meterIDs, from, to)
+    if err != nil { return CustomerUsageResult{}, err }
+
+    return assembleResult(cust, subs, period, rated), nil
+}
+```
+
+`usage.RateForCustomer` is a thin wrapper that calls the existing `AggregateByPricingRules` per meter, hands the resulting `(rule, quantity)` pairs to `pricing.ComputeAmountCents`, and assembles the per-rule breakdown. **No new SQL.** The rating-rule lookup uses the same priority-ordered scan as the cycle engine, so dashboard math == invoice math.
+
+### Period resolution
+
+- **Default (no `from`/`to`):** look at the customer's primary active subscription (most recent `current_period_start`). Use its `current_period_start` and `current_period_end`. If multiple active subs with divergent cycles, pick the latest start; emit a warning if cycle bounds disagree.
+- **Explicit:** parse `from` / `to`, validate `from < to`, validate window ≤ 1 year (configurable via env at v2).
+- **Cap to 1 year** because the LATERAL JOIN cost grows linearly with row count; one year of high-volume usage events on a multi-dim meter is already 100M+ rows for active tenants. We surface this in 400, not silently degrade.
+
+### RLS
+
+Standard `BeginTx(ctx, postgres.TxTenant, tenantID)`. The customer lookup naturally 404s for cross-tenant IDs (RLS hides the row). No new policy.
+
+### Caching
+
+**No caching in v1.** Each call hits Postgres. The aggregate query is fast (~tens of ms on dev hardware for 1M events). Add caching only if a real performance issue emerges; the failure mode of a stale dashboard is worse than the cost of the live query.
+
+## Tests
+
+### Unit tests
+
+- `resolvePeriod` table-driven: explicit window, default → current cycle, default → no subscription → 400, partial-bounds → 400, window > 1 year → 400, `from > to` → 400.
+- `assembleResult` shape: multi-currency plans emit one meter entry per currency; total aggregations across rules sum correctly; empty events → 0-amount lines, not omitted entries.
+
+### Integration tests (real Postgres)
+
+- **Single-meter, single-rule.** Seed 1000 events on a `b2b_saas_pro`-style flat meter. Verify `total_quantity` and `total_amount_cents` match the cycle-scan output for the same period.
+- **Multi-dim meter.** Seed events split across 3 dimension combinations on `anthropic_style`. Verify the per-rule breakdown sums to `total_amount_cents` and matches `usage.AggregateByPricingRules` exactly. This is the parity test that catches drift between dashboard math and invoice math.
+- **Cycle alignment.** Seed events both inside and outside the cycle window. Default call only counts in-cycle. Explicit-window call counts the requested range.
+- **Cross-tenant isolation.** Customer ID exists for tenant A; tenant B's GET → 404. RLS-by-construction.
+- **No subscription, no period.** Customer with zero active subs + no query params → 400. With explicit `?from=&to=` → 200 with `subscriptions: []` and per-meter aggregates by raw event scan.
+- **Plan transition mid-window.** Customer was on plan X (Apr 1–15) then plan Y (Apr 15–30). Explicit window Apr 1 → May 1 returns both subscriptions; per-meter aggregates span both.
+- **Closed cycle parity.** A previously billed cycle's aggregate matches the sum of `invoice_line_items` for the cycle's invoice (small drift tolerance for any rounding mode differences — should be zero for `flat` rules).
+
+### End-to-end test (against running stack)
+
+`cmd/velox-customer-usage-e2e/main.go` (or extend `velox-recipes-e2e`): instantiate `anthropic_style`, create a customer, ingest 100 events across 3 dimension combinations, call `GET /v1/customers/{id}/usage`, assert the response matches an inline expected fixture. Catches contract drift between this design and the actual cycle scan.
+
+## Migrations
+
+**None.** The schema (`usage_events`, `meter_pricing_rules`, `subscriptions`, `plans`) is sufficient. This is a read-side endpoint over existing tables.
+
+## Performance
+
+- One aggregate query per meter on the customer's subscribed plans. For a typical customer on 1 plan with 1 multi-dim meter and 12 rules, the LATERAL JOIN runs once over the customer's in-cycle events.
+- `usage_events` is already indexed on `(tenant_id, customer_id, timestamp)` — the period scan is a range scan on this index, not a full-table scan.
+- Target: < 100ms p95 for the typical customer (10K events / cycle). Target: < 500ms p99 for the heavy customer (1M events / cycle, 12 dimension rules). Beyond that, we add per-day rollups (deferred to v2 if it ever becomes a problem).
+- No N+1: `subscriptions.ListActiveForCustomer` is one query; the per-meter aggregate is one query per meter (typically 1–3). No per-event call-out.
+
+## Decimal & numeric considerations
+
+Quantity is `decimal.Decimal` (NUMERIC(38,12)) per ADR-005, marshaled as a string (`"1234567.000000000000"`) to preserve precision. Amounts are integer cents per ADR-005; the rating-rule mode (`flat`, `graduated`, `package`) determines how the aggregated quantity becomes cents — all math runs through `pricing.ComputeAmountCents`, no recompute here.
+
+## Open questions
+
+1. **Should the endpoint accept `external_id` in the path** (e.g. `GET /v1/customers/by-external-id/{external_id}/usage`)? **Proposal: no for v1.** Add a separate lookup endpoint or a `?customer_external_id=` filter on the existing `GET /v1/customers` endpoint if a partner asks. Avoids two paths to the same resource.
+2. **Should `rules[].dimension_match` echo the rule's match expression, or the raw event dimensions seen?** **Proposal: the rule's match expression** — that's the canonical pricing identity. The dashboard already knows what dimensions exist on the meter. Echoing observed values would be log data, which belongs on `/v1/usage-events`.
+3. **Should we expose pre-cycle / not-yet-billed usage separately from billed?** **Proposal: not in v1.** The "current period" answer already implies "not yet billed". For closed cycles, the matching invoice is the source of truth for billed numbers, and the usage aggregate matches it (parity test above). Two-section responses add UI complexity for no clear win.
+4. **Does the response need a `next_invoice_estimate` block** (projected end-of-cycle cents)? **Proposal: no — pure UI math.** The dashboard has the rate (cents-per-unit per rule) and the elapsed-vs-total cycle ratio; it can extrapolate. Server-side projection invites disagreement with whatever heuristic the dashboard wants.
+5. **Pagination on `meters[]`?** **Proposal: no.** A customer is on at most a handful of meters; even the heaviest tenant we can imagine has ≤ 20. If we hit a real catalog-size customer, paginate then.
+6. **Should the endpoint live under `/v1/customers/{id}/usage` or `/v1/usage/by-customer/{id}`?** **Proposal: `/v1/customers/{id}/usage`** — it composes naturally with the rest of the customer namespace and matches Stripe's convention (`/v1/customers/{id}/balance_transactions`). The /usage namespace stays for raw event ingest/list.
+7. **Should `total_amount_cents` come from a fresh `ComputeAmountCents` call or from the matching `invoice_line_items` if the cycle is closed?** **Proposal: always fresh compute.** If the customer's pricing was edited mid-cycle, the dashboard wants the live answer; the invoice has the historical answer. Cycle-closed parity test guards drift.
+8. **Should warnings include "subscription cycle has rolled over but `current_period_*` hasn't been refreshed yet"?** **Proposal: yes**, surfaces a real ops issue (cycle scanner stuck) without breaking the response. Format: `cycle_refresh_lagging` warning code + the offending subscription ID.
+
+## Implementation checklist (Week 5)
+
+- [ ] `internal/usage/service.go` — `GetCustomerUsage` + `RateForCustomer` (composes existing store calls, no new SQL)
+- [ ] `internal/usage/handler.go` — `GET /v1/customers/{id}/usage` route (mounted off the customer router or as its own sub-router; whichever matches the existing customer endpoint pattern)
+- [ ] `resolvePeriod` helper + unit tests
+- [ ] Integration tests: single-meter parity, multi-dim parity, cycle alignment, cross-tenant 404, no-sub + explicit window, plan transition, closed-cycle parity
+- [ ] `cmd/velox-customer-usage-e2e/main.go` (or extend recipes e2e) — assertion fixture
+- [ ] OpenAPI spec update (`docs/openapi.yaml`)
+- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B, after coordinating)
+
+## Track B unblock
+
+Track B can scaffold the cost-dashboard against this design today. The contract Track B should mock:
+
+- `GET /v1/customers/{id}/usage` (no params) → response shape above with `period.source: "current_billing_cycle"`.
+- `GET /v1/customers/{id}/usage?from=…&to=…` → same shape with `period.source: "explicit"`.
+- 400 on `customer_has_no_subscription` when neither cycle nor explicit window is resolvable.
+- 404 on cross-tenant / unknown customer.
+
+The dashboard shape Track B should aim at:
+
+- Header: customer name + plan + "cycle X of Y days · Z% through".
+- Big number: cycle-to-date `totals.amount_cents` formatted in `totals.currency`.
+- Per-meter cards: `meter_name · total_quantity · total_amount_cents`. Click → expanded view of `rules[]` with dimension chips and per-rule cents.
+- Filters: cycle (default) / last cycle / last 90 days / custom — all map to the same endpoint with different `from`/`to`.
+
+Track B can ship the UI against a mocked API (MSW handlers seeded from the example response above) before Track A finishes the backend, then swap to the real API at integration time. Same parallel-work pattern as recipes (`docs/parallel-work.md` § "Design-first / RFC pattern").
+
+## Review status
+
+- **Track A author:** drafted 2026-04-26
+- **Track B review:** pending — Track B can scaffold the cost-dashboard against this design without waiting for implementation
+- **Human review:** pending — please flag any open question to resolve before Week 5 starts

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -234,3 +234,28 @@ Track A merged PR #20 (multi-dim backend, 12 commits) into `main` at 18:25:30Z. 
   - PR (this work, `feat/backend-week3-recipes`) — to be opened next.
   - The 7 open questions in `docs/design-recipes.md` — most settled by the implementation; worth a short doc pass to reflect the actual v1 decisions before closing the design as "shipped".
 - **Next session (Track A):** open the PR for review, then either (a) drive it to merge + start Week 4 (`create_preview` design / billing-cycle hardening per 90-day plan), or (b) wait for Track B to ship the recipe picker so we can iterate on API ergonomics with real UI feedback.
+
+---
+
+## 2026-04-26 (Sun) — Track A response: recipes wire-shape fix + customer-usage RFC pre-stage
+
+### Track A
+- **Picked up after merges:** Track B reported three wire-shape drifts during fresh smoke testing of the merged recipes backend (PascalCase JSON keys, missing `creates` summary on list/detail, missing `objects` wrapper + `warnings` on preview). All three fixed in this slice — data shape only, no behavior change to `Instantiate` / `Uninstall`.
+- **Shipped:**
+  - **JSON tags on `domain.Recipe`** — top-level fields (`Key`, `Version`, `Name`, `Summary`, `Description`, `Overridable`, `Meters`, `RatingRules`, `PricingRules`, `Plans`, `DunningPolicy`, `Webhook`, `SampleData`) were missing tags entirely, so the encoder fell back to PascalCase. Added snake_case tags with `omitempty` on `description` / `dunning_policy` / `webhook`. `SampleData` is now `json:"-"` — it's a seed hint, not part of the public API surface.
+  - **`creates` summary on list + detail.** New `RecipeCreates` struct (`{meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints}` integer counts), `countCreates(domain.Recipe)` helper, `Creates` field added to `RecipeListItem`, and a new `RecipeDetail` wrapper for `GetRecipe` so detail also carries the summary. Picker UI renders "1 meter · 9 pricing rules · monthly billing" chips without a follow-up preview call.
+  - **`PreviewResult` wrapper** — `Service.Preview` now returns `{key, version, objects: {meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints}, warnings: []}` per the design spec. `dunning_policies` and `webhook_endpoints` are 0-or-1-length slices for uniform iteration. All object slices default to non-nil so the JSON encoder emits `[]` not `null`. `warnings` is empty in v1 — slot in place for the design's non-fatal-condition shape (currency-vs-Stripe mismatch, placeholder webhook URLs).
+  - **Regression test** — new `TestWireShape_SnakeCase` (3 sub-tests) marshals real responses from `ListRecipes`, `GetRecipe`, and `Preview`, then asserts every required snake_case key is present and no PascalCase key leaks. Drift here trips CI before reaching the dashboard.
+  - **`docs/design-customer-usage.md`** pre-staged (per Track B's standing ask). Same RFC structure as `design-recipes.md`: motivation grounded in cost-transparency wedge, goals + non-goals, today's-surface map (composition over invention — `usage.AggregateForBillingPeriod`, `customer.Store.Get`, `subscription.Store.List`, `pricing.ComputeAmountCents` all already exist), wire-contract example responses for default-cycle and explicit-window, internals sketch, integration test list (multi-dim parity, RLS, plan transitions, closed-cycle parity), 8 open questions with proposed answers, Track B unblock section with mockable contract + dashboard layout suggestions.
+  - CHANGELOG entries on both surfaces (per `feedback_changelog_discipline`): `CHANGELOG.md` Unreleased > Fixed entry describing all three drifts + regression test, plus `web-v2/src/pages/Changelog.tsx` Linear-style fix entry dated 2026-04-26.
+- **Decisions made inline (per `feedback_feat8_autonomy`):**
+  - Kept the heavy meters/rating_rules/etc. arrays at top level on `GET /v1/recipes` rather than removing them. Track B's report flagged the missing `creates` and accepted "either re-add the creates summary or update the doc" — adding `creates` is the lower-risk path; removing the arrays would force Track B to re-architect the picker if it's already consuming them. Can revisit in v2 if the response weight becomes a real concern.
+  - `omitempty` on `description` / `dunning_policy` / `webhook` (recipe-level) but **not** on `objects.meters` / `objects.dunning_policies` / etc. (preview-level). Reason: recipe-level optionals are sometimes-absent fields the client can reasonably skip; preview-level slices are always-present-but-possibly-empty arrays the picker iterates without null guards. Different semantics, different convention.
+  - For multi-currency plans (rare today), the design-customer-usage RFC's `totals` becomes an array of `{currency, amount_cents}`. Single-currency cases keep the scalar shape. Documented in the open-question section so it surfaces in review rather than getting buried.
+- **Blocking Track B on:** nothing. Picker UI types should match the spec now; smoke-test against the new shape and ping if anything else drifts.
+- **Track B can start:**
+  - Re-run the picker smoke test against the fixed contract; flag any further mismatches.
+  - **Cost-dashboard scaffold (Week 5)** — `docs/design-customer-usage.md` is the contract to mock against. Same parallel-work pattern as recipes (MSW handlers seeded from the example response, then swap to real API at Track A integration time). Design's "Track B unblock" section has the dashboard layout suggestions.
+- **Open for human review:**
+  - PR for the recipes wire-shape fix (to be opened next).
+  - `docs/design-customer-usage.md` open questions (8) — most have proposed answers; please flag any you want resolved before Week 5 implementation begins.

--- a/internal/domain/recipe.go
+++ b/internal/domain/recipe.go
@@ -44,21 +44,26 @@ type CreatedObjects struct {
 // at process boot from the embedded FS and held in the registry; never
 // mutated after load. Render() applies overrides and produces a
 // RenderedRecipe ready for instantiation.
+//
+// JSON tags use snake_case to match the rest of /v1/* and the wire
+// contract in docs/design-recipes.md. SampleData is omitted from JSON
+// because it's an internal-only seed hint, not part of the public
+// API surface.
 type Recipe struct {
-	Key         string
-	Version     string
-	Name        string
-	Summary     string
-	Description string
-	Overridable []RecipeOverride
+	Key         string           `json:"key"`
+	Version     string           `json:"version"`
+	Name        string           `json:"name"`
+	Summary     string           `json:"summary"`
+	Description string           `json:"description,omitempty"`
+	Overridable []RecipeOverride `json:"overridable"`
 
-	Meters        []RecipeMeter
-	RatingRules   []RecipeRatingRule
-	PricingRules  []RecipePricingRule
-	Plans         []RecipePlan
-	DunningPolicy *RecipeDunningPolicy
-	Webhook       *RecipeWebhook
-	SampleData    *RecipeSampleData
+	Meters        []RecipeMeter        `json:"meters"`
+	RatingRules   []RecipeRatingRule   `json:"rating_rules"`
+	PricingRules  []RecipePricingRule  `json:"pricing_rules"`
+	Plans         []RecipePlan         `json:"plans"`
+	DunningPolicy *RecipeDunningPolicy `json:"dunning_policy,omitempty"`
+	Webhook       *RecipeWebhook       `json:"webhook,omitempty"`
+	SampleData    *RecipeSampleData    `json:"-"`
 }
 
 // RecipeOverride is one override key declared in a recipe's `overridable`

--- a/internal/recipe/service.go
+++ b/internal/recipe/service.go
@@ -73,12 +73,48 @@ func NewService(
 }
 
 // RecipeListItem is one entry in the GET /v1/recipes response — the
-// canonical recipe metadata plus the per-tenant installation record (or
-// nil when uninstalled). The dashboard uses Instantiated to flip the CTA
-// from "Install" to "Manage / Uninstall".
+// canonical recipe metadata plus per-tenant installation state and a
+// creates summary so the picker UI can render "1 meter · 9 pricing
+// rules · monthly billing" without an extra preview round-trip. The
+// dashboard uses Instantiated to flip the CTA from "Install" to
+// "Manage / Uninstall".
 type RecipeListItem struct {
 	domain.Recipe
+	Creates      RecipeCreates          `json:"creates"`
 	Instantiated *domain.RecipeInstance `json:"instantiated,omitempty"`
+}
+
+// RecipeCreates is the per-role count of objects a recipe will produce
+// when instantiated. Surfaced on list + detail responses so the
+// dashboard can render summary chips without round-tripping preview.
+// Counts mirror the shape of domain.CreatedObjects (which is per-ID),
+// scaled down to integers for display.
+type RecipeCreates struct {
+	Meters           int `json:"meters"`
+	RatingRules      int `json:"rating_rules"`
+	PricingRules     int `json:"pricing_rules"`
+	Plans            int `json:"plans"`
+	DunningPolicies  int `json:"dunning_policies"`
+	WebhookEndpoints int `json:"webhook_endpoints"`
+}
+
+// countCreates derives a RecipeCreates summary from a parsed recipe.
+// Optional sections (DunningPolicy, Webhook) count as 1 when present, 0
+// when absent — they're singletons in the YAML schema, not slices.
+func countCreates(r domain.Recipe) RecipeCreates {
+	c := RecipeCreates{
+		Meters:       len(r.Meters),
+		RatingRules:  len(r.RatingRules),
+		PricingRules: len(r.PricingRules),
+		Plans:        len(r.Plans),
+	}
+	if r.DunningPolicy != nil {
+		c.DunningPolicies = 1
+	}
+	if r.Webhook != nil {
+		c.WebhookEndpoints = 1
+	}
+	return c
 }
 
 // ListRecipes returns every recipe in the registry tagged with this
@@ -88,7 +124,7 @@ func (s *Service) ListRecipes(ctx context.Context, tenantID string) ([]RecipeLis
 	recipes := s.registry.List()
 	out := make([]RecipeListItem, 0, len(recipes))
 	for _, r := range recipes {
-		item := RecipeListItem{Recipe: r}
+		item := RecipeListItem{Recipe: r, Creates: countCreates(r)}
 		inst, err := s.store.GetByKey(ctx, tenantID, r.Key)
 		switch {
 		case err == nil:
@@ -104,14 +140,24 @@ func (s *Service) ListRecipes(ctx context.Context, tenantID string) ([]RecipeLis
 	return out, nil
 }
 
+// RecipeDetail is the GET /v1/recipes/{key} response. Same fields as a
+// list item plus the long-form description and full overridable_schema
+// (already on the embedded domain.Recipe). Wrapping rather than
+// returning bare domain.Recipe lets us co-emit the creates summary so
+// the dashboard's picker drawer renders chips without a preview call.
+type RecipeDetail struct {
+	domain.Recipe
+	Creates RecipeCreates `json:"creates"`
+}
+
 // GetRecipe returns the rendered-with-defaults form of a recipe so the
 // dashboard can populate the override form. No DB I/O; pure registry.
-func (s *Service) GetRecipe(key string) (domain.Recipe, error) {
+func (s *Service) GetRecipe(key string) (RecipeDetail, error) {
 	r, ok := s.registry.Get(key)
 	if !ok {
-		return domain.Recipe{}, errs.ErrNotFound
+		return RecipeDetail{}, errs.ErrNotFound
 	}
-	return r, nil
+	return RecipeDetail{Recipe: r, Creates: countCreates(r)}, nil
 }
 
 // ListInstances returns the recipe_instances rows for the tenant.
@@ -119,20 +165,83 @@ func (s *Service) ListInstances(ctx context.Context, tenantID string) ([]domain.
 	return s.store.List(ctx, tenantID)
 }
 
-// Preview renders a recipe with caller-supplied overrides and returns the
-// resolved domain.Recipe — same graph Instantiate would build, minus the
-// IDs. Pure in-memory; no DB writes, no transactions. Cheap enough to
-// call on every override-form keystroke.
-func (s *Service) Preview(_ context.Context, recipeKey string, overrides map[string]any) (domain.Recipe, error) {
+// PreviewResult is the wire shape of POST /v1/recipes/{key}/preview.
+// `objects` groups the would-be-created entities by role so the
+// dashboard's preview panel renders one collapsible card per type.
+// `warnings` surfaces non-fatal conditions (currency-vs-Stripe-account
+// mismatches, placeholder webhook URLs, etc.); empty array in v1 — slot
+// is in place so the contract stays stable when richer warnings land.
+type PreviewResult struct {
+	Key      string         `json:"key"`
+	Version  string         `json:"version"`
+	Objects  PreviewObjects `json:"objects"`
+	Warnings []string       `json:"warnings"`
+}
+
+// PreviewObjects mirrors the recipe's object-graph sections. Optional
+// pieces (DunningPolicy, Webhook) are emitted as 0-or-1-length slices so
+// the wire shape is uniform — picker UI iterates without null guards.
+// Empty arrays are emitted (no `omitempty`) for the same reason.
+type PreviewObjects struct {
+	Meters           []domain.RecipeMeter         `json:"meters"`
+	RatingRules      []domain.RecipeRatingRule    `json:"rating_rules"`
+	PricingRules     []domain.RecipePricingRule   `json:"pricing_rules"`
+	Plans            []domain.RecipePlan          `json:"plans"`
+	DunningPolicies  []domain.RecipeDunningPolicy `json:"dunning_policies"`
+	WebhookEndpoints []domain.RecipeWebhook       `json:"webhook_endpoints"`
+}
+
+// Preview renders a recipe with caller-supplied overrides and returns
+// the would-be-created object graph. Pure in-memory; no DB writes, no
+// transactions. Cheap enough to call on every override-form keystroke.
+func (s *Service) Preview(_ context.Context, recipeKey string, overrides map[string]any) (PreviewResult, error) {
 	r, ok := s.registry.Get(recipeKey)
 	if !ok {
-		return domain.Recipe{}, errs.ErrNotFound
+		return PreviewResult{}, errs.ErrNotFound
 	}
 	rendered, err := renderRecipe(r, overrides)
 	if err != nil {
-		return domain.Recipe{}, errs.Invalid("overrides", err.Error())
+		return PreviewResult{}, errs.Invalid("overrides", err.Error())
 	}
-	return rendered, nil
+	return previewResultFrom(rendered), nil
+}
+
+// previewResultFrom converts a rendered domain.Recipe into the public
+// preview wire shape. Slices default to non-nil so the JSON encoder
+// emits `[]` rather than `null` — picker UI maps without guards.
+func previewResultFrom(r domain.Recipe) PreviewResult {
+	out := PreviewResult{
+		Key:     r.Key,
+		Version: r.Version,
+		Objects: PreviewObjects{
+			Meters:           r.Meters,
+			RatingRules:      r.RatingRules,
+			PricingRules:     r.PricingRules,
+			Plans:            r.Plans,
+			DunningPolicies:  []domain.RecipeDunningPolicy{},
+			WebhookEndpoints: []domain.RecipeWebhook{},
+		},
+		Warnings: []string{},
+	}
+	if out.Objects.Meters == nil {
+		out.Objects.Meters = []domain.RecipeMeter{}
+	}
+	if out.Objects.RatingRules == nil {
+		out.Objects.RatingRules = []domain.RecipeRatingRule{}
+	}
+	if out.Objects.PricingRules == nil {
+		out.Objects.PricingRules = []domain.RecipePricingRule{}
+	}
+	if out.Objects.Plans == nil {
+		out.Objects.Plans = []domain.RecipePlan{}
+	}
+	if r.DunningPolicy != nil {
+		out.Objects.DunningPolicies = []domain.RecipeDunningPolicy{*r.DunningPolicy}
+	}
+	if r.Webhook != nil {
+		out.Objects.WebhookEndpoints = []domain.RecipeWebhook{*r.Webhook}
+	}
+	return out
 }
 
 // InstantiateOptions controls one-off knobs for Instantiate. Force is

--- a/internal/recipe/service_integration_test.go
+++ b/internal/recipe/service_integration_test.go
@@ -277,10 +277,10 @@ func TestService_Instantiate_PreviewParity(t *testing.T) {
 		t.Fatalf("Instantiate: %v", err)
 	}
 
-	if got, want := len(inst.CreatedObjects.RatingRuleIDs), len(previewed.RatingRules); got != want {
+	if got, want := len(inst.CreatedObjects.RatingRuleIDs), len(previewed.Objects.RatingRules); got != want {
 		t.Errorf("rating-rule count drift: instantiate=%d, preview=%d", got, want)
 	}
-	if got, want := len(inst.CreatedObjects.PricingRuleIDs), len(previewed.PricingRules); got != want {
+	if got, want := len(inst.CreatedObjects.PricingRuleIDs), len(previewed.Objects.PricingRules); got != want {
 		t.Errorf("pricing-rule count drift: instantiate=%d, preview=%d", got, want)
 	}
 	plans, err := f.pricingSvc.ListPlans(ctx, tenantID)

--- a/internal/recipe/service_test.go
+++ b/internal/recipe/service_test.go
@@ -3,6 +3,7 @@ package recipe
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -118,17 +119,23 @@ func TestService_Preview_RendersTemplates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Preview: %v", err)
 	}
-	if len(rendered.Plans) != 1 {
-		t.Fatalf("expected 1 plan, got %d", len(rendered.Plans))
+	if rendered.Key != "anthropic_style" {
+		t.Errorf("Key: got %q, want anthropic_style", rendered.Key)
 	}
-	if got := rendered.Plans[0].Code; got != "ai_eur" {
+	if len(rendered.Objects.Plans) != 1 {
+		t.Fatalf("expected 1 plan, got %d", len(rendered.Objects.Plans))
+	}
+	if got := rendered.Objects.Plans[0].Code; got != "ai_eur" {
 		t.Errorf("plan.code: got %q, want ai_eur", got)
 	}
-	if got := rendered.Plans[0].Currency; got != "EUR" {
+	if got := rendered.Objects.Plans[0].Currency; got != "EUR" {
 		t.Errorf("plan.currency: got %q, want EUR", got)
 	}
-	if got := rendered.RatingRules[0].Currency; got != "EUR" {
+	if got := rendered.Objects.RatingRules[0].Currency; got != "EUR" {
 		t.Errorf("rating_rule.currency: got %q, want EUR", got)
+	}
+	if rendered.Warnings == nil {
+		t.Error("Warnings must be non-nil so JSON serializes as [] not null")
 	}
 }
 
@@ -206,6 +213,108 @@ func TestService_Instantiate_UnknownRecipe(t *testing.T) {
 	if !errors.Is(err, errs.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
+}
+
+// TestWireShape_SnakeCase pins the JSON contract Track B's picker UI
+// depends on. Drift here (e.g. dropping a json:"…" tag and falling back
+// to PascalCase) breaks the dashboard at runtime, so we assert the
+// snake_case field names + creates summary + preview wrapper directly.
+func TestWireShape_SnakeCase(t *testing.T) {
+	svc := NewService(nil, newMemStore(), loadRegistry(t), nil, nil, nil)
+
+	t.Run("ListRecipes", func(t *testing.T) {
+		items, err := svc.ListRecipes(context.Background(), "t1")
+		if err != nil {
+			t.Fatalf("ListRecipes: %v", err)
+		}
+		blob, err := json.Marshal(items[0])
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"key", "version", "name", "summary", "overridable", "meters", "rating_rules", "pricing_rules", "plans", "creates"} {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("list response missing %q key (raw=%v)", k, raw)
+			}
+		}
+		for _, k := range []string{"Key", "Version", "Name", "Summary", "RatingRules", "PricingRules", "DunningPolicy"} {
+			if _, ok := raw[k]; ok {
+				t.Errorf("list response should not have PascalCase key %q", k)
+			}
+		}
+		creates, ok := raw["creates"].(map[string]any)
+		if !ok {
+			t.Fatalf("creates not an object: %T", raw["creates"])
+		}
+		for _, k := range []string{"meters", "rating_rules", "pricing_rules", "plans", "dunning_policies", "webhook_endpoints"} {
+			if _, ok := creates[k]; !ok {
+				t.Errorf("creates missing %q", k)
+			}
+		}
+	})
+
+	t.Run("GetRecipe", func(t *testing.T) {
+		detail, err := svc.GetRecipe("anthropic_style")
+		if err != nil {
+			t.Fatalf("GetRecipe: %v", err)
+		}
+		blob, err := json.Marshal(detail)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"key", "version", "name", "summary", "description", "creates"} {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("detail response missing %q (raw keys=%v)", k, mapKeys(raw))
+			}
+		}
+	})
+
+	t.Run("Preview", func(t *testing.T) {
+		out, err := svc.Preview(context.Background(), "anthropic_style", nil)
+		if err != nil {
+			t.Fatalf("Preview: %v", err)
+		}
+		blob, err := json.Marshal(out)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"key", "version", "objects", "warnings"} {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("preview response missing %q (raw keys=%v)", k, mapKeys(raw))
+			}
+		}
+		objects, ok := raw["objects"].(map[string]any)
+		if !ok {
+			t.Fatalf("objects not an object: %T", raw["objects"])
+		}
+		for _, k := range []string{"meters", "rating_rules", "pricing_rules", "plans", "dunning_policies", "webhook_endpoints"} {
+			if _, ok := objects[k]; !ok {
+				t.Errorf("preview.objects missing %q", k)
+			}
+		}
+		if _, isSlice := raw["warnings"].([]any); !isSlice {
+			t.Errorf("warnings must marshal as JSON array, got %T", raw["warnings"])
+		}
+	})
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 func TestRatingRuleFromRecipe(t *testing.T) {

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -18,6 +18,18 @@ const entries: {
 }[] = [
   {
     date: '2026-04-26',
+    title: 'Recipes API wire shape — snake_case + creates summary + preview wrapper',
+    tag: 'fix',
+    body: 'Three drifts between the recipes API design doc and the Week 3 implementation are fixed so the picker UI lights up cleanly: PascalCase JSON keys are now snake_case (matching the rest of /v1/*), each list/detail entry carries a creates: {meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints} count summary, and POST /v1/recipes/{key}/preview now wraps its response as {key, version, objects: {…}, warnings: []} per the spec. Data shape only — no behavior change to instantiate / uninstall.',
+    bullets: [
+      'JSON tags added to domain.Recipe — keys are key, version, name, summary, description, overridable, meters, rating_rules, pricing_rules, plans, dunning_policy, webhook (was PascalCase). Optional sections use omitempty so wire output stays tight.',
+      'GET /v1/recipes and GET /v1/recipes/{key} now include a creates summary so the picker UI renders "1 meter · 9 pricing rules · monthly billing" chips without a follow-up preview call.',
+      'POST /v1/recipes/{key}/preview returns {key, version, objects: {meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints}, warnings: []} per the spec — previously inlined every array at the top level. dunning_policies and webhook_endpoints are 0-or-1-length slices for uniform iteration.',
+      'New TestWireShape_SnakeCase regression test pins all three contracts so future drift trips CI before reaching the dashboard.',
+    ],
+  },
+  {
+    date: '2026-04-26',
     title: 'Pricing recipes — one-call billing setup',
     tag: 'feature',
     body: 'Five built-in recipes (anthropic_style, openai_style, replicate_style, b2b_saas_pro, marketplace_gmv) collapse a multi-day Stripe-Billing-style onboarding into a single API call. POST /v1/recipes/{key}/instantiate atomically builds the full graph — meters, multi-dim pricing rules, plan, dunning policy, webhook endpoint — under one transaction; partial state never reaches the tenant. Designed to make the multi-dimensional meter engine immediately usable: a 12-rule anthropic_style setup goes from ~30 manual API calls to one POST.',


### PR DESCRIPTION
## Summary

Two bundled deliverables Track B was standing by on:

**1. Recipes API wire-shape fix.** Track B's first smoke test of the merged Week 3 backend surfaced three drifts vs. `docs/design-recipes.md`:

- PascalCase JSON keys instead of snake_case (every field on every recipes response — `Key`, `Version`, `Meters`, `RatingRules`, `DunningPolicy`, …). Root cause: `domain.Recipe`'s top-level fields had no `json:"…"` tags. Sub-types had them; the wrapper struct didn't.
- `creates` summary missing on `GET /v1/recipes`. Picker UI needs counts (`{meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints}`) to render summary chips without a follow-up preview call.
- `objects` wrapper + `warnings` array missing on `POST /v1/recipes/{key}/preview`. Spec says `{key, version, objects: {...}, warnings: []}`; we were inlining all the object arrays at the top level.

All three fixed. Data shape only — no behavior change to `Instantiate` / `Uninstall`. New `TestWireShape_SnakeCase` regression test marshals real responses from `ListRecipes`, `GetRecipe`, and `Preview` and asserts every required snake_case key is present and no PascalCase key leaks; drift trips CI before reaching the dashboard.

**2. `docs/design-customer-usage.md` pre-staged** for Track B's Week 5 cost-dashboard scaffold. Same RFC structure as `design-recipes.md` (motivation, goals, non-goals, today's surface, API surface with example responses, internals, tests, open questions, Track B unblock). Composes existing surfaces — `usage.AggregateForBillingPeriod`, `customer.Store.Get`, `subscription.Store.List`, `pricing.ComputeAmountCents` — no new aggregation logic. 8 open questions with proposed answers; flag any to resolve before Week 5 starts.

## Decisions made inline

- Kept the heavy `meters` / `rating_rules` / etc. arrays at top level on `GET /v1/recipes` rather than removing them. Track B accepted "either re-add the creates summary or update the doc" — adding `creates` is the lower-risk path. Can revisit in v2 if response weight matters.
- `omitempty` on recipe-level optionals (`description`, `dunning_policy`, `webhook`) but **not** on preview-level slices. Different semantics: optionals can be absent; slices are always-present-but-possibly-empty so the picker iterates without null guards.
- `SampleData` is `json:"-"` — it's a seed hint for `seed_sample_data=true`, not part of the public API surface.

## Test plan

- [x] `go test ./internal/recipe/... -short` — all unit tests green
- [x] `go test ./... -short` — full short suite green
- [x] `DATABASE_URL=… go test ./internal/recipe/... -short=false` — integration tests green (preview/instantiate parity, atomicity rollback, RLS, idempotency, etc.)
- [x] `gofmt -l internal/recipe/ internal/domain/recipe.go` — clean
- [x] `go vet ./...` — clean
- [ ] Track B re-runs picker smoke test against the fixed contract; flag any further mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)