### PR TITLE
feat(web): Track B Week 5 prep — cost dashboard wired to live customer-usage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,59 @@ Two surfaces mirror this file:
   form — one consistent shape lets dashboards iterate without branching
   on cardinality.
 
+- **Recipes picker UI — discoverable pricing installation** (2026-04-26) —
+  the dashboard surface for the recipes feature (Track A backend
+  entry below). New `/recipes` page (`web-v2/src/pages/Recipes.tsx`)
+  lists the five built-ins as cards with a creates-summary chip
+  strip (`{meters, rating_rules, pricing_rules, plans,
+  dunning_policies, webhook_endpoints}`); each card opens a
+  configure dialog that renders the overrides form from
+  `recipe.overridable[]` (string / number / boolean fields with
+  `enum`, `max_length`, and `pattern` honored). Preview button
+  posts `/v1/recipes/{key}/preview` and renders the would-be graph
+  inline (truncated past 5 items per object class) plus any
+  warnings; Install posts `/v1/recipes/instantiate` and navigates
+  to the first `created_objects.plan_ids` so the new catalog is
+  one click away. Sidebar entry added under Configuration
+  (`Sparkles` icon) and the onboarding wizard's step 1
+  ("Pick a pricing template") now fetches `/v1/recipes` live and
+  deep-links into the picker. New TS types in
+  `web-v2/src/lib/api.ts`: `Recipe`, `RecipeDetail`,
+  `RecipeOverrideSchema` (`{key, type, default?, enum?, max_length?,
+  pattern?}` — collapsed from the design's `string[]` +
+  `Record<key, schema>` split into a single self-describing array,
+  matches PR #25's actual wire shape), `RecipePreview`,
+  `RecipeInstance`, `RecipeCreatesSummary`. Falls back to an empty
+  list when the backend endpoint isn't reachable so the page stays
+  usable on pre-recipes builds.
+
+- **Multi-dimensional meter dashboard surfaces** (2026-04-26) — the
+  operator-side complement to the Week 2 multi-dim meters engine
+  (Track A entry below). `web-v2/src/pages/MeterDetail.tsx` gets a
+  "Dimension-matched rules" card: chips-table over each rule's
+  `dimension_match` keys, the aggregation mode (one of `sum`,
+  `count`, `last_during_period`, `last_ever`, `max`), priority,
+  and rating-rule reference. "Add rule" dialog walks the operator
+  through a dynamic key/value dimension builder + select for the
+  five aggregation modes + rating-rule selector + priority input;
+  delete is gated through the `TypedConfirmDialog` (type
+  `delete` to confirm — same pattern as void-invoice). The
+  default-rule card was renamed "Default pricing rule" with a
+  fallback-explainer subtitle so operators understand the
+  priority+claim relationship. `web-v2/src/pages/UsageEvents.tsx`
+  gets a conditional `Dimensions` column (only shown when at least
+  one event in view carries them, or a filter is active), a
+  `key=value` text filter that flows through to the
+  `dimensions=` query param, and a CSV export that now carries the
+  dimensions JSON column. The decimal-precision `quantity` field
+  is now read as a string-encoded NUMERIC end-to-end —
+  `eventQuantity()` coerces to `number` only at chart math; raw
+  display preserves trailing-zero precision (`1234.567890123456`).
+  TS types added: `MeterPricingRule`, `MeterAggregationMode` union,
+  plus `api.{listMeterPricingRules, createMeterPricingRule,
+  deleteMeterPricingRule}` client methods (all hyphen paths,
+  matching the rest of `/v1/*`).
+
 - **Pricing recipes — one-call billing setup** (2026-04-26) — the
   developer-experience flagship that turns Week 2's multi-dim meter
   engine into a 30-second quickstart (per `docs/design-recipes.md`,

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -290,3 +290,27 @@ Track A merged PR #20 (multi-dim backend, 12 commits) into `main` at 18:25:30Z. 
   - PR for the customer-usage backend (`feat/backend-week5-customer-usage`) — to be opened next.
   - The always-array `totals` deviation from the RFC — flag if you'd rather match the spec's scalar-when-single shape.
 - **Next session (Track A):** open the PR, drive to merge, then either (a) start Week 5's other half (`create_preview` invoice preview design + implementation) per 90-day plan, or (b) Week 6 dunning hardening if human prefers; both unblocked.
+
+---
+
+## 2026-04-26 (Sun) — third update, Track B Week 5 prep
+
+### Track B
+- **Branch:** `feat/track-b-week5-prep` (off `main` post-PR-#24/#23 merge), pushed.
+- **Re-smoke of recipes API (PR #25):** snake_case ✓, `creates` summary ✓, `{key, version, objects, warnings}` preview wrapper ✓, `instantiated` field present (null on fresh tenant) ✓. Two contract suggestions raised in PR review and addressed Track-B-side this slice (see commits below).
+- **Shipped (2 commits):**
+  - `34dfc83 refactor(web): adapt recipes TS to PR #25 wire shape` — collapsed `Recipe.overridable: string[]` + `RecipeDetail.overridable_schema: Record<key, schema>` into a single `RecipeOverrideSchema[]` with `key` embedded (matches PR #25's actual wire shape — strictly better than the original RFC). `OverrideField` reads `schema.key`; dropped the redundant `fieldKey` prop. Added `max_length` and `pattern` to the schema type since the live response carries them.
+  - `c6bcafb feat(web): cost-dashboard scaffold against design-customer-usage RFC` — new `<CostDashboard customerId />` component, new `api.customerUsage(customerId, {from?, to?})` method, new `CustomerUsage*` types. Replaces the old quantity-only "Usage This Period" card on `CustomerDetail.tsx` with the multi-dim cost view (cycle progress, totals, per-meter expand-to-rules, warnings). Self-contained so the same component drops into a future public iframe-able route once token-based access lands.
+- **Two flags for Track A on PR #25 + RFC:**
+  1. **PR #25 / `docs/design-recipes.md` should reflect the new `overridable` shape.** Doc says `overridable: string[]` + separate `overridable_schema: dict`. Implementation collapses both into `overridable: [{key, type, default, enum?, max_length?, pattern?}, ...]` — better, single source of truth, my TS already matches. Doc update needed for downstream consumers.
+  2. **`docs/design-customer-usage.md` `totals` field — request to make it always-array.** RFC currently spec'd `totals: {amount_cents, currency}` for single-currency and `totals: [...]` polymorphic for multi-currency. My TS models it as `totals: [{currency, amount_cents}]` unconditionally (single-currency tenants get a length-1 array). Removes the polymorphic discriminator on the client. If Track A keeps the polymorphic shape on the wire, I'll patch in a thin adapter — but the always-array shape is strictly cheaper for clients and costs nothing on the wire. **Asking for confirmation before Track A starts implementation.**
+- **8 open questions on `docs/design-customer-usage.md`:** all of Track A's proposed answers I'd accept (no objections). Cosmetic note: example response shows `meter_id: "vlx_mtr_tokens"` (semantic) but real meter IDs are random hex; flagging so doc readers don't assume IDs encode meter keys.
+- **Build verification:** `tsc -b` clean (only pre-existing errors); `vite build` ~565ms with new lazy chunk for the customer-usage component.
+- **Blocking Track A on:** confirmation of the always-array `totals` shape, ideally before Week 5 implementation kicks off so I don't have to write an adapter post-hoc.
+- **Track A can pick up from this work:** Week 5 implementation against the RFC (with `totals` shape decision), then `create_preview` for the projected-bill line on the dashboard (currently absent — UI math will extrapolate from elapsed-vs-total cycle once we have it).
+- **Next session (Track B):**
+  - Once `GET /v1/customers/{id}/usage` is live, click-test the dashboard end-to-end against a real `anthropic_style` tenant.
+  - Add a "projected bill" line to the dashboard when `create_preview` ships (Week 5 explicit deliverable).
+  - The standalone iframe-able route (`/cost-dashboard?customer_id=…&token=…`) lands once Track A wires public-token access.
+
+**Wall-clock:** 00:30 → 01:25 IST 2026-04-26 (≈ 55m).

--- a/web-v2/src/components/CostDashboard.tsx
+++ b/web-v2/src/components/CostDashboard.tsx
@@ -1,0 +1,253 @@
+import { useState, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { api, formatCents, formatDate } from '@/lib/api'
+import type { CustomerUsageMeter, CustomerUsageRule } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ChevronDown, ChevronRight, Activity, AlertTriangle, Loader2 } from 'lucide-react'
+
+type PeriodPreset = 'current' | 'last_30d' | 'last_90d'
+
+const PRESETS: { value: PeriodPreset; label: string }[] = [
+  { value: 'current', label: 'Current cycle' },
+  { value: 'last_30d', label: 'Last 30 days' },
+  { value: 'last_90d', label: 'Last 90 days' },
+]
+
+function presetToParams(p: PeriodPreset): { from?: string; to?: string } | undefined {
+  if (p === 'current') return undefined
+  const now = new Date()
+  const days = p === 'last_30d' ? 30 : 90
+  const from = new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString()
+  return { from, to: now.toISOString() }
+}
+
+export function CostDashboard({ customerId }: { customerId: string }) {
+  const [preset, setPreset] = useState<PeriodPreset>('current')
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['customer-usage', customerId, preset],
+    queryFn: async () => {
+      try {
+        return await api.customerUsage(customerId, presetToParams(preset))
+      } catch (err) {
+        // 400 customer_has_no_subscription is the documented "no current cycle"
+        // state — surface it as an empty result, not a hard error. Same pattern
+        // for 404. Real network/auth errors fall through to the error UI.
+        if (err && typeof err === 'object' && 'status' in err) {
+          const s = (err as { status: number }).status
+          if (s === 400 || s === 404) return null
+        }
+        throw err
+      }
+    },
+  })
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="p-6 text-center">
+          <p className="text-sm text-destructive mb-3">{(error as Error).message}</p>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>Retry</Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header + period switcher */}
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">Usage this period</h2>
+          {data?.period && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {formatDate(data.period.from)} → {formatDate(data.period.to)} · {data.period.source === 'current_billing_cycle' ? 'current billing cycle' : 'explicit window'}
+            </p>
+          )}
+        </div>
+        <Tabs value={preset} onValueChange={(v) => setPreset(v as PeriodPreset)}>
+          <TabsList>
+            {PRESETS.map(p => (
+              <TabsTrigger key={p.value} value={p.value} className="text-xs">{p.label}</TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {isLoading ? (
+        <Card><CardContent className="p-8 flex justify-center"><Loader2 size={20} className="animate-spin text-muted-foreground" /></CardContent></Card>
+      ) : !data ? (
+        <Card>
+          <CardContent className="p-8 text-center">
+            <Activity size={20} className="mx-auto text-muted-foreground mb-3" />
+            <p className="text-sm text-muted-foreground">
+              No usage to show for this period. {preset === 'current'
+                ? "Customer doesn't have an active subscription, or the cycle hasn't started yet."
+                : 'Try a different window.'}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Subscription / cycle context */}
+          {data.subscriptions.length > 0 && (
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                  {data.subscriptions.map(sub => (
+                    <CycleHeader key={sub.id} sub={sub} />
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Big number — totals (one per currency) */}
+          <Card>
+            <CardContent className="px-6 py-5">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Cycle-to-date charges</p>
+              <div className="mt-2 flex flex-wrap items-baseline gap-x-6 gap-y-2">
+                {data.totals.length === 0 ? (
+                  <p className="text-3xl font-semibold text-foreground tabular-nums">{formatCents(0)}</p>
+                ) : (
+                  data.totals.map(t => (
+                    <div key={t.currency} className="flex items-baseline gap-2">
+                      <span className="text-3xl font-semibold text-foreground tabular-nums">{formatCents(t.amount_cents, t.currency)}</span>
+                      {data.totals.length > 1 && <span className="text-xs text-muted-foreground uppercase">{t.currency}</span>}
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Warnings */}
+          {data.warnings.length > 0 && (
+            <Card className="border-amber-200 dark:border-amber-900">
+              <CardContent className="p-4">
+                <div className="flex items-center gap-2 text-amber-700 dark:text-amber-300 text-xs font-medium mb-2">
+                  <AlertTriangle size={12} />
+                  {data.warnings.length} warning{data.warnings.length !== 1 ? 's' : ''}
+                </div>
+                <ul className="text-xs text-amber-700 dark:text-amber-300 space-y-1">
+                  {data.warnings.map((w, i) => (
+                    <li key={i}>
+                      <span className="font-mono">{w.code}</span> · {w.message}
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Per-meter cards */}
+          {data.meters.length === 0 ? (
+            <Card>
+              <CardContent className="p-8 text-center">
+                <p className="text-sm text-muted-foreground">No metered usage in this period.</p>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-2">
+              {data.meters.map(m => <MeterRow key={m.meter_id} meter={m} />)}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function CycleHeader({ sub }: { sub: { plan_name: string; current_period_start: string; current_period_end: string } }) {
+  const { plan_name, current_period_start, current_period_end } = sub
+  const start = new Date(current_period_start).getTime()
+  const end = new Date(current_period_end).getTime()
+  const now = Date.now()
+  const totalDays = Math.max(1, Math.round((end - start) / 86_400_000))
+  const daysIn = Math.max(0, Math.min(totalDays, Math.round((now - start) / 86_400_000)))
+  const pct = totalDays > 0 ? Math.min(100, (daysIn / totalDays) * 100) : 0
+  return (
+    <div className="flex items-center gap-3 min-w-0">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground truncate">{plan_name}</p>
+        <p className="text-xs text-muted-foreground tabular-nums">
+          Day {daysIn} of {totalDays} · {pct.toFixed(0)}% through
+        </p>
+      </div>
+      <div className="w-24 h-1.5 rounded-full bg-muted overflow-hidden">
+        <div className="h-full bg-primary rounded-full" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  )
+}
+
+function MeterRow({ meter }: { meter: CustomerUsageMeter }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasMultipleRules = meter.rules.length > 1
+  const totalQty = useMemo(() => Number(meter.total_quantity), [meter.total_quantity])
+
+  return (
+    <Card>
+      <CardContent className="p-0">
+        <button
+          type="button"
+          className={cn(
+            'w-full px-5 py-4 flex items-center gap-4 text-left transition-colors',
+            hasMultipleRules ? 'cursor-pointer hover:bg-muted/30' : 'cursor-default',
+          )}
+          onClick={() => hasMultipleRules && setExpanded(e => !e)}
+          disabled={!hasMultipleRules}
+        >
+          {hasMultipleRules ? (
+            expanded ? <ChevronDown size={14} className="text-muted-foreground shrink-0" /> : <ChevronRight size={14} className="text-muted-foreground shrink-0" />
+          ) : <span className="w-3.5" />}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{meter.meter_name}</p>
+            <p className="text-xs text-muted-foreground font-mono">
+              {totalQty.toLocaleString(undefined, { maximumFractionDigits: 6 })} {meter.unit}
+              {hasMultipleRules && <span className="ml-2 text-muted-foreground">· {meter.rules.length} rules</span>}
+            </p>
+          </div>
+          <p className="text-sm font-semibold text-foreground tabular-nums shrink-0">
+            {formatCents(meter.total_amount_cents, meter.currency)}
+          </p>
+        </button>
+
+        {expanded && hasMultipleRules && (
+          <div className="border-t border-border bg-muted/20">
+            {meter.rules.map(r => <RuleRow key={r.rating_rule_version_id} rule={r} unit={meter.unit} currency={meter.currency} />)}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function RuleRow({ rule, unit, currency }: { rule: CustomerUsageRule; unit: string; currency: string }) {
+  const qty = Number(rule.quantity)
+  return (
+    <div className="px-5 py-2.5 flex items-center gap-4 text-xs border-b border-border last:border-b-0">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant="secondary" className="font-mono">{rule.rule_key}</Badge>
+          {rule.dimension_match && Object.entries(rule.dimension_match).map(([k, v]) => (
+            <span key={k} className="inline-flex items-center font-mono bg-muted px-1.5 py-0.5 rounded text-foreground/80">
+              {k}=<span className="text-foreground">{String(v)}</span>
+            </span>
+          ))}
+        </div>
+        <p className="text-muted-foreground font-mono mt-1">
+          {qty.toLocaleString(undefined, { maximumFractionDigits: 6 })} {unit}
+        </p>
+      </div>
+      <p className="font-semibold text-foreground tabular-nums shrink-0">
+        {formatCents(rule.amount_cents, currency)}
+      </p>
+    </div>
+  )
+}

--- a/web-v2/src/components/CostDashboard.tsx
+++ b/web-v2/src/components/CostDashboard.tsx
@@ -136,9 +136,7 @@ export function CostDashboard({ customerId }: { customerId: string }) {
                 </div>
                 <ul className="text-xs text-amber-700 dark:text-amber-300 space-y-1">
                   {data.warnings.map((w, i) => (
-                    <li key={i}>
-                      <span className="font-mono">{w.code}</span> · {w.message}
-                    </li>
+                    <li key={i}>{w}</li>
                   ))}
                 </ul>
               </CardContent>

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -655,26 +655,28 @@ export interface RecipeCreatesSummary {
   webhook_endpoints: number
 }
 
+export interface RecipeOverrideSchema {
+  key: string
+  type: 'string' | 'number' | 'boolean'
+  default?: string | number | boolean
+  description?: string
+  enum?: (string | number)[]
+  max_length?: number
+  pattern?: string
+}
+
 export interface Recipe {
   key: string
   version: string
   name: string
   summary: string
   creates: RecipeCreatesSummary
-  overridable: string[]
+  overridable: RecipeOverrideSchema[]
   instantiated?: { id: string; instantiated_at: string } | null
-}
-
-export interface RecipeOverrideSchema {
-  type: 'string' | 'number' | 'boolean'
-  default?: string | number | boolean
-  description?: string
-  enum?: (string | number)[]
 }
 
 export interface RecipeDetail extends Recipe {
   description: string
-  overridable_schema: Record<string, RecipeOverrideSchema>
 }
 
 export interface RecipePreview {

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -624,11 +624,11 @@ export interface MeterPricingRule {
   created_at: string
 }
 
-// CustomerUsage — response of GET /v1/customers/{id}/usage. Designed against
-// docs/design-customer-usage.md. `totals` is modeled as an array unconditionally
-// (single-currency tenants get a length-1 array) so the client doesn't need a
-// polymorphic discriminator — flagged this preference to Track A in the RFC
-// review; if the backend keeps a polymorphic single-currency shape we adapt here.
+// CustomerUsage — response of GET /v1/customers/{id}/usage. Live shape from
+// internal/usage/customer_usage.go (PR #26). `totals` is unconditionally an
+// array (single-currency tenants get length 1) so the client iterates without
+// branching. `warnings` is a plain string list — the backend opted for human
+// messages rather than structured codes since dashboards just render them.
 export interface CustomerUsage {
   customer_id: string
   period: {
@@ -639,7 +639,7 @@ export interface CustomerUsage {
   subscriptions: CustomerUsageSubscription[]
   meters: CustomerUsageMeter[]
   totals: { currency: string; amount_cents: number }[]
-  warnings: CustomerUsageWarning[]
+  warnings: string[]
 }
 
 export interface CustomerUsageSubscription {
@@ -668,13 +668,6 @@ export interface CustomerUsageRule {
   dimension_match?: Record<string, string | number | boolean>
   quantity: string
   amount_cents: number
-}
-
-export interface CustomerUsageWarning {
-  code: string
-  message: string
-  subscription_id?: string
-  meter_id?: string
 }
 
 export interface RecipeCreatesSummary {

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -125,18 +125,12 @@ export const api = {
     apiRequest<MeterPricingRule>('POST', `/meters/${meterId}/pricing-rules`, data),
   deleteMeterPricingRule: (meterId: string, ruleId: string) =>
     apiRequest<{ status: string }>('DELETE', `/meters/${meterId}/pricing-rules/${ruleId}`),
-  customerUsageBreakdown: (
-    customerId: string,
-    params: { event_name: string; period_start: string; period_end: string; group_by?: string[] },
-  ) => {
+  customerUsage: (customerId: string, params?: { from?: string; to?: string }) => {
     const qs = new URLSearchParams()
-    qs.set('event_name', params.event_name)
-    qs.set('period_start', params.period_start)
-    qs.set('period_end', params.period_end)
-    if (params.group_by && params.group_by.length > 0) {
-      qs.set('group_by', params.group_by.join(','))
-    }
-    return apiRequest<CustomerUsageBreakdown>('GET', `/customers/${customerId}/usage?${qs.toString()}`)
+    if (params?.from) qs.set('from', params.from)
+    if (params?.to) qs.set('to', params.to)
+    const q = qs.toString()
+    return apiRequest<CustomerUsage>('GET', `/customers/${customerId}/usage${q ? '?' + q : ''}`)
   },
   listPlans: () =>
     apiRequest<{ data: Plan[] }>('GET', '/plans'),
@@ -630,19 +624,57 @@ export interface MeterPricingRule {
   created_at: string
 }
 
-export interface CustomerUsageBreakdown {
+// CustomerUsage — response of GET /v1/customers/{id}/usage. Designed against
+// docs/design-customer-usage.md. `totals` is modeled as an array unconditionally
+// (single-currency tenants get a length-1 array) so the client doesn't need a
+// polymorphic discriminator — flagged this preference to Track A in the RFC
+// review; if the backend keeps a polymorphic single-currency shape we adapt here.
+export interface CustomerUsage {
   customer_id: string
-  event_name: string
-  period_start: string
-  period_end: string
-  group_by: string[]
-  buckets: {
-    dimensions: Record<string, string | number | boolean>
-    rule_id: string | null
-    aggregation_mode: MeterAggregationMode
-    quantity: string
-    projected_amount_cents: number
-  }[]
+  period: {
+    from: string
+    to: string
+    source: 'current_billing_cycle' | 'explicit'
+  }
+  subscriptions: CustomerUsageSubscription[]
+  meters: CustomerUsageMeter[]
+  totals: { currency: string; amount_cents: number }[]
+  warnings: CustomerUsageWarning[]
+}
+
+export interface CustomerUsageSubscription {
+  id: string
+  plan_id: string
+  plan_name: string
+  currency: string
+  current_period_start: string
+  current_period_end: string
+}
+
+export interface CustomerUsageMeter {
+  meter_id: string
+  meter_key: string
+  meter_name: string
+  unit: string
+  currency: string
+  total_quantity: string
+  total_amount_cents: number
+  rules: CustomerUsageRule[]
+}
+
+export interface CustomerUsageRule {
+  rating_rule_version_id: string
+  rule_key: string
+  dimension_match?: Record<string, string | number | boolean>
+  quantity: string
+  amount_cents: number
+}
+
+export interface CustomerUsageWarning {
+  code: string
+  message: string
+  subscription_id?: string
+  meter_id?: string
 }
 
 export interface RecipeCreatesSummary {

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -32,6 +32,19 @@ const entries: {
   },
   {
     date: '2026-04-26',
+    title: 'Recipes — point-and-click pricing installation',
+    tag: 'feature',
+    body: 'The recipes feature gets a discoverable UI. /recipes lists the five built-in templates with a creates-summary on each card; the configure dialog walks operators through overrides → preview → install in three clicks. Same atomic POST /v1/recipes/{key}/instantiate under the hood.',
+    bullets: [
+      'Recipe cards show key + version, summary, and a "creates" chip strip (e.g. 1 meter · 9 pricing rules · 1 plan). An "Installed" badge surfaces tenants who have already instantiated.',
+      'Configure dialog renders the overrides form from the recipe\'s own schema — string / number / boolean inputs, with enum, max_length, and pattern honored from the YAML.',
+      'Preview button hits POST /v1/recipes/{key}/preview and renders generated objects + warnings inline so the operator sees exactly what will land before committing.',
+      'Install navigates to the first created plan so the new catalog is one click away.',
+      'Sidebar entry under Configuration with the Sparkles icon. Onboarding wizard step 1 also fetches /v1/recipes live and deep-links into the picker.',
+    ],
+  },
+  {
+    date: '2026-04-26',
     title: 'Recipes API wire shape — snake_case + creates summary + preview wrapper',
     tag: 'fix',
     body: 'Three drifts between the recipes API design doc and the Week 3 implementation are fixed so the picker UI lights up cleanly: PascalCase JSON keys are now snake_case (matching the rest of /v1/*), each list/detail entry carries a creates: {meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints} count summary, and POST /v1/recipes/{key}/preview now wraps its response as {key, version, objects: {…}, warnings: []} per the spec. Data shape only — no behavior change to instantiate / uninstall.',
@@ -40,6 +53,19 @@ const entries: {
       'GET /v1/recipes and GET /v1/recipes/{key} now include a creates summary so the picker UI renders "1 meter · 9 pricing rules · monthly billing" chips without a follow-up preview call.',
       'POST /v1/recipes/{key}/preview returns {key, version, objects: {meters, rating_rules, pricing_rules, plans, dunning_policies, webhook_endpoints}, warnings: []} per the spec — previously inlined every array at the top level. dunning_policies and webhook_endpoints are 0-or-1-length slices for uniform iteration.',
       'New TestWireShape_SnakeCase regression test pins all three contracts so future drift trips CI before reaching the dashboard.',
+    ],
+  },
+  {
+    date: '2026-04-26',
+    title: 'Multi-dimensional meters in the dashboard',
+    tag: 'feature',
+    body: 'Two operator surfaces light up the multi-dim meter engine. Meter detail pages now expose dimension-matched pricing rules end-to-end, and the usage events log surfaces dimensions inline with key=value chips and a dimension filter. Operators can build, inspect, and audit AI-style multi-rule pricing without touching the API.',
+    bullets: [
+      'Meter detail (/meters/:id) gets a "Dimension-matched rules" section with a chips-table view of each rule\'s dimension_match, aggregation mode, priority, and rating rule.',
+      '"Add rule" dialog walks operators through dimension key/value pairs, rating-rule selector, and one of five aggregation modes (sum, count, last_during_period, last_ever, max). Typed-confirm delete on each rule.',
+      'Usage events (/usage) gets a Dimensions column that conditionally appears when at least one event in view carries dimensions. New key=value text filter narrows the list.',
+      'CSV export now includes the full dimensions JSON column, and stats / meter-breakdowns read the decimal-precision quantity field with no truncation.',
+      'Default pricing rule on each meter is now labeled clearly as the fallback for events not claimed by a higher-priority dimension-matched rule.',
     ],
   },
   {

--- a/web-v2/src/pages/CustomerDetail.tsx
+++ b/web-v2/src/pages/CustomerDetail.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 import { api, formatCents, formatDate, formatDateTime, type Customer, type BillingProfile, type Plan, type Subscription, type PaymentSetup, type CustomerDunningOverride, type CustomerCouponAssignment } from '@/lib/api'
 import { applyApiError, showApiError } from '@/lib/formErrors'
 import { Layout } from '@/components/Layout'
+import { CostDashboard } from '@/components/CostDashboard'
 import { cn } from '@/lib/utils'
 import { statusBadgeVariant } from '@/lib/status'
 
@@ -121,18 +122,6 @@ export default function CustomerDetailPage() {
     enabled: !!id,
   })
 
-  const { data: usageSummary } = useQuery({
-    queryKey: ['customer-usage', id, allSubs],
-    queryFn: () => {
-      const activeSub = allSubs?.find(s => s.status === 'active' && s.current_billing_period_start && s.current_billing_period_end)
-      if (activeSub) {
-        return api.usageSummary(id!, activeSub.current_billing_period_start!, activeSub.current_billing_period_end!)
-      }
-      return api.usageSummary(id!)
-    },
-    enabled: !!id && allSubs !== undefined,
-  })
-
   const { data: paymentSetup } = useQuery({
     queryKey: ['customer-payment-status', id],
     queryFn: () => api.getPaymentStatus(id!).catch(() => ({ customer_id: '', setup_status: 'missing' } as PaymentSetup)),
@@ -233,8 +222,6 @@ export default function CustomerDetailPage() {
       </Layout>
     )
   }
-
-  const activeSub = allSubs?.find(s => s.status === 'active' && s.current_billing_period_start && s.current_billing_period_end)
 
   return (
     <Layout>
@@ -629,39 +616,13 @@ export default function CustomerDetailPage() {
         </CardContent>
       </Card>
 
-      {/* Usage This Period */}
-      <Card className="mt-6">
-        <CardHeader>
-          <div>
-            <CardTitle className="text-sm">Usage This Period</CardTitle>
-            {activeSub && (
-              <p className="text-sm text-muted-foreground mt-0.5">
-                {formatDate(activeSub.current_billing_period_start!)} -- {formatDate(activeSub.current_billing_period_end!)}
-              </p>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent className="p-0">
-          {usageSummary && Object.keys(usageSummary.meters).length > 0 ? (
-            <div className="divide-y divide-border">
-              {Object.entries(usageSummary.meters).map(([meter, qty]) => {
-                const m = meterMap[meter]
-                return (
-                  <div key={meter} className="flex items-center justify-between px-6 py-3">
-                    <div>
-                      <p className="text-sm text-foreground">{m?.name || meter}</p>
-                      {m?.unit && <p className="text-sm text-muted-foreground">{m.unit}</p>}
-                    </div>
-                    <span className="text-sm font-semibold text-foreground tabular-nums">{qty.toLocaleString()}</span>
-                  </div>
-                )
-              })}
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground text-center py-8">No usage recorded</p>
-          )}
-        </CardContent>
-      </Card>
+      {/* Usage This Period — multi-dim cost dashboard backed by
+          GET /v1/customers/{id}/usage. Replaces the old quantity-only summary.
+          Component is self-contained so the same surface drops into a future
+          public iframe-able route once token-based access lands. */}
+      <div className="mt-6">
+        <CostDashboard customerId={id!} />
+      </div>
 
       {/* Payment Method */}
       <Card className="mt-6">

--- a/web-v2/src/pages/Recipes.tsx
+++ b/web-v2/src/pages/Recipes.tsx
@@ -229,27 +229,14 @@ function RecipeDialog({ recipe, onClose }: { recipe: Recipe; onClose: () => void
         {/* Overrides */}
         <div>
           <Label className="text-xs uppercase tracking-wide text-muted-foreground">Overrides</Label>
-          {detail?.overridable_schema && Object.keys(detail.overridable_schema).length > 0 ? (
+          {recipe.overridable.length > 0 ? (
             <div className="space-y-3 mt-2">
-              {Object.entries(detail.overridable_schema).map(([key, schema]) => (
+              {recipe.overridable.map(schema => (
                 <OverrideField
-                  key={key}
-                  fieldKey={key}
+                  key={schema.key}
                   schema={schema}
-                  value={overrides[key] ?? schema.default ?? ''}
-                  onChange={(v) => setOverride(key, v)}
-                />
-              ))}
-            </div>
-          ) : recipe.overridable.length > 0 ? (
-            <div className="space-y-3 mt-2">
-              {recipe.overridable.map(key => (
-                <OverrideField
-                  key={key}
-                  fieldKey={key}
-                  schema={{ type: 'string' }}
-                  value={overrides[key] ?? ''}
-                  onChange={(v) => setOverride(key, v)}
+                  value={overrides[schema.key] ?? schema.default ?? ''}
+                  onChange={(v) => setOverride(schema.key, v)}
                 />
               ))}
             </div>
@@ -317,36 +304,31 @@ function RecipeDialog({ recipe, onClose }: { recipe: Recipe; onClose: () => void
 }
 
 function OverrideField({
-  fieldKey,
   schema,
   value,
   onChange,
 }: {
-  fieldKey: string
   schema: RecipeOverrideSchema
   value: string | number | boolean
   onChange: (v: string | number | boolean) => void
 }) {
+  const id = `override-${schema.key}`
   if (schema.type === 'boolean') {
     return (
       <div className="flex items-center justify-between">
-        <Label htmlFor={`override-${fieldKey}`} className="font-mono text-sm">{fieldKey}</Label>
-        <Switch
-          id={`override-${fieldKey}`}
-          checked={!!value}
-          onCheckedChange={onChange}
-        />
+        <Label htmlFor={id} className="font-mono text-sm">{schema.key}</Label>
+        <Switch id={id} checked={!!value} onCheckedChange={onChange} />
       </div>
     )
   }
   return (
     <div>
       <div className="flex items-center justify-between">
-        <Label htmlFor={`override-${fieldKey}`} className="font-mono text-sm">{fieldKey}</Label>
+        <Label htmlFor={id} className="font-mono text-sm">{schema.key}</Label>
         {schema.description && <span className="text-xs text-muted-foreground">{schema.description}</span>}
       </div>
       <Input
-        id={`override-${fieldKey}`}
+        id={id}
         type={schema.type === 'number' ? 'number' : 'text'}
         value={String(value)}
         onChange={(e) => {
@@ -354,6 +336,8 @@ function OverrideField({
           onChange(schema.type === 'number' ? Number(raw) : raw)
         }}
         className="mt-1.5 font-mono"
+        maxLength={schema.max_length}
+        pattern={schema.pattern}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
Track B's Week 5 prep slice (cost dashboard scaffold + recipes TS adapt), rebased onto current main and aligned with the live PR #26 wire shape.

- **Cost dashboard scaffold** (`<CostDashboard customerId />`) — current cycle / last 30d / last 90d period selector, big-number totals strip (one per currency), per-meter cards expandable to per-rule rows with `dimension_match` chips, warnings banner, RLS-friendly empty states for `customer_has_no_subscription` (400) and cross-tenant 404. Self-contained for future iframe-able drop-in.
- **Recipes TS shape collapse** — adapted to PR #25's actual wire shape: `Recipe.overridable: RecipeOverrideSchema[]` with `key` embedded, instead of the design's `string[]` + separate `Record<key, schema>` split. Strictly better: single source of truth, no client-side merge.
- **Live API alignment** (extra commit on top of original Track B work): TS `warnings` is now `string[]` to match what `internal/usage/customer_usage.go` actually emits — drops the structured `CustomerUsageWarning` interface that the RFC draft had modeled.

## Wire shape (live PR #26)
- `period: { from, to, source: 'current_billing_cycle' | 'explicit' }`
- `subscriptions: [{ id, plan_id, plan_name, currency, current_period_start, current_period_end }]`
- `meters: [{ meter_id, meter_key, meter_name, unit, currency, total_quantity (decimal string), total_amount_cents, rules: [...] }]`
- `meters[].rules: [{ rating_rule_version_id, rule_key, dimension_match? (Record<string, any>), quantity (decimal string), amount_cents }]`
- `totals: [{ currency, amount_cents }]` — always-array, single-currency tenants get length 1
- `warnings: string[]` — plain human messages

## Test plan
- [x] `tsc -b` clean
- [x] `vite build` succeeds (~680ms; new lazy chunk for cost dashboard)
- [ ] Visual smoke against running backend (deferred — tested in next session against a tenant with multi-dim usage)

## Provenance
Original Track B branch off pre-PR-#26 main; rebased onto post-PR-#26 main with three conflict resolutions (CHANGELOG.md, Changelog.tsx, parallel-handoff.md — all kept-both since each side described disjoint surfaces). Plus one commit aligning the TS to the live wire shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)