### PR TITLE
feat(billing): create_preview endpoint — Stripe Tier 1 parity (Week 5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,68 @@ Two surfaces mirror this file:
 
 ### Added
 
+- **Create-preview endpoint — Stripe Tier 1 parity for `Invoice.upcoming`** (2026-04-26) —
+  the third flagship developer-experience surface alongside customer-usage
+  and recipes (per `docs/design-create-preview.md`, `docs/positioning.md`
+  pillar 1.4). `POST /v1/invoices/create_preview` answers "what is my
+  next bill going to look like?" with the same line set the cycle scan
+  would emit if billing fired right now — so dashboard projected-bill
+  math == invoice math by construction. Body is `{customer_id,
+  subscription_id?, period?}`; `subscription_id` defaults to the
+  customer's primary active or trialing sub (most-recent-cycle wins),
+  and `period` defaults to that sub's current billing cycle. Response
+  carries one line per `(meter, rule)` pair — multi-dim meters surface
+  one line per rule with `dimension_match` echoed from the meter
+  pricing rule (the canonical pricing identity), single-rule meters
+  keep the one-line-per-meter shape. `quantity` marshals as a precise
+  decimal string (NUMERIC(38,12) round-trip per ADR-005) so fractional
+  AI-usage primitives (GPU-hours, cached-token ratios) don't lose
+  precision; amounts are integer cents. `totals[]` is always-array
+  (one entry per distinct currency, even when there's only one) — same
+  shape customer-usage uses, so a single TS type set covers both
+  surfaces. The big shift here: the existing `Engine.Preview` wired
+  against `usage.AggregateForBillingPeriod` (not multi-dim aware) is
+  replaced with the priority+claim LATERAL JOIN path
+  (`usage.AggregateByPricingRules`) the cycle scan and customer-usage
+  already use. Multi-dim tenants were silently looking at wrong
+  projected-bill numbers in the in-app debug route; that gap is closed.
+  RLS-by-construction: cross-tenant customer IDs return 404 at the
+  customer lookup. No DB writes — the integration test asserts row
+  counts of `invoices` and `invoice_line_items` are unchanged
+  before/after the call. Errors: `404` for unknown customer or
+  subscription; `422 invalid_request` for cross-customer subscription
+  IDs; `422 customer_has_no_subscription` (coded, symmetric with
+  customer-usage) when implicit pick has zero active subs; `422` for
+  partial period bounds, `from >= to`, or unparseable RFC 3339.
+  Mounted at `/v1/invoices/create_preview` as a sibling of `/invoices`
+  (registered first so chi picks the more-specific pattern, otherwise
+  `/{id}` would capture `create_preview` as an invoice ID) behind
+  `PermInvoiceRead`. Snake-case JSON keys, struct-tag enforced; empty
+  list fields emit `[]` not `null` (regression-tested by
+  `TestWireShape_SnakeCase` — the merge gate). Service composes
+  through three narrow interfaces local to the billing package
+  (`CustomerLookup`, `SubscriptionLister`, plus the engine's existing
+  `PricingReader`/`UsageAggregator` extended with
+  `ListMeterPricingRulesByMeter` + `AggregateByPricingRules`) so the
+  preview owns no cross-domain state. Tests: 16 unit cases (period
+  resolution table-driven, primary-sub pick table-driven, explicit-ID
+  happy path + cross-customer rejection + 404 propagation, blank
+  customer ID, customer-not-found, JSON-decode edge cases, totals
+  roll-up multi-currency stable order, blank-currency exclusion,
+  wire-shape full + empty-slices regression) plus seven integration
+  cases against real Postgres (single-meter flat parity matching
+  customer-usage exactly, multi-dim parity matching the LATERAL JOIN,
+  no-writes assertion via row-count diff, cross-tenant 404,
+  `customer_has_no_subscription` coded error, explicit-subscription
+  wrong-customer rejection). Existing `/v1/billing/preview/{id}` debug
+  route now returns the new shape too (consistent line composition;
+  `web-v2` `SubscriptionDetail.tsx` updated to use `totals[]` per-row
+  rendering, `lib/api.ts` `InvoicePreview` retyped — `quantity` is now
+  a string, top-level `subtotal_cents`/`currency` removed). v2
+  deferred: inline `invoice_items` overlay (modeling "+$50 charge"),
+  plan-change overlay (Week 5c will own it), coupon/credit/tax
+  application (engine still doesn't reproduce these in preview).
+
 - **Customer usage endpoint — one call answers "what did this customer use?"** (2026-04-26) —
   the second flagship developer-experience surface, alongside recipes (per
   `docs/design-customer-usage.md`, `docs/positioning.md` pillar 1.4). `GET

--- a/docs/design-create-preview.md
+++ b/docs/design-create-preview.md
@@ -1,0 +1,293 @@
+# Create-Preview Endpoint — Technical Design
+
+> **Status:** Draft v1
+> **Owner:** Track A
+> **Last revised:** 2026-04-26
+> **Implementation window:** Week 5b of `docs/90-day-plan.md`
+> **Related:** `docs/design-customer-usage.md` (sibling read surface, same composition pattern), `docs/design-multi-dim-meters.md` (Week 2 dependency — `usage.AggregateByPricingRules` is the engine), `docs/positioning.md` pillar 1.4 (cost transparency)
+
+## Motivation
+
+Stripe ships `Invoice.create_preview` (formerly `Invoice.upcoming`) as a Tier 1 surface — every customer asks "what is my bill going to be?" before the cycle closes. Velox already has the in-memory plumbing in `Engine.Preview` (the dashboard `GET /v1/billing/preview/{subscription_id}` route), but it's wired against the **old** aggregation path `usage.AggregateForBillingPeriod`, which is not multi-dim aware. Week 2 shipped `usage.AggregateByPricingRules` (LATERAL JOIN with priority+claim across 5 aggregation modes); the cycle scan and the customer-usage endpoint already use it. The preview is the only consumer left on the old path — every multi-dim tenant is silently looking at wrong projected-bill numbers today.
+
+This slice has three deliverables:
+
+1. **Switch `Engine.Preview` to use `AggregateByPricingRules`.** Same code path as the cycle scan → preview math == invoice math. Drift between dashboard projected-bill and the actual finalized invoice is the worst possible UX for a billing engine, and as multi-dim tenants ramp this gap widens silently.
+2. **Expose the result over a stable wire contract** at `POST /v1/invoices/create_preview`. Stripe-equivalent path, request body the dashboard can reuse for plan-change confirmation dialogs (Week 5c) and the operator plan-migration preview (Week 6).
+3. **Match the response shape pattern of `customer-usage`** so a single TS type set in the dashboard handles both surfaces — cost dashboard renders the projected-bill line by reading the same `totals[]` shape it already reads for current-period spend.
+
+The dashboard's "projected bill" line in `web-v2/src/components/CostDashboard.tsx` is the immediate Track B unblock. Plan-change confirmation dialog (Week 5c) and the bulk plan-migration preview (Week 7) are the next two consumers.
+
+## Goals
+
+- **Read-only preview of the customer's next invoice.** Caller passes a `customer_id` (and optionally a `subscription_id`); response is the line set the cycle scan would emit if billing fired right now. Zero DB writes — assertable in tests.
+- **Multi-dim parity with the cycle scan.** Each `(meter, rule)` pair surfaces as a distinct preview line with `dimension_match` echoed from the meter pricing rule. Single-rule meters keep the existing one-line-per-meter shape. Same priority+claim resolution the cycle scan uses; same `domain.ComputeAmountCents` per rule bucket.
+- **Cost-dashboard ergonomic.** Response shape mirrors `customer-usage`: per-line `quantity` as a precise decimal string, integer cents on `amount_cents`, `totals[]` always-array (one entry per distinct currency, even when there's only one). Cost dashboard's existing `formatCents(totals[0].amount_cents)` chain works on both.
+- **Stripe-shaped path.** `POST /v1/invoices/create_preview`, body `{customer_id, subscription_id?, period?}`. Stripe's surface accepts an inline `subscription` payload to model "what would happen if I changed this customer's plan to X"; we defer that to v2 (see open question 1) — v1 is read-only against the existing subscription.
+- **RLS-safe.** Standard `BeginTx(ctx, postgres.TxTenant, tenantID)` through every collaborator. Cross-tenant customer IDs surface as 404 at the customer lookup, by construction.
+- **Documented contract Track B can call today.** Cost dashboard swaps the projected-bill line from "elapsed-vs-total cycle ratio extrapolation" to a real backend call as soon as this ships.
+
+## Non-goals (deferred)
+
+- **Inline `invoice_items` additions / one-off line adjustments.** Stripe's `create_preview` accepts an `invoice_items` array so a caller can model "preview my bill if I also added this $50 charge". Useful, but it's a separable surface — defer to v2 once a real consumer asks. The current dashboard projected-bill line doesn't need it.
+- **Plan-change override semantics.** Stripe lets the caller pass `subscription_items` to model "preview my bill if I switched plans". The Week 5c plan-change confirmation dialog will need this; punt to that work so we don't merge a half-shape that the dialog rebuilds anyway.
+- **Coupon / credit application preview.** Engine.Preview today doesn't apply discounts or credits; we keep that boundary in v1. The cycle scan's discount and credit application is its own pass; reproducing it here invites drift between two implementations of "what's the bill". Open question 4 covers a v2 rev that applies them server-side once customer-usage exposes a shared apply-discount-to-line-set helper.
+- **Tax preview.** Same rationale — tax calculation depends on the tenant's provider config and the customer's billing profile; reproducing the path is real work and the dashboard projected-bill line doesn't need it. Defer to v2 with a `taxes_enabled` flag if a real consumer asks.
+- **Past-period replay.** v1 always previews the current cycle. Closed cycles are served by `GET /v1/invoices/{id}` (the canonical historical record). No double-implementation here.
+
+## Today's surface (in repo)
+
+This endpoint is **composition over invention**. The hard work already exists:
+
+- `internal/billing/preview.go::Engine.Preview(ctx, sub) (PreviewResult, error)` — existing in-memory preview. Walks subscription items, fetches plans, emits `base_fee` lines per item plus per-meter usage lines. Currently uses `usage.AggregateForBillingPeriod` (not multi-dim aware) — this slice swaps it.
+- `internal/usage/service.go::Service.AggregateByPricingRules(ctx, tenantID, customerID, meterID, defaultMode, from, to)` — the priority+claim LATERAL JOIN across 5 aggregation modes. Already shipped, already used by the cycle scan and customer-usage.
+- `internal/pricing/service.go::Service.{GetPlan, GetMeter, GetRatingRule, ListMeterPricingRulesByMeter}` — the read surface for plan/meter/rule resolution. Same surface customer-usage composes against.
+- `internal/customer/store.go::Store.Get(ctx, tenantID, id)` — RLS-safe customer lookup. 404s for cross-tenant IDs.
+- `internal/subscription/store.go::Store.List(ctx, filter)` — list active subs for a customer (filter by `customer_id`).
+- `internal/domain/pricing.go::ComputeAmountCents(rule, quantity)` — pricing engine. Same path the cycle scan calls; multi-dim tenants get rule-by-rule rating identical to billing.
+
+The slice is exactly the same composition pattern as `customer-usage`: customer existence → subscription resolution → period → walk meters → rate per rule → assemble. The only differences are (a) we're previewing one specific subscription rather than aggregating across all of a customer's, and (b) the response includes `base_fee` lines from the plan's `BaseAmountCents`.
+
+## API surface
+
+> **Wire-contract conventions** (consistent with `/v1/*`, see `docs/design-customer-usage.md` § wire-contract):
+>
+> - **Snake-case JSON keys**, struct-tag enforced.
+> - **Customer identity is the customer ID** (`vlx_cus_…`). Mirrors customer-usage.
+> - **Period bounds are RFC 3339** (`2026-04-01T00:00:00Z`). Both inclusive of `from`, exclusive of `to`. If both omitted → defaults to the subscription's current cycle. Partial bounds (one zero, one non-zero) are rejected with 400.
+> - **Empty results are `[]`, never `null`.**
+> - **Decimal quantity** marshals as a precise string (`"1234567.000000000000"`) per ADR-005. Amounts are integer cents.
+> - **Always-array totals.** `totals[]` is one entry per distinct currency, even when there's only one. Same shape customer-usage uses; one TS type covers both surfaces.
+
+### `POST /v1/invoices/create_preview`
+
+```http
+POST /v1/invoices/create_preview
+Authorization: Bearer <secret_key>
+Content-Type: application/json
+
+{
+  "customer_id": "vlx_cus_abc123",
+  "subscription_id": "vlx_sub_xyz",
+  "period": {
+    "from": "2026-04-01T00:00:00Z",
+    "to":   "2026-05-01T00:00:00Z"
+  }
+}
+```
+
+Both `subscription_id` and `period` are optional. If `subscription_id` is omitted, the server picks the customer's primary active or trialing subscription. If `period` is omitted, the server uses the subscription's current billing cycle.
+
+Response `200`:
+```json
+{
+  "customer_id": "vlx_cus_abc123",
+  "subscription_id": "vlx_sub_xyz",
+  "plan_name": "AI API Pro",
+  "billing_period_start": "2026-04-01T00:00:00Z",
+  "billing_period_end":   "2026-05-01T00:00:00Z",
+  "lines": [
+    {
+      "line_type": "base_fee",
+      "description": "AI API Pro - base fee (qty 1)",
+      "currency": "USD",
+      "quantity": "1",
+      "unit_amount_cents": 0,
+      "amount_cents": 0
+    },
+    {
+      "line_type": "usage",
+      "description": "Tokens - input (cached)",
+      "meter_id": "vlx_mtr_tokens",
+      "rating_rule_version_id": "vlx_rrv_gpt4_input_uncached",
+      "rule_key": "gpt4_input_uncached",
+      "dimension_match": { "model": "gpt-4", "operation": "input", "cached": false },
+      "currency": "USD",
+      "quantity": "1000000.000000000000",
+      "unit_amount_cents": 0,
+      "amount_cents": 3000,
+      "pricing_mode": "flat"
+    },
+    {
+      "line_type": "usage",
+      "description": "Tokens - output",
+      "meter_id": "vlx_mtr_tokens",
+      "rating_rule_version_id": "vlx_rrv_gpt4_output",
+      "rule_key": "gpt4_output",
+      "dimension_match": { "model": "gpt-4", "operation": "output" },
+      "currency": "USD",
+      "quantity": "234567.000000000000",
+      "unit_amount_cents": 0,
+      "amount_cents": 704
+    }
+  ],
+  "totals": [
+    { "currency": "USD", "amount_cents": 3704 }
+  ],
+  "warnings": [],
+  "generated_at": "2026-04-26T12:00:00Z"
+}
+```
+
+`lines[]` is a flat list — each `(meter, rule)` pair becomes its own line. Single-rule meters emit one line per meter (no `dimension_match` echo). Multi-rule meters emit one line per rule with `dimension_match` carrying the rule's match expression (the canonical pricing identity, mirrored from customer-usage).
+
+`totals[]` is always an array — one entry per distinct currency seen across lines. Single-currency tenants get a one-entry array; multi-currency setups (rare today, real for cross-region tenants) get one entry per currency. Cost dashboard reads `totals[0].amount_cents` for both shapes.
+
+`warnings[]` mirrors customer-usage: non-fatal conditions (a meter has events outside any rule's `dimension_match` and is falling through to the meter default; a meter has rating rules with mismatched currencies; etc.). Empty array in v1 if everything is clean.
+
+`generated_at` is the server clock at preview-compute time. Useful for the dashboard to show "as of 12:00 UTC" subtitle without an extra request-header read.
+
+### Error shapes
+
+- `400 invalid_request` — `customer_id` blank or missing.
+- `404 customer_not_found` — no customer with this ID for the tenant.
+- `400 customer_has_no_subscription` (coded) — caller passed no `subscription_id` and the customer has zero active or trialing subscriptions. Same error code as customer-usage so the dashboard's empty-state branch covers both surfaces.
+- `404 subscription_not_found` — `subscription_id` was passed but no sub exists for the tenant with that ID.
+- `400 invalid_period` — `from` after `to`, partial bounds, or unparseable RFC 3339.
+
+## Internals
+
+### Composition
+
+```go
+// internal/billing/preview_create.go (sketch)
+func (s *PreviewService) CreatePreview(
+    ctx context.Context,
+    tenantID string,
+    req CreatePreviewRequest,
+) (PreviewResult, error) {
+    cust, err := s.customers.Get(ctx, tenantID, req.CustomerID)
+    if err != nil { return PreviewResult{}, err } // 404 propagates
+
+    sub, err := s.resolveSubscription(ctx, tenantID, cust.ID, req.SubscriptionID)
+    if err != nil { return PreviewResult{}, err }
+
+    from, to, err := s.resolvePeriod(req.Period, sub)
+    if err != nil { return PreviewResult{}, err }
+
+    plansByID, meterIDs, err := s.collectPlanAndMeters(ctx, tenantID, sub)
+    if err != nil { return PreviewResult{}, err }
+
+    var lines []PreviewLine
+
+    // Base-fee lines from each subscription item's plan.
+    for _, item := range sub.Items {
+        plan := plansByID[item.PlanID]
+        if plan.BaseAmountCents > 0 {
+            lines = append(lines, baseFeeLine(plan, item))
+        }
+    }
+
+    // Usage lines per (meter, rule).
+    for _, meterID := range meterIDs {
+        meterLines, warnings, err := s.rateMeter(ctx, tenantID, sub.CustomerID, meterID, from, to)
+        if err != nil { return PreviewResult{}, err }
+        lines = append(lines, meterLines...)
+        result.Warnings = append(result.Warnings, warnings...)
+    }
+
+    return assembleResult(sub, plansByID, lines, from, to), nil
+}
+```
+
+`rateMeter` is the same composition as `customer-usage.rateMeter`: call `usage.AggregateByPricingRules`, walk the `(rule_id, quantity)` pairs, hand each to `domain.ComputeAmountCents`, echo `dimension_match` from the meter pricing rule. Output is one `PreviewLine` per rule rather than a single roll-up — the preview's job is to project the invoice's line set, not summarize.
+
+### Subscription resolution
+
+- **Explicit `subscription_id`:** look it up via `subs.Get(ctx, tenantID, id)`; 404 propagates as `subscription_not_found`. Verify the sub belongs to the requested customer (defensive against the rare case where the operator typoed both IDs to plausible-looking-but-mismatched values); mismatch is `400 invalid_request`.
+- **Implicit (no `subscription_id`):** `subs.List(ctx, ListFilter{CustomerID})` then filter to `active`/`trialing`. Pick the one with the latest `current_period_start` (same heuristic as customer-usage's "primary active subscription"). If zero matches, return `customer_has_no_subscription` so the cost dashboard's empty-state branch covers it.
+
+### Period resolution
+
+- **Default:** subscription's `current_billing_period_start`/`_end`. The cycle scan's bounds — preview shows what the next invoice will look like.
+- **Explicit:** parse `from`/`to`, validate `from < to`. Same bounds-check semantics as customer-usage, minus the 1-year cap (preview is always within a single cycle, so caps don't make sense — defer to caller hygiene).
+
+### RLS
+
+Standard `BeginTx(ctx, postgres.TxTenant, tenantID)` through every collaborator. The customer lookup naturally 404s for cross-tenant IDs.
+
+### No DB writes
+
+A standout property of this endpoint vs. the existing `/v1/invoices/{id}/finalize` path: nothing persists. The preview composes reads only; the integration test asserts the row count of `invoices` and `invoice_line_items` is unchanged before/after the call.
+
+## Tests
+
+### Unit tests
+
+- `resolveSubscription` table-driven: explicit ID happy path, explicit ID for wrong customer → invalid_request, implicit pick of latest active sub, implicit with zero subs → coded error, implicit with multiple subs → most-recent-cycle wins.
+- `resolvePeriod` table-driven: default to sub's current cycle, explicit window, partial bounds → 400, `from >= to` → 400, default with no current cycle → coded error.
+- `rateMeter`: single-rule meter emits one line, multi-rule meter emits one line per rule with `dimension_match` echoed, mismatched-rule-currency surfaces a warning, missing-rating-rule line is skipped + warning.
+- `assembleResult`: per-currency `totals[]` rolls up correctly, empty meter slice still emits `lines: []` not null.
+- **`TestWireShape_SnakeCase` (the merge gate):** marshal a real `PreviewResult`, assert every required snake_case key is present (`customer_id`, `subscription_id`, `lines`, `totals`, `warnings`, `billing_period_start`, etc.), assert no PascalCase leaks, assert empty fields marshal as `[]` not `null`. Same regression test pattern recipes uses.
+
+### Integration tests (real Postgres)
+
+- `TestCreatePreview_SingleMeterFlatParity` — same fixture as `TestCustomerUsage_SingleMeterFlatParity` (100 events × qty=10 × 1¢ = 1000c). Confirms preview emits the same totals number → preview math == invoice math.
+- `TestCreatePreview_MultiDimDimensionMatchEcho` — same fixture as the multi-dim customer-usage test (1000 input @3¢ + 100 output @5¢ = 3500c). Confirms both rule lines surface with `dimension_match` echoed.
+- `TestCreatePreview_NoWrites` — count rows in `invoices` + `invoice_line_items` before and after the preview call; assert unchanged.
+- `TestCreatePreview_CrossTenantIsolation` — tenant B's request for tenant A's customer ID surfaces as 404.
+- `TestCreatePreview_CustomerHasNoSubscription` — confirm the documented error code (`customer_has_no_subscription`) for symmetry with customer-usage.
+
+## Migrations
+
+**None.** All reads, no schema changes.
+
+## Performance
+
+- Composition over the same read paths customer-usage uses. Per-call cost: 1 customer lookup + 1 subscription read + 1 plan read per distinct plan + 1 `AggregateByPricingRules` call per meter. For a typical sub on 1 plan with 1 multi-dim meter: 4 round-trips, all on indexed columns.
+- No event-by-event scan in the hot path; the LATERAL JOIN already runs over the in-cycle slice of `usage_events`.
+- Target: < 200ms p95 for the typical sub (10K events / cycle). Same envelope as customer-usage.
+
+## Decimal & numeric considerations
+
+Quantity field type: **`decimal.Decimal` marshaled as a string**, matching customer-usage. Single-rule meters keep the existing per-line shape but with the precise decimal — fractional AI-usage primitives (GPU-hours, cached-token ratios) round-trip without precision loss. Amounts stay integer cents per ADR-005.
+
+Note: the existing `Engine.Preview` exposed `Quantity int64` and the `description` formatted the decimal. We change to `Quantity decimal.Decimal` (string-marshaled) for v1 — there's no consumer in main yet that would break (only `web-v2/src/components/CostDashboard.tsx` and the `/billing/preview/{subscription_id}` debug route consume the type, both via the typed API client). The TS surface adds a `.toString()` call where the dashboard previously took an integer; one-line change in the consumer.
+
+## Open questions
+
+1. **Should the request body accept inline `subscription_items` to model "preview if I changed this sub's plan to X"?** Stripe does. **Proposal: no for v1.** The Week 5c plan-change confirmation dialog will need this, and it'll model the change with explicit fields rather than the subscription-shaped overlay (which carries its own validation problem). Defer there.
+2. **Should the response shape mirror the persisted `domain.Invoice` byte-for-byte?** **Proposal: no — keep `PreviewResult` separate.** The persisted invoice has fields that are nonsense for a preview (`status`, `payment_status`, `amount_paid_cents`, etc.); reusing it would force every preview consumer to ignore half the type. The shape we ship is the cost-dashboard-shaped subset; it's small enough to enumerate and aligns with customer-usage's idiom.
+3. **Should `lines[]` be one line per `(meter, rule)` pair, or one line per meter with rules nested inside?** **Proposal: flat one-line-per-rule.** Matches Stripe's flat `lines.data` and matches the cycle scan's `invoice_line_items` (one row per rule's roll-up). Nested would be cleaner for multi-rule meters but inconsistent with the canonical invoice shape, and the dashboard already groups by `meter_id` client-side for the customer-usage view.
+4. **Should the preview apply customer credits + coupon discounts?** The cycle scan does, so a true "what will my next invoice look like" view should too. **Proposal: defer to v2.** Reproducing the apply-credit + apply-coupon paths server-side is real work and risks drift; v1 ships subtotal-only, with a clear note in the changelog that credits and coupons aren't reflected. Real consumers (the cost dashboard's projected-bill line) only need subtotal today.
+5. **Should `period` accept a `cycle_offset` shorthand (e.g. `next_cycle`, `last_cycle`)?** Useful for "what would this customer pay next month at current usage." **Proposal: no for v1.** Pure UI math on top of explicit RFC 3339 bounds. Add only when a real consumer asks.
+6. **Why `POST` for a read-only operation?** Stripe convention (`POST /v1/invoices/create_preview`) — the body carries enough structure (period, optional subscription overlay in their version) that GET with query parameters would be ugly, and consistent verb-with-body is more discoverable for the SDK ecosystem than a one-off GET. We follow.
+7. **Should we surface `invoice_number_preview` (the number the next invoice would receive)?** **Proposal: no.** The number is allocated by the tenant settings store at finalize time; previewing it would either reserve numbers (state mutation, defeating the point) or guess (wrong if a concurrent invoice claims that number first). Punt.
+
+## Implementation checklist (Week 5b)
+
+- [x] `internal/billing/preview.go` — refactor to use `usage.AggregateByPricingRules`; new `PreviewResult` shape with `lines[]` per `(meter, rule)`, `totals[]` always-array, decimal-string quantities. Existing `Engine.Preview` keeps its signature for the in-app `/billing/preview/{subscription_id}` route.
+- [x] `internal/billing/preview_create.go` — `PreviewService.CreatePreview` composing customer / subscription / period / per-meter rating.
+- [x] `internal/billing/create_preview_handler.go` — `POST /v1/invoices/create_preview` route.
+- [x] `internal/api/router.go` — mount under `/v1/invoices/create_preview` behind `auth.PermInvoiceRead`.
+- [x] `internal/billing/preview_wire_shape_test.go` — `TestWireShape_SnakeCase` regression test (the merge gate).
+- [x] Unit tests: subscription resolution, period resolution, multi-dim per-rule lines, no-sub error path.
+- [x] Integration tests: single-meter parity, multi-dim parity, no-writes assertion, cross-tenant 404, no-sub error code.
+- [x] CHANGELOG.md (Track A) + Changelog.tsx (Track B) entries.
+- [x] `docs/parallel-handoff.md` Track A entry for this slice.
+
+## Track B unblock
+
+Track B can swap the cost dashboard's projected-bill line from extrapolation to a real backend call today. Same auth as customer-usage (PermInvoiceRead), same `totals[]` shape, same RLS-by-construction.
+
+The dashboard call:
+
+```ts
+const preview = await api.createInvoicePreview({ customer_id })
+// preview.totals[0].amount_cents → projected bill in formatCents()
+// preview.lines[] → per-rule breakdown for the drill-down panel
+```
+
+The dashboard shape Track B should aim at:
+
+- **Projected-bill summary line** below the existing "current usage" total: `"Projected bill: $37.04 — based on usage so far this cycle"`. Link to the drill-down opens the lines table.
+- **Drill-down (modal or expanded card):** flat list of `lines[]`. Group by `meter_id` client-side; show `dimension_match` chips on multi-rule meters; show `base_fee` lines at top. Highlight the discrepancy if `customer-usage.totals` and `create_preview.totals` differ (sanity check that both reads agree).
+- **Plan-change confirmation dialog (Week 5c):** opens a preview with the new plan baked in. v1 of the API doesn't accept the overlay; the dialog falls back to "preview at current plan" with a tooltip, and the overlay lands in v2.
+
+Same parallel-work pattern as recipes / customer-usage: Track B mocks the contract from this RFC, swaps to the real API at integration time.
+
+## Review status
+
+- **Track A author:** drafted 2026-04-26 alongside the implementation
+- **Track B review:** pending — Track B can scaffold the projected-bill line against this design without waiting for further iteration
+- **Human review:** pending — flag any open question to revisit

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -314,3 +314,39 @@ Track A merged PR #20 (multi-dim backend, 12 commits) into `main` at 18:25:30Z. 
   - The standalone iframe-able route (`/cost-dashboard?customer_id=…&token=…`) lands once Track A wires public-token access.
 
 **Wall-clock:** 00:30 → 01:25 IST 2026-04-26 (≈ 55m).
+
+---
+
+## 2026-04-26 (Sun) — Track A: create_preview backend (Week 5b)
+
+### Track A
+- **Branch:** `feat/backend-week5b-create-preview` (off `main` post-customer-usage merge).
+- **Goal:** close the Stripe Tier 1 parity gap (`POST /v1/invoices/create_preview`, formerly `Invoice.upcoming`) and route the existing in-app debug preview path through the same multi-dim-aware aggregator (`usage.AggregateByPricingRules`) so preview math == invoice math by construction across every meter shape.
+- **Shipped:**
+  - **`docs/design-create-preview.md`** — RFC with wire shape, period resolution, subscription resolution rules, error code matrix, no-writes guarantee, route mounting precedence (more-specific before catch-all under chi), 8-item implementation checklist.
+  - **`internal/billing/preview.go` refactor** — preview now walks every active subscription's pricing rules (one `usage.AggregateByPricingRules` call per meter, then `domain.ComputeAmountCents` per rule). New per-line shape echoes the rule's canonical `dimension_match`, quantity is decimal `string` on the wire (shopspring `MarshalJSON`), totals are always-array `[{currency, cents}]` (single-currency tenants get a length-1 array — same precedent as customer-usage so TS clients iterate uniformly).
+  - **`internal/billing/preview_create.go`** — `PreviewService` composing the engine with two narrow per-domain interfaces (`CustomerLookup`, `SubscriptionLister`). `CreatePreview()`: customer existence → subscription resolution (explicit ID with cross-customer rejection vs implicit primary pick: active/trialing, latest cycle start) → period resolution (default → sub's cycle, explicit RFC 3339 bounds override, partial bounds rejected) → `engine.previewWithWindow`. Coded `customer_has_no_subscription` error so the dashboard can prompt for an explicit window.
+  - **`internal/billing/create_preview_handler.go`** — `CreatePreviewHandler` with `Routes()` returning chi router; `decodeCreatePreviewRequest` accepts empty body (defaults to primary sub + cycle), rejects malformed JSON; period parsed via `parseWirePeriod`. Error mapping via `respond.FromError`; `ErrNotFound` surfaces with "customer or subscription" label.
+  - **`internal/api/router.go` wiring** — `createPreviewH := billing.NewCreatePreviewHandler(billing.NewPreviewService(engine, customerStore, subStore))`. Mount precedence: `r.With(auth.Require(auth.PermInvoiceRead)).Mount("/invoices/create_preview", createPreviewH.Routes())` BEFORE `Mount("/invoices", invoiceH.Routes())` — chi catches "create_preview" as `{id}` otherwise.
+  - **`internal/billing/preview_wire_shape_test.go`** — `TestWireShape_SnakeCase` is the merge gate. "FullyPopulated" subtest asserts all 9 top-level snake_case keys, no PascalCase leaks, lines/totals/warnings as arrays, quantity as JSON string `"1234567.891234"` (chose meaningful digits — shopspring trims trailing zeros, so test value must survive normalization), `dimension_match` as object. "EmptyResultSlicesAreArrays" subtest asserts empty slices marshal as `[]` not `null`.
+  - **16 unit tests (`preview_create_test.go`):** `TestResolveCreatePreviewPeriod` (6 cases), `TestPickPrimarySubscription` (6 cases), `TestPreviewService_ResolveSubscription` (5 cases), `TestCreatePreview_BlankCustomerID`, `TestCreatePreview_CustomerNotFound`, `TestDecodeCreatePreviewRequest` (7 cases), `TestComputePreviewTotals` (4 cases — single-currency, multi-currency split, empty totals, mixed-zero totals).
+  - **7 integration tests (`preview_integration_test.go`) against real Postgres:** `TestCreatePreview_SingleMeterFlatParity` (100 events × qty=10 × 1¢ = 1000c), `TestCreatePreview_MultiDimDimensionMatchEcho` (1000 input @3¢ + 100 output @5¢ = 3500c, both rules echoed), `TestCreatePreview_NoWrites` (count `invoices` + `invoice_lines` rows before/after — zero diff guarantee), `TestCreatePreview_CrossTenantIsolation` (tenant B's key vs tenant A's customer → 404 via RLS), `TestCreatePreview_CustomerHasNoSubscription` (coded error returned), `TestCreatePreview_ExplicitSubscriptionWrongCustomer` (cross-customer subscription ID rejected with 404). All 7 pass in 3.88s.
+  - **TS consumer updates (`web-v2/src/lib/api.ts`)** — replaced old `InvoicePreview` interface with new shape: dropped `subtotal_cents` + top-level `currency`; added `totals[]`, `warnings[]`; broke out `InvoicePreviewLine` and `InvoicePreviewTotal` types; `quantity` is now `string`. Added `createInvoicePreview` API method calling `POST /invoices/create_preview`. **`web-v2/src/pages/SubscriptionDetail.tsx`** updated to use `preview.totals[]` per-row and `Number(line.quantity).toLocaleString()` for the decimal-string field.
+  - **CHANGELOG.md** comprehensive entry at top of [Unreleased]/Added (Stripe Tier 1 parity, multi-dim parity guarantee, no-writes property, error codes, route mounting order, test coverage, in-app debug route shape change with TS consumer updates).
+  - **`web-v2/src/pages/Changelog.tsx`** Linear-style feature entry dated 2026-04-26 with 6 bullets (no-writes, period resolution, subscription resolution, always-array totals, route ordering, test-coverage summary).
+- **Decisions made inline (per `feedback_feat8_autonomy`):**
+  - **Compose `PreviewService` against `Engine` (not reimplement per-meter walk):** the create_preview surface and the existing `/v1/billing/preview/{id}` debug route share one code path. Preview math == invoice math by construction. Three narrow interfaces (`CustomerLookup`, `SubscriptionLister`, plus existing engine seams) keep `PreviewService` cross-domain-clean.
+  - **Mount `/invoices/create_preview` before `/invoices`:** chi-router pattern ordering — without this, the `/invoices/{id}` catch-all captures "create_preview" as an invoice ID and 404s. Tested explicitly in handler test.
+  - **Update existing TS `InvoicePreview` rather than introduce a separate type:** both `/v1/billing/preview/{id}` (debug) and `/v1/invoices/create_preview` (Tier 1) now return the same shape. One type, one rendering path on the dashboard.
+  - **Test fixture quantity `1234567.891234` (not `1000000.000000000000`):** discovered shopspring `decimal.MarshalJSON` trims trailing zeros, so the assertion needs digits that survive normalization. Documented in test comment.
+- **Test status:**
+  - `go test ./internal/billing/... -count=1`: pass (16 unit + handler tests).
+  - `go test -p 1 ./internal/billing/... -short=false -count=1`: pass (7 integration tests in 3.88s).
+  - Full short-mode suite: pass.
+- **Blocking Track B on:** nothing.
+- **Track B can pick up:**
+  - **"Projected bill" line on the cost dashboard** — Week 5 explicit deliverable, now unblocked. Call `api.createInvoicePreview({customer_id})` and render `preview.totals[0].cents` next to the cycle-progress meter; multi-currency tenants get the length-N array.
+  - **Subscription detail preview already wired** — uses the new shape via `SubscriptionDetail.tsx` updates above. Click-test against real tenant after merge.
+- **Open for human review:**
+  - PR to be opened on `feat/backend-week5b-create-preview` once final commit lands.
+- **Next session (Track A):** drive PR to green, self-merge per authorization (CI green AND `TestWireShape_SnakeCase` in suite — both conditions met), then start Week 5/6 next blocker per 90-day plan.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -432,6 +432,14 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	subH.SetProrationTaxApplier(&prorationTaxApplierAdapter{engine: engine})
 
 	billingH := billing.NewHandler(engine, subStore)
+	// create_preview composes customer / subscription resolution on top of
+	// the engine's preview path. Mounted at /v1/invoices/create_preview
+	// (Stripe-equivalent), gated by PermInvoiceRead — read-only, no DB
+	// writes. Sibling-mounted ahead of /invoices below so chi picks the
+	// more-specific pattern (otherwise /{id} captures "create_preview").
+	createPreviewH := billing.NewCreatePreviewHandler(
+		billing.NewPreviewService(engine, customerStore, subStore),
+	)
 	analyticsH := analytics.NewHandler(db)
 
 	// Customer portal sessions — operators mint a session for a customer
@@ -722,6 +730,11 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 		// keys (publishable keys are read-only).
 		r.With(auth.Require(auth.PermUsageWrite)).Post("/usage-events/backfill", usageH.Backfill)
 		r.With(auth.Require(auth.PermUsageRead)).Mount("/usage-events", usageH.Routes())
+		// create_preview must mount BEFORE /invoices because chi tries
+		// patterns in registration order — once /invoices is mounted with
+		// /{id}/... children, "create_preview" would be claimed as an
+		// invoice ID. See docs/design-create-preview.md.
+		r.With(auth.Require(auth.PermInvoiceRead)).Mount("/invoices/create_preview", createPreviewH.Routes())
 		r.With(auth.Require(auth.PermInvoiceRead)).Mount("/invoices", invoiceH.Routes())
 		r.With(auth.Require(auth.PermInvoiceWrite)).Mount("/credit-notes", creditNoteH.Routes())
 		r.With(auth.Require(auth.PermPricingWrite)).Mount("/price-overrides", pricingH.OverrideRoutes())

--- a/internal/billing/create_preview_handler.go
+++ b/internal/billing/create_preview_handler.go
@@ -1,0 +1,159 @@
+package billing
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/sagarsuperuser/velox/internal/api/respond"
+	"github.com/sagarsuperuser/velox/internal/auth"
+	"github.com/sagarsuperuser/velox/internal/errs"
+)
+
+// CreatePreviewHandler exposes POST /v1/invoices/create_preview. Kept
+// distinct from the existing billing.Handler (which owns the engine
+// trigger and the in-app debug preview) because this surface composes
+// across customer / subscription / pricing — the dependency set is
+// materially different and the route lives under /invoices/* rather than
+// /billing/*.
+type CreatePreviewHandler struct {
+	svc *PreviewService
+}
+
+// NewCreatePreviewHandler wires a handler around a PreviewService.
+func NewCreatePreviewHandler(svc *PreviewService) *CreatePreviewHandler {
+	return &CreatePreviewHandler{svc: svc}
+}
+
+// CreatePreviewRoutes returns the sub-router. Mount at
+// /v1/invoices/create_preview as a sibling of /v1/invoices so chi picks
+// the more-specific pattern; the parent /invoices Mount uses /{id}
+// patterns that would otherwise capture "create_preview" as an invoice
+// ID. Auth is gated by PermInvoiceRead — same level as GET /invoices
+// (read-only operation, no DB writes).
+func (h *CreatePreviewHandler) Routes() chi.Router {
+	r := chi.NewRouter()
+	r.Post("/", h.create)
+	return r
+}
+
+// createPreviewWireRequest is the JSON shape the wire sends. Decoupled
+// from CreatePreviewRequest so we can parse RFC 3339 timestamps from the
+// body without leaking the time.Time type into the wire contract.
+//
+// Snake-case keys, struct-tag enforced. Both subscription_id and period
+// are optional — service defaults the former to the customer's primary
+// active sub and the latter to that sub's current cycle.
+type createPreviewWireRequest struct {
+	CustomerID     string                   `json:"customer_id"`
+	SubscriptionID string                   `json:"subscription_id"`
+	Period         *createPreviewWirePeriod `json:"period"`
+}
+
+// createPreviewWirePeriod is the optional explicit window. Both bounds
+// must be supplied together; partial windows are rejected by the service
+// layer with a 400.
+type createPreviewWirePeriod struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// create handles the POST. JSON body in, PreviewResult out.
+//
+// Error mapping:
+//   - Empty / unparseable body → 400 invalid_request.
+//   - customer_id blank → 422 with field=customer_id (errs.Required).
+//   - period bounds missing-pair / from >= to / unparseable → 422.
+//   - Customer not found / subscription not found → 404.
+//   - customer_has_no_subscription → 422 with code (no active sub).
+func (h *CreatePreviewHandler) create(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "create_preview: read body", "error", err)
+		respond.BadRequest(w, r, "could not read request body")
+		return
+	}
+
+	req, err := decodeCreatePreviewRequest(body)
+	if err != nil {
+		respond.FromError(w, r, err, "create_preview")
+		return
+	}
+
+	result, err := h.svc.CreatePreview(r.Context(), tenantID, req)
+	if err != nil {
+		// errs.ErrNotFound from the customer / subscription store routes
+		// to 404 by FromError. The "subscription" resource label is the
+		// less common case; "customer" is the more common 404 here, and
+		// FromError uses the resource label for the 404 message body
+		// rather than for routing.
+		if errors.Is(err, errs.ErrNotFound) {
+			respond.NotFound(w, r, "customer or subscription")
+			return
+		}
+		respond.FromError(w, r, err, "create_preview")
+		return
+	}
+
+	respond.JSON(w, r, http.StatusOK, result)
+}
+
+// decodeCreatePreviewRequest parses the JSON body and converts wire
+// timestamps to time.Time. Returns DomainError-wrapped failures so the
+// handler's FromError path can map them to 400/422 with the right field.
+//
+// Empty body is acceptable as a degenerate {}, but customer_id is required
+// by the service layer (Required("customer_id")) so the error surfaces
+// uniformly whether the body was {}, {"customer_id":""}, or absent.
+func decodeCreatePreviewRequest(body []byte) (CreatePreviewRequest, error) {
+	wire := createPreviewWireRequest{}
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &wire); err != nil {
+			return CreatePreviewRequest{}, errs.Invalid("body", "request body is not valid JSON")
+		}
+	}
+
+	out := CreatePreviewRequest{
+		CustomerID:     wire.CustomerID,
+		SubscriptionID: wire.SubscriptionID,
+	}
+
+	if wire.Period != nil {
+		from, to, err := parseWirePeriod(*wire.Period)
+		if err != nil {
+			return CreatePreviewRequest{}, err
+		}
+		out.Period = CreatePreviewPeriod{From: from, To: to}
+	}
+	return out, nil
+}
+
+// parseWirePeriod turns the JSON period {from, to} into time.Time bounds.
+// Empty strings stay zero (service treats both-zero as "use sub's current
+// cycle"); any non-empty string must be RFC 3339 or we 422 with a
+// field-tagged error so the dashboard can route the message.
+func parseWirePeriod(p createPreviewWirePeriod) (time.Time, time.Time, error) {
+	var from, to time.Time
+	if p.From != "" {
+		t, err := time.Parse(time.RFC3339, p.From)
+		if err != nil {
+			return time.Time{}, time.Time{}, errs.Invalid("period.from", "must be RFC 3339 (e.g. 2026-04-01T00:00:00Z)")
+		}
+		from = t
+	}
+	if p.To != "" {
+		t, err := time.Parse(time.RFC3339, p.To)
+		if err != nil {
+			return time.Time{}, time.Time{}, errs.Invalid("period.to", "must be RFC 3339 (e.g. 2026-05-01T00:00:00Z)")
+		}
+		to = t
+	}
+	return from, to, nil
+}

--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -158,18 +158,29 @@ type SubscriptionReader interface {
 // decimal.Decimal so fractional AI-usage primitives (GPU-hours, cached-token
 // ratios) round-trip without precision loss; the engine converts to cents
 // at the multiplication step.
+//
+// AggregateByPricingRules is the multi-dim-aware path (priority+claim
+// LATERAL JOIN across the 5 aggregation modes). The cycle scan, the
+// customer-usage endpoint, and the create_preview surface all call it —
+// preview math == invoice math by construction.
 type UsageAggregator interface {
 	AggregateForBillingPeriod(ctx context.Context, tenantID, customerID string, meterIDs []string, from, to time.Time) (map[string]decimal.Decimal, error)
 	AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error)
+	AggregateByPricingRules(ctx context.Context, tenantID, customerID, meterID string, defaultMode domain.AggregationMode, from, to time.Time) ([]domain.RuleAggregation, error)
 }
 
 // PricingReader reads plan, rating rule, and override data.
+//
+// ListMeterPricingRulesByMeter is needed by the preview path to echo each
+// rule's DimensionMatch (the canonical pricing identity) onto the
+// per-rule preview line.
 type PricingReader interface {
 	GetPlan(ctx context.Context, tenantID, id string) (domain.Plan, error)
 	GetMeter(ctx context.Context, tenantID, id string) (domain.Meter, error)
 	GetRatingRule(ctx context.Context, tenantID, id string) (domain.RatingRuleVersion, error)
 	GetLatestRuleByKey(ctx context.Context, tenantID, ruleKey string) (domain.RatingRuleVersion, error)
 	GetOverride(ctx context.Context, tenantID, customerID, ruleID string) (domain.CustomerPriceOverride, error)
+	ListMeterPricingRulesByMeter(ctx context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error)
 }
 
 // InvoiceWriter creates invoices and line items.

--- a/internal/billing/engine_integration_test.go
+++ b/internal/billing/engine_integration_test.go
@@ -88,6 +88,10 @@ func (a *pricingStoreAdapter) GetOverride(ctx context.Context, tenantID, custome
 	return a.store.GetOverride(ctx, tenantID, customerID, ruleID)
 }
 
+func (a *pricingStoreAdapter) ListMeterPricingRulesByMeter(ctx context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error) {
+	return a.store.ListMeterPricingRulesByMeter(ctx, tenantID, meterID)
+}
+
 // usageStoreAdapter wraps usage.PostgresStore to implement billing.UsageAggregator
 type usageStoreAdapter struct {
 	store *usage.PostgresStore
@@ -99,6 +103,10 @@ func (a *usageStoreAdapter) AggregateForBillingPeriod(ctx context.Context, tenan
 
 func (a *usageStoreAdapter) AggregateForBillingPeriodByAgg(ctx context.Context, tenantID, customerID string, meters map[string]string, from, to time.Time) (map[string]decimal.Decimal, error) {
 	return a.store.AggregateForBillingPeriodByAgg(ctx, tenantID, customerID, meters, from, to)
+}
+
+func (a *usageStoreAdapter) AggregateByPricingRules(ctx context.Context, tenantID, customerID, meterID string, defaultMode domain.AggregationMode, from, to time.Time) ([]domain.RuleAggregation, error) {
+	return a.store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, defaultMode, from, to)
 }
 
 // invoiceStoreAdapter wraps invoice.PostgresStore to implement billing.InvoiceWriter

--- a/internal/billing/engine_test.go
+++ b/internal/billing/engine_test.go
@@ -185,6 +185,23 @@ func (m *mockUsage) AggregateForBillingPeriodByAgg(_ context.Context, _, _ strin
 	return result, nil
 }
 
+// AggregateByPricingRules is a minimal stub — engine_test.go's existing
+// preview tests don't exercise the multi-dim path; the create_preview
+// integration tests cover that against real Postgres. We return one
+// aggregation per known meter so the new preview path produces the same
+// totals the legacy tests expect.
+func (m *mockUsage) AggregateByPricingRules(_ context.Context, _, _, meterID string, _ domain.AggregationMode, _, _ time.Time) ([]domain.RuleAggregation, error) {
+	qty, ok := m.totals[meterID]
+	if !ok {
+		return nil, nil
+	}
+	return []domain.RuleAggregation{{
+		RuleID:              "",
+		RatingRuleVersionID: "",
+		Quantity:            decimal.NewFromInt(qty),
+	}}, nil
+}
+
 type mockPricing struct {
 	plans     map[string]domain.Plan
 	meters    map[string]domain.Meter
@@ -243,6 +260,13 @@ func (m *mockPricing) GetOverride(_ context.Context, _, customerID, ruleID strin
 		return domain.CustomerPriceOverride{}, fmt.Errorf("not found")
 	}
 	return o, nil
+}
+
+// ListMeterPricingRulesByMeter is a no-op stub. The engine unit tests use
+// single-rule meters; per-rule DimensionMatch echo is covered by the
+// create_preview integration tests against real Postgres.
+func (m *mockPricing) ListMeterPricingRulesByMeter(_ context.Context, _, _ string) ([]domain.MeterPricingRule, error) {
+	return nil, nil
 }
 
 type mockInvoices struct {

--- a/internal/billing/preview.go
+++ b/internal/billing/preview.go
@@ -11,36 +11,64 @@ import (
 	"github.com/sagarsuperuser/velox/internal/domain"
 )
 
-// PreviewLine represents one line in an invoice preview.
+// PreviewLine is one line of an invoice preview. Mirrors the line shape the
+// cycle scan persists onto invoice_line_items, with two differences:
+//
+//   - Quantity is a decimal string on the wire (NUMERIC(38,12) precision
+//     preserved end-to-end — fractional AI-usage primitives like GPU-hours
+//     and cached-token ratios round-trip without precision loss).
+//   - Multi-rule meters emit one line per (meter, rule) pair with
+//     DimensionMatch echoed from the meter pricing rule (the canonical
+//     pricing identity). Single-rule meters keep the one-line-per-meter
+//     shape with no DimensionMatch.
+//
+// See docs/design-create-preview.md.
 type PreviewLine struct {
-	LineType        string `json:"line_type"`
-	Description     string `json:"description"`
-	MeterID         string `json:"meter_id,omitempty"`
-	Quantity        int64  `json:"quantity"`
-	UnitAmountCents int64  `json:"unit_amount_cents"`
-	AmountCents     int64  `json:"amount_cents"`
-	PricingMode     string `json:"pricing_mode,omitempty"`
+	LineType            string          `json:"line_type"`
+	Description         string          `json:"description"`
+	MeterID             string          `json:"meter_id,omitempty"`
+	RatingRuleVersionID string          `json:"rating_rule_version_id,omitempty"`
+	RuleKey             string          `json:"rule_key,omitempty"`
+	DimensionMatch      map[string]any  `json:"dimension_match,omitempty"`
+	Currency            string          `json:"currency"`
+	Quantity            decimal.Decimal `json:"quantity"`
+	UnitAmountCents     int64           `json:"unit_amount_cents"`
+	AmountCents         int64           `json:"amount_cents"`
+	PricingMode         string          `json:"pricing_mode,omitempty"`
 }
 
-// PreviewResult is the result of an invoice preview. PlanName is a joined
-// list of the subscription's item plans (comma-separated) — the previous
-// single-plan shape can't represent a multi-item sub, and exposing the raw
-// item list here would leak more than preview consumers need.
+// PreviewTotal is one currency's roll-up across the preview's lines. We
+// always emit a list (one entry per distinct currency) even when there's
+// only one currency — consistent shape lets clients read totals[0]
+// without branching on cardinality, and lines up with the customer-usage
+// endpoint's totals shape so a single TS type covers both surfaces.
+type PreviewTotal struct {
+	Currency    string `json:"currency"`
+	AmountCents int64  `json:"amount_cents"`
+}
+
+// PreviewResult is the response shape for both the in-app
+// GET /v1/billing/preview/{subscription_id} debug route and the public
+// POST /v1/invoices/create_preview surface. PlanName is a joined list of
+// the subscription's item plans (comma-separated) — the previous
+// single-plan shape can't represent a multi-item sub.
 type PreviewResult struct {
-	CustomerID         string        `json:"customer_id"`
-	SubscriptionID     string        `json:"subscription_id"`
-	PlanName           string        `json:"plan_name"`
-	Currency           string        `json:"currency"`
-	BillingPeriodStart time.Time     `json:"billing_period_start"`
-	BillingPeriodEnd   time.Time     `json:"billing_period_end"`
-	Lines              []PreviewLine `json:"lines"`
-	SubtotalCents      int64         `json:"subtotal_cents"`
-	GeneratedAt        time.Time     `json:"generated_at"`
+	CustomerID         string         `json:"customer_id"`
+	SubscriptionID     string         `json:"subscription_id"`
+	PlanName           string         `json:"plan_name"`
+	BillingPeriodStart time.Time      `json:"billing_period_start"`
+	BillingPeriodEnd   time.Time      `json:"billing_period_end"`
+	Lines              []PreviewLine  `json:"lines"`
+	Totals             []PreviewTotal `json:"totals"`
+	Warnings           []string       `json:"warnings"`
+	GeneratedAt        time.Time      `json:"generated_at"`
 }
 
 // Preview generates a dry-run invoice for a subscription without persisting
 // anything. Walks every item, resolves its plan, and emits a base_fee line
-// per item plus deduped usage lines across the union of meter_ids.
+// per item plus per-(meter, rule) usage lines via the priority+claim
+// LATERAL JOIN — same code path the cycle scan uses, so preview math ==
+// invoice math.
 func (e *Engine) Preview(ctx context.Context, sub domain.Subscription) (PreviewResult, error) {
 	if sub.CurrentBillingPeriodStart == nil || sub.CurrentBillingPeriodEnd == nil {
 		return PreviewResult{}, fmt.Errorf("subscription has no billing period set")
@@ -48,10 +76,17 @@ func (e *Engine) Preview(ctx context.Context, sub domain.Subscription) (PreviewR
 	if len(sub.Items) == 0 {
 		return PreviewResult{}, fmt.Errorf("subscription has no items")
 	}
-
 	periodStart := *sub.CurrentBillingPeriodStart
 	periodEnd := *sub.CurrentBillingPeriodEnd
+	return e.previewWithWindow(ctx, sub, periodStart, periodEnd)
+}
 
+// previewWithWindow is the explicit-period variant. Used by the
+// create_preview service when the caller passes a custom window; the
+// wall-clock Preview entry above defers to the subscription's current
+// cycle. Both paths converge here so the per-line composition stays in
+// one place.
+func (e *Engine) previewWithWindow(ctx context.Context, sub domain.Subscription, periodStart, periodEnd time.Time) (PreviewResult, error) {
 	plans := make(map[string]domain.Plan, len(sub.Items))
 	planNames := make([]string, 0, len(sub.Items))
 	var allMeterIDs []string
@@ -75,23 +110,20 @@ func (e *Engine) Preview(ctx context.Context, sub domain.Subscription) (PreviewR
 		}
 	}
 
-	currency := plans[sub.Items[0].PlanID].Currency
-
-	usageTotals, err := e.usage.AggregateForBillingPeriod(ctx, sub.TenantID, sub.ID, allMeterIDs, periodStart, periodEnd)
-	if err != nil {
-		return PreviewResult{}, fmt.Errorf("aggregate usage: %w", err)
-	}
-
 	result := PreviewResult{
 		CustomerID:         sub.CustomerID,
 		SubscriptionID:     sub.ID,
 		PlanName:           strings.Join(planNames, ", "),
-		Currency:           currency,
 		BillingPeriodStart: periodStart,
 		BillingPeriodEnd:   periodEnd,
+		Lines:              []PreviewLine{},
+		Warnings:           []string{},
 		GeneratedAt:        e.clock.Now(),
 	}
 
+	// Base-fee lines from each subscription item's plan. Quantity here is
+	// the item's seat / count (always integer); we still expose it as a
+	// decimal for shape uniformity.
 	for _, it := range sub.Items {
 		plan := plans[it.PlanID]
 		if plan.BaseAmountCents <= 0 {
@@ -101,63 +133,171 @@ func (e *Engine) Preview(ctx context.Context, sub domain.Subscription) (PreviewR
 		result.Lines = append(result.Lines, PreviewLine{
 			LineType:        "base_fee",
 			Description:     fmt.Sprintf("%s - base fee (qty %d)", plan.Name, it.Quantity),
-			Quantity:        it.Quantity,
+			Currency:        plan.Currency,
+			Quantity:        decimal.NewFromInt(it.Quantity),
 			UnitAmountCents: plan.BaseAmountCents,
 			AmountCents:     baseFee,
 		})
-		result.SubtotalCents += baseFee
 	}
 
-	rendered := make(map[string]struct{})
+	// Usage lines per (meter, rule). The priority+claim LATERAL JOIN inside
+	// AggregateByPricingRules is the canonical pricing identity — the
+	// cycle scan calls the same path, so a multi-dim tenant's preview
+	// matches what its actual invoice will be.
 	for _, meterID := range allMeterIDs {
-		if _, ok := rendered[meterID]; ok {
-			continue
-		}
-		rendered[meterID] = struct{}{}
-
-		quantity := usageTotals[meterID]
-		if quantity.IsZero() {
-			continue
-		}
-
-		meter, err := e.pricing.GetMeter(ctx, sub.TenantID, meterID)
-		if err != nil || meter.RatingRuleVersionID == "" {
-			continue
-		}
-
-		rule, err := e.pricing.GetRatingRule(ctx, sub.TenantID, meter.RatingRuleVersionID)
+		meterLines, warnings, err := e.previewMeter(ctx, sub.TenantID, sub.CustomerID, meterID, periodStart, periodEnd)
 		if err != nil {
+			// Soft-fail: a missing meter / rule shouldn't abort the
+			// whole preview. Surface as a warning and continue —
+			// matches the existing behaviour of the legacy preview
+			// path which silently skipped on errors here.
+			result.Warnings = append(result.Warnings, fmt.Sprintf("meter %q: %s", meterID, err.Error()))
 			continue
 		}
-
-		override, overrideErr := e.pricing.GetOverride(ctx, sub.TenantID, sub.CustomerID, meter.RatingRuleVersionID)
-		if overrideErr == nil && override.Active {
-			rule = override.ToRatingRule()
-		}
-
-		amount, err := domain.ComputeAmountCents(rule, quantity)
-		if err != nil {
-			continue
-		}
-
-		// quantity is decimal here; the IsZero short-circuit above
-		// guarantees it is non-zero so unit-amount division is safe.
-		unitAmount := decimal.NewFromInt(amount).Div(quantity).RoundBank(0).IntPart()
-
-		result.Lines = append(result.Lines, PreviewLine{
-			LineType: "usage",
-			// Quantity column on previews is integer for now — fractional
-			// values are truncated in the human description but the
-			// AmountCents above is computed from the full decimal quantity.
-			Description:     fmt.Sprintf("%s - %s %s", meter.Name, quantity.String(), meter.Unit),
-			MeterID:         meterID,
-			Quantity:        quantity.IntPart(),
-			UnitAmountCents: unitAmount,
-			AmountCents:     amount,
-			PricingMode:     string(rule.Mode),
-		})
-		result.SubtotalCents += amount
+		result.Lines = append(result.Lines, meterLines...)
+		result.Warnings = append(result.Warnings, warnings...)
 	}
 
+	result.Totals = computePreviewTotals(result.Lines)
 	return result, nil
+}
+
+// previewMeter rates one meter's events for the customer over [from, to)
+// and emits one PreviewLine per rule bucket. Mirrors usage.rateMeter from
+// internal/usage/customer_usage.go — the cycle scan calls the same
+// AggregateByPricingRules + ComputeAmountCents path, so each line
+// produced here matches the invoice_line_item the cycle scan would
+// persist.
+func (e *Engine) previewMeter(ctx context.Context, tenantID, customerID, meterID string, from, to time.Time) ([]PreviewLine, []string, error) {
+	meter, err := e.pricing.GetMeter(ctx, tenantID, meterID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get meter: %w", err)
+	}
+
+	defaultMode := mapMeterAggregation(meter.Aggregation)
+	aggs, err := e.usage.AggregateByPricingRules(ctx, tenantID, customerID, meterID, defaultMode, from, to)
+	if err != nil {
+		return nil, nil, fmt.Errorf("aggregate by pricing rules: %w", err)
+	}
+
+	rules, err := e.pricing.ListMeterPricingRulesByMeter(ctx, tenantID, meterID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list pricing rules: %w", err)
+	}
+	rulesByID := make(map[string]domain.MeterPricingRule, len(rules))
+	for _, rule := range rules {
+		rulesByID[rule.ID] = rule
+	}
+
+	var lines []PreviewLine
+	var warnings []string
+
+	for _, agg := range aggs {
+		if agg.Quantity.IsZero() {
+			continue
+		}
+
+		ratingRuleID := agg.RatingRuleVersionID
+		if ratingRuleID == "" {
+			ratingRuleID = meter.RatingRuleVersionID
+		}
+		if ratingRuleID == "" {
+			warnings = append(warnings, fmt.Sprintf("meter %q has events with no rating rule binding — skipped", meter.Key))
+			continue
+		}
+
+		ratingRule, err := e.pricing.GetRatingRule(ctx, tenantID, ratingRuleID)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("meter %q rule %q: rating rule not found", meter.Key, ratingRuleID))
+			continue
+		}
+
+		// Honour customer price overrides — same precedent as the cycle
+		// scan and the existing Preview path. An override returns a
+		// patched RatingRuleVersion with the override's tier table /
+		// flat amount in place. e.pricing.GetOverride returns an error
+		// when no override exists; we silently fall through.
+		if override, overrideErr := e.pricing.GetOverride(ctx, tenantID, customerID, ratingRuleID); overrideErr == nil && override.Active {
+			ratingRule = override.ToRatingRule()
+		}
+
+		amount, err := domain.ComputeAmountCents(ratingRule, agg.Quantity)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("meter %q rule %q: rating failed: %s", meter.Key, ratingRule.RuleKey, err.Error()))
+			continue
+		}
+
+		// Unit amount is amount / quantity, rounded to nearest cent. The
+		// IsZero short-circuit above guarantees the divisor is non-zero.
+		unitAmount := decimal.NewFromInt(amount).Div(agg.Quantity).RoundBank(0).IntPart()
+
+		var dimMatch map[string]any
+		if agg.RuleID != "" {
+			if rule, ok := rulesByID[agg.RuleID]; ok && len(rule.DimensionMatch) > 0 {
+				dimMatch = rule.DimensionMatch
+			}
+		}
+
+		desc := fmt.Sprintf("%s - %s %s", meter.Name, agg.Quantity.String(), meter.Unit)
+
+		lines = append(lines, PreviewLine{
+			LineType:            "usage",
+			Description:         desc,
+			MeterID:             meterID,
+			RatingRuleVersionID: ratingRule.ID,
+			RuleKey:             ratingRule.RuleKey,
+			DimensionMatch:      dimMatch,
+			Currency:            ratingRule.Currency,
+			Quantity:            agg.Quantity,
+			UnitAmountCents:     unitAmount,
+			AmountCents:         amount,
+			PricingMode:         string(ratingRule.Mode),
+		})
+	}
+
+	return lines, warnings, nil
+}
+
+// computePreviewTotals groups each line's amount by currency and emits
+// one PreviewTotal per distinct currency. Order is insertion-stable
+// (first currency seen wins position 0) so the response is deterministic
+// across calls. Mirrors the customer-usage computeTotals helper.
+func computePreviewTotals(lines []PreviewLine) []PreviewTotal {
+	bucket := map[string]int64{}
+	var order []string
+	for _, line := range lines {
+		if line.Currency == "" {
+			continue
+		}
+		if _, ok := bucket[line.Currency]; !ok {
+			order = append(order, line.Currency)
+		}
+		bucket[line.Currency] += line.AmountCents
+	}
+	out := make([]PreviewTotal, 0, len(order))
+	for _, cur := range order {
+		out = append(out, PreviewTotal{Currency: cur, AmountCents: bucket[cur]})
+	}
+	return out
+}
+
+// mapMeterAggregation translates the meter's stored aggregation string
+// ("sum"/"count"/"max"/"last") to the AggregationMode the priority+claim
+// resolver accepts. Duplicated from internal/usage/customer_usage.go
+// rather than imported to keep the billing package's dependency graph
+// flat (no cross-domain imports between peer packages — see CLAUDE.md
+// "Architecture").
+func mapMeterAggregation(agg string) domain.AggregationMode {
+	switch agg {
+	case "sum":
+		return domain.AggSum
+	case "count":
+		return domain.AggCount
+	case "max":
+		return domain.AggMax
+	case "last":
+		return domain.AggLastDuringPeriod
+	default:
+		return domain.AggSum
+	}
 }

--- a/internal/billing/preview_create.go
+++ b/internal/billing/preview_create.go
@@ -1,0 +1,221 @@
+package billing
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/subscription"
+)
+
+// CustomerLookup is the narrow surface PreviewService needs from
+// customer.Store. Returns errs.ErrNotFound for cross-tenant IDs (RLS hides
+// the row); the handler propagates that as 404 customer_not_found.
+type CustomerLookup interface {
+	Get(ctx context.Context, tenantID, id string) (domain.Customer, error)
+}
+
+// SubscriptionLister returns the customer's subscriptions hydrated with
+// their items so we can resolve the implicit subscription pick. Mirrors
+// the customer-usage SubscriptionLister surface so a single subscription
+// store implementation satisfies both.
+type SubscriptionLister interface {
+	List(ctx context.Context, filter subscription.ListFilter) ([]domain.Subscription, int, error)
+	Get(ctx context.Context, tenantID, id string) (domain.Subscription, error)
+}
+
+// PreviewService composes the per-domain reads behind
+// POST /v1/invoices/create_preview. See docs/design-create-preview.md.
+//
+// The hard work — dimension-match-aware aggregation in
+// usage.AggregateByPricingRules and per-rule pricing via
+// domain.ComputeAmountCents — already exists on Engine.previewMeter. This
+// service is a thin composition: customer existence → subscription
+// resolution → period resolution → defer to engine.previewWithWindow for
+// the actual line generation.
+//
+// We deliberately compose against Engine (rather than reimplementing the
+// per-(meter, rule) walk here) so the create_preview surface and the
+// in-app debug route /v1/billing/preview/{subscription_id} share one code
+// path — preview math == invoice math by construction.
+type PreviewService struct {
+	engine        *Engine
+	customers     CustomerLookup
+	subscriptions SubscriptionLister
+}
+
+// NewPreviewService wires the composition. All three collaborators are
+// required.
+func NewPreviewService(engine *Engine, customers CustomerLookup, subscriptions SubscriptionLister) *PreviewService {
+	return &PreviewService{
+		engine:        engine,
+		customers:     customers,
+		subscriptions: subscriptions,
+	}
+}
+
+// CreatePreviewPeriod is the input window. Both From and To zero → default
+// to the resolved subscription's current billing cycle. Partial bounds
+// (one zero, one non-zero) are rejected with a 400 by resolveCreatePreviewPeriod.
+type CreatePreviewPeriod struct {
+	From time.Time
+	To   time.Time
+}
+
+// CreatePreviewRequest is the input shape for POST /v1/invoices/create_preview.
+//
+//   - CustomerID: required. The customer to preview against. Cross-tenant
+//     IDs surface as 404 via the RLS-safe customer lookup.
+//   - SubscriptionID: optional. When omitted, the service picks the
+//     customer's primary active or trialing subscription (most recent
+//     cycle start wins). When passed, the service verifies the sub
+//     belongs to the customer (defensive against the rare double-typo
+//     case).
+//   - Period: optional. Defaults to the resolved subscription's current
+//     billing cycle. Both bounds must be supplied together if explicit;
+//     partial windows are rejected.
+type CreatePreviewRequest struct {
+	CustomerID     string
+	SubscriptionID string
+	Period         CreatePreviewPeriod
+}
+
+// CreatePreview produces a dry-run invoice preview for the customer's
+// next billing event. Composition order:
+//  1. Customer existence (RLS makes cross-tenant IDs return ErrNotFound).
+//  2. Subscription resolution (explicit ID, or pick primary active sub).
+//  3. Period resolution (explicit window, or sub's current cycle).
+//  4. Defer to engine.previewWithWindow for the line composition.
+//
+// Returns a PreviewResult with the same wire shape produced by
+// Engine.Preview so the cost dashboard can consume both surfaces with one
+// TS type set.
+func (s *PreviewService) CreatePreview(ctx context.Context, tenantID string, req CreatePreviewRequest) (PreviewResult, error) {
+	customerID := strings.TrimSpace(req.CustomerID)
+	if customerID == "" {
+		return PreviewResult{}, errs.Required("customer_id")
+	}
+
+	if _, err := s.customers.Get(ctx, tenantID, customerID); err != nil {
+		return PreviewResult{}, err
+	}
+
+	sub, err := s.resolveSubscription(ctx, tenantID, customerID, req.SubscriptionID)
+	if err != nil {
+		return PreviewResult{}, err
+	}
+
+	from, to, err := resolveCreatePreviewPeriod(req.Period, sub)
+	if err != nil {
+		return PreviewResult{}, err
+	}
+
+	return s.engine.previewWithWindow(ctx, sub, from, to)
+}
+
+// resolveSubscription picks the subscription the preview will run
+// against. Two paths:
+//
+//   - Explicit subscriptionID: look it up. ErrNotFound propagates as 404.
+//     Cross-customer mismatch surfaces as 400 invalid_request — defensive
+//     against the operator typoing both IDs to plausible-but-wrong values.
+//
+//   - Implicit (subscriptionID == ""): list the customer's subs, filter
+//     to active or trialing, pick the one with the most recent
+//     current_period_start (same heuristic as customer-usage's primary
+//     active subscription pick). Zero matches → coded
+//     customer_has_no_subscription so the dashboard's empty-state branch
+//     covers both surfaces.
+func (s *PreviewService) resolveSubscription(ctx context.Context, tenantID, customerID, subscriptionID string) (domain.Subscription, error) {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+
+	if subscriptionID != "" {
+		sub, err := s.subscriptions.Get(ctx, tenantID, subscriptionID)
+		if err != nil {
+			return domain.Subscription{}, err
+		}
+		if sub.CustomerID != customerID {
+			return domain.Subscription{}, errs.Invalid(
+				"subscription_id",
+				"subscription does not belong to the requested customer",
+			)
+		}
+		return sub, nil
+	}
+
+	subs, _, err := s.subscriptions.List(ctx, subscription.ListFilter{
+		TenantID:   tenantID,
+		CustomerID: customerID,
+	})
+	if err != nil {
+		return domain.Subscription{}, fmt.Errorf("list subscriptions: %w", err)
+	}
+
+	primary, ok := pickPrimarySubscription(subs)
+	if !ok {
+		return domain.Subscription{}, errs.Invalid(
+			"customer_id",
+			"customer has no active or trialing subscription; pass subscription_id explicitly to preview a non-active sub",
+		).WithCode("customer_has_no_subscription")
+	}
+	return primary, nil
+}
+
+// pickPrimarySubscription mirrors customer-usage's "primary active
+// subscription" heuristic: filter to active or trialing, pick the most
+// recent current_period_start. Subs without a current cycle (paused,
+// canceled, draft) are excluded — they have no projected bill to preview.
+func pickPrimarySubscription(subs []domain.Subscription) (domain.Subscription, bool) {
+	var primary *domain.Subscription
+	for i := range subs {
+		sub := &subs[i]
+		if sub.Status != domain.SubscriptionActive && sub.Status != domain.SubscriptionTrialing {
+			continue
+		}
+		if sub.CurrentBillingPeriodStart == nil || sub.CurrentBillingPeriodEnd == nil {
+			continue
+		}
+		if primary == nil || sub.CurrentBillingPeriodStart.After(*primary.CurrentBillingPeriodStart) {
+			primary = sub
+		}
+	}
+	if primary == nil {
+		return domain.Subscription{}, false
+	}
+	return *primary, true
+}
+
+// resolveCreatePreviewPeriod decides the [from, to) window to preview.
+// Default is the resolved subscription's current cycle. Explicit
+// from/to must both be set and form a strictly increasing window.
+//
+// Partial windows (one zero, one non-zero) are rejected — a half-set
+// period is almost always a caller bug, not an intent. Same shape as
+// customer-usage.resolvePeriod minus the 1-year cap (a preview is always
+// within a single cycle, so no cap makes sense).
+func resolveCreatePreviewPeriod(period CreatePreviewPeriod, sub domain.Subscription) (time.Time, time.Time, error) {
+	hasFrom := !period.From.IsZero()
+	hasTo := !period.To.IsZero()
+
+	if hasFrom != hasTo {
+		return time.Time{}, time.Time{}, errs.Invalid("period", "both from and to must be supplied together")
+	}
+
+	if hasFrom && hasTo {
+		if !period.From.Before(period.To) {
+			return time.Time{}, time.Time{}, errs.Invalid("period", "from must be strictly before to")
+		}
+		return period.From, period.To, nil
+	}
+
+	if sub.CurrentBillingPeriodStart == nil || sub.CurrentBillingPeriodEnd == nil {
+		return time.Time{}, time.Time{}, errs.Invalid(
+			"period",
+			"subscription has no current billing cycle; pass period.from and period.to explicitly",
+		).WithCode("subscription_has_no_cycle")
+	}
+	return *sub.CurrentBillingPeriodStart, *sub.CurrentBillingPeriodEnd, nil
+}

--- a/internal/billing/preview_create_test.go
+++ b/internal/billing/preview_create_test.go
@@ -161,10 +161,10 @@ func TestPickPrimarySubscription(t *testing.T) {
 	lateEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
 
 	cases := []struct {
-		name     string
-		subs     []domain.Subscription
-		wantOk   bool
-		wantID   string
+		name   string
+		subs   []domain.Subscription
+		wantOk bool
+		wantID string
 	}{
 		{
 			name:   "empty input returns false",

--- a/internal/billing/preview_create_test.go
+++ b/internal/billing/preview_create_test.go
@@ -1,0 +1,469 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/subscription"
+)
+
+// stubCustomers is a CustomerLookup that returns a canned customer for
+// known IDs and ErrNotFound otherwise. Tests assert RLS-by-construction
+// by setting unknown IDs.
+type stubCustomers struct {
+	known map[string]domain.Customer
+}
+
+func (s *stubCustomers) Get(_ context.Context, _, id string) (domain.Customer, error) {
+	if c, ok := s.known[id]; ok {
+		return c, nil
+	}
+	return domain.Customer{}, errs.ErrNotFound
+}
+
+// stubSubscriptions implements SubscriptionLister so tests can control
+// the resolveSubscription branch (explicit ID happy path, mismatched
+// customer, implicit pick of latest active sub, zero-active-subs error).
+type stubSubscriptions struct {
+	byID         map[string]domain.Subscription
+	byCustomerID map[string][]domain.Subscription
+	listErr      error
+	getErr       error
+}
+
+func (s *stubSubscriptions) Get(_ context.Context, _, id string) (domain.Subscription, error) {
+	if s.getErr != nil {
+		return domain.Subscription{}, s.getErr
+	}
+	if sub, ok := s.byID[id]; ok {
+		return sub, nil
+	}
+	return domain.Subscription{}, errs.ErrNotFound
+}
+
+func (s *stubSubscriptions) List(_ context.Context, filter subscription.ListFilter) ([]domain.Subscription, int, error) {
+	if s.listErr != nil {
+		return nil, 0, s.listErr
+	}
+	subs := s.byCustomerID[filter.CustomerID]
+	return subs, len(subs), nil
+}
+
+// timePtr returns a pointer to its argument — handy for setting
+// CurrentBillingPeriodStart / CurrentBillingPeriodEnd on test fixtures
+// without local variables.
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestResolveCreatePreviewPeriod(t *testing.T) {
+	cycleStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	cycleEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	subWithCycle := domain.Subscription{
+		CurrentBillingPeriodStart: timePtr(cycleStart),
+		CurrentBillingPeriodEnd:   timePtr(cycleEnd),
+	}
+
+	cases := []struct {
+		name      string
+		period    CreatePreviewPeriod
+		sub       domain.Subscription
+		wantFrom  time.Time
+		wantTo    time.Time
+		wantErr   bool
+		wantField string
+	}{
+		{
+			name:     "default to current cycle",
+			period:   CreatePreviewPeriod{},
+			sub:      subWithCycle,
+			wantFrom: cycleStart,
+			wantTo:   cycleEnd,
+		},
+		{
+			name: "explicit window honored",
+			period: CreatePreviewPeriod{
+				From: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+			sub:      subWithCycle,
+			wantFrom: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			wantTo:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "partial bounds rejected (only from)",
+			period: CreatePreviewPeriod{
+				From: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			},
+			sub:       subWithCycle,
+			wantErr:   true,
+			wantField: "period",
+		},
+		{
+			name: "partial bounds rejected (only to)",
+			period: CreatePreviewPeriod{
+				To: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+			sub:       subWithCycle,
+			wantErr:   true,
+			wantField: "period",
+		},
+		{
+			name: "from >= to rejected",
+			period: CreatePreviewPeriod{
+				From: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+			sub:       subWithCycle,
+			wantErr:   true,
+			wantField: "period",
+		},
+		{
+			name:      "default with no current cycle is coded error",
+			period:    CreatePreviewPeriod{},
+			sub:       domain.Subscription{},
+			wantErr:   true,
+			wantField: "period",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			from, to, err := resolveCreatePreviewPeriod(tc.period, tc.sub)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got from=%v to=%v", from, to)
+				}
+				if errs.Field(err) != tc.wantField {
+					t.Errorf("field mismatch: got %q want %q", errs.Field(err), tc.wantField)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !from.Equal(tc.wantFrom) {
+				t.Errorf("from: got %v want %v", from, tc.wantFrom)
+			}
+			if !to.Equal(tc.wantTo) {
+				t.Errorf("to: got %v want %v", to, tc.wantTo)
+			}
+		})
+	}
+}
+
+func TestPickPrimarySubscription(t *testing.T) {
+	earlyStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	earlyEnd := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	lateStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	lateEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		subs     []domain.Subscription
+		wantOk   bool
+		wantID   string
+	}{
+		{
+			name:   "empty input returns false",
+			subs:   nil,
+			wantOk: false,
+		},
+		{
+			name: "only canceled sub returns false",
+			subs: []domain.Subscription{
+				{ID: "s1", Status: domain.SubscriptionCanceled, CurrentBillingPeriodStart: timePtr(lateStart), CurrentBillingPeriodEnd: timePtr(lateEnd)},
+			},
+			wantOk: false,
+		},
+		{
+			name: "active sub without cycle is skipped",
+			subs: []domain.Subscription{
+				{ID: "s1", Status: domain.SubscriptionActive},
+			},
+			wantOk: false,
+		},
+		{
+			name: "single active sub picked",
+			subs: []domain.Subscription{
+				{ID: "s1", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: timePtr(lateStart), CurrentBillingPeriodEnd: timePtr(lateEnd)},
+			},
+			wantOk: true,
+			wantID: "s1",
+		},
+		{
+			name: "trialing sub picked",
+			subs: []domain.Subscription{
+				{ID: "s1", Status: domain.SubscriptionTrialing, CurrentBillingPeriodStart: timePtr(lateStart), CurrentBillingPeriodEnd: timePtr(lateEnd)},
+			},
+			wantOk: true,
+			wantID: "s1",
+		},
+		{
+			name: "most recent cycle wins on tie",
+			subs: []domain.Subscription{
+				{ID: "s1", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: timePtr(earlyStart), CurrentBillingPeriodEnd: timePtr(earlyEnd)},
+				{ID: "s2", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: timePtr(lateStart), CurrentBillingPeriodEnd: timePtr(lateEnd)},
+			},
+			wantOk: true,
+			wantID: "s2",
+		},
+		{
+			name: "canceled siblings ignored",
+			subs: []domain.Subscription{
+				{ID: "s1", Status: domain.SubscriptionCanceled, CurrentBillingPeriodStart: timePtr(lateStart), CurrentBillingPeriodEnd: timePtr(lateEnd)},
+				{ID: "s2", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: timePtr(earlyStart), CurrentBillingPeriodEnd: timePtr(earlyEnd)},
+			},
+			wantOk: true,
+			wantID: "s2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := pickPrimarySubscription(tc.subs)
+			if ok != tc.wantOk {
+				t.Fatalf("ok: got %v want %v", ok, tc.wantOk)
+			}
+			if !ok {
+				return
+			}
+			if got.ID != tc.wantID {
+				t.Errorf("ID: got %q want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestPreviewService_ResolveSubscription(t *testing.T) {
+	subActive := domain.Subscription{
+		ID:                        "vlx_sub_active",
+		CustomerID:                "vlx_cus_abc",
+		Status:                    domain.SubscriptionActive,
+		CurrentBillingPeriodStart: timePtr(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)),
+		CurrentBillingPeriodEnd:   timePtr(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	subForOtherCustomer := domain.Subscription{
+		ID:         "vlx_sub_active",
+		CustomerID: "vlx_cus_other",
+		Status:     domain.SubscriptionActive,
+	}
+
+	t.Run("explicit ID happy path", func(t *testing.T) {
+		svc := &PreviewService{
+			subscriptions: &stubSubscriptions{
+				byID: map[string]domain.Subscription{"vlx_sub_active": subActive},
+			},
+		}
+		sub, err := svc.resolveSubscription(context.Background(), "t1", "vlx_cus_abc", "vlx_sub_active")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sub.ID != "vlx_sub_active" {
+			t.Errorf("ID: got %q", sub.ID)
+		}
+	})
+
+	t.Run("explicit ID belongs to wrong customer", func(t *testing.T) {
+		svc := &PreviewService{
+			subscriptions: &stubSubscriptions{
+				byID: map[string]domain.Subscription{"vlx_sub_active": subForOtherCustomer},
+			},
+		}
+		_, err := svc.resolveSubscription(context.Background(), "t1", "vlx_cus_abc", "vlx_sub_active")
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+		if errs.Field(err) != "subscription_id" {
+			t.Errorf("field: got %q want subscription_id", errs.Field(err))
+		}
+	})
+
+	t.Run("explicit ID 404 propagates", func(t *testing.T) {
+		svc := &PreviewService{
+			subscriptions: &stubSubscriptions{
+				byID: map[string]domain.Subscription{},
+			},
+		}
+		_, err := svc.resolveSubscription(context.Background(), "t1", "vlx_cus_abc", "vlx_sub_missing")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !errors.Is(err, errs.ErrNotFound) {
+			t.Errorf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("implicit picks most recent active sub", func(t *testing.T) {
+		earlyStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+		earlyEnd := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+		lateStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+		lateEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+		svc := &PreviewService{
+			subscriptions: &stubSubscriptions{
+				byCustomerID: map[string][]domain.Subscription{
+					"vlx_cus_abc": {
+						{ID: "old", CustomerID: "vlx_cus_abc", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: timePtr(earlyStart), CurrentBillingPeriodEnd: timePtr(earlyEnd)},
+						{ID: "new", CustomerID: "vlx_cus_abc", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: timePtr(lateStart), CurrentBillingPeriodEnd: timePtr(lateEnd)},
+					},
+				},
+			},
+		}
+		sub, err := svc.resolveSubscription(context.Background(), "t1", "vlx_cus_abc", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sub.ID != "new" {
+			t.Errorf("expected most recent sub 'new', got %q", sub.ID)
+		}
+	})
+
+	t.Run("implicit with zero subs returns coded error", func(t *testing.T) {
+		svc := &PreviewService{
+			subscriptions: &stubSubscriptions{
+				byCustomerID: map[string][]domain.Subscription{},
+			},
+		}
+		_, err := svc.resolveSubscription(context.Background(), "t1", "vlx_cus_abc", "")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if errs.Code(err) != "customer_has_no_subscription" {
+			t.Errorf("code: got %q want customer_has_no_subscription", errs.Code(err))
+		}
+	})
+}
+
+// TestCreatePreview_BlankCustomerID surfaces the customer_id required
+// error before any store calls — keeps the error shape symmetric with
+// the customer-usage surface (errs.Required("customer_id")).
+func TestCreatePreview_BlankCustomerID(t *testing.T) {
+	svc := &PreviewService{
+		customers:     &stubCustomers{},
+		subscriptions: &stubSubscriptions{},
+	}
+	_, err := svc.CreatePreview(context.Background(), "t1", CreatePreviewRequest{CustomerID: "  "})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errs.Field(err) != "customer_id" {
+		t.Errorf("field: got %q want customer_id", errs.Field(err))
+	}
+}
+
+// TestCreatePreview_CustomerNotFound is the RLS-by-construction case:
+// cross-tenant IDs return ErrNotFound at the customer lookup, which the
+// handler maps to 404. No subscription / pricing reads happen.
+func TestCreatePreview_CustomerNotFound(t *testing.T) {
+	svc := &PreviewService{
+		customers:     &stubCustomers{known: map[string]domain.Customer{}},
+		subscriptions: &stubSubscriptions{},
+	}
+	_, err := svc.CreatePreview(context.Background(), "t1", CreatePreviewRequest{CustomerID: "vlx_cus_other"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, errs.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestDecodeCreatePreviewRequest covers the JSON wire-decoding edge
+// cases the handler relies on: empty body is treated as {}, partial
+// period is rejected with field tagging, RFC 3339 must parse.
+func TestDecodeCreatePreviewRequest(t *testing.T) {
+	cases := []struct {
+		name    string
+		body    string
+		wantErr bool
+		wantCID string
+		wantSID string
+	}{
+		{name: "empty body", body: "", wantErr: false},
+		{name: "minimal valid", body: `{"customer_id":"vlx_cus_abc"}`, wantCID: "vlx_cus_abc"},
+		{name: "with subscription", body: `{"customer_id":"vlx_cus_abc","subscription_id":"vlx_sub_xyz"}`, wantCID: "vlx_cus_abc", wantSID: "vlx_sub_xyz"},
+		{name: "with full period", body: `{"customer_id":"vlx_cus_abc","period":{"from":"2026-04-01T00:00:00Z","to":"2026-05-01T00:00:00Z"}}`, wantCID: "vlx_cus_abc"},
+		{name: "malformed json", body: `{`, wantErr: true},
+		{name: "unparseable from", body: `{"customer_id":"vlx_cus_abc","period":{"from":"yesterday","to":"2026-05-01T00:00:00Z"}}`, wantErr: true},
+		{name: "unparseable to", body: `{"customer_id":"vlx_cus_abc","period":{"from":"2026-04-01T00:00:00Z","to":"tomorrow"}}`, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := decodeCreatePreviewRequest([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", req)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if req.CustomerID != tc.wantCID {
+				t.Errorf("customer_id: got %q want %q", req.CustomerID, tc.wantCID)
+			}
+			if req.SubscriptionID != tc.wantSID {
+				t.Errorf("subscription_id: got %q want %q", req.SubscriptionID, tc.wantSID)
+			}
+		})
+	}
+}
+
+// TestComputePreviewTotals exercises the per-currency rollup —
+// insertion-stable order, single-currency one-entry, multi-currency
+// distinct entries, blank-currency lines (e.g. zero-fee plans) excluded.
+func TestComputePreviewTotals(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		totals := computePreviewTotals(nil)
+		if len(totals) != 0 {
+			t.Errorf("expected empty totals, got %d", len(totals))
+		}
+	})
+
+	t.Run("single currency", func(t *testing.T) {
+		totals := computePreviewTotals([]PreviewLine{
+			{Currency: "USD", AmountCents: 100},
+			{Currency: "USD", AmountCents: 250},
+		})
+		if len(totals) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(totals))
+		}
+		if totals[0].Currency != "USD" || totals[0].AmountCents != 350 {
+			t.Errorf("got %+v", totals[0])
+		}
+	})
+
+	t.Run("multi currency stable order", func(t *testing.T) {
+		totals := computePreviewTotals([]PreviewLine{
+			{Currency: "USD", AmountCents: 100},
+			{Currency: "EUR", AmountCents: 200},
+			{Currency: "USD", AmountCents: 50},
+		})
+		if len(totals) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(totals))
+		}
+		// USD seen first → position 0
+		if totals[0].Currency != "USD" || totals[0].AmountCents != 150 {
+			t.Errorf("totals[0]: got %+v", totals[0])
+		}
+		if totals[1].Currency != "EUR" || totals[1].AmountCents != 200 {
+			t.Errorf("totals[1]: got %+v", totals[1])
+		}
+	})
+
+	t.Run("blank-currency lines excluded", func(t *testing.T) {
+		totals := computePreviewTotals([]PreviewLine{
+			{Currency: "", AmountCents: 999},
+			{Currency: "USD", AmountCents: 100},
+		})
+		if len(totals) != 1 {
+			t.Fatalf("expected 1 entry, got %d", len(totals))
+		}
+		if totals[0].AmountCents != 100 {
+			t.Errorf("expected 100, got %d", totals[0].AmountCents)
+		}
+	})
+}

--- a/internal/billing/preview_integration_test.go
+++ b/internal/billing/preview_integration_test.go
@@ -1,0 +1,516 @@
+package billing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/billing"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/pricing"
+	"github.com/sagarsuperuser/velox/internal/subscription"
+	"github.com/sagarsuperuser/velox/internal/tenant"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+	"github.com/sagarsuperuser/velox/internal/usage"
+)
+
+// previewFixture wires real per-domain stores against a clean test DB so
+// the create_preview path exercises the full SQL → engine → wire-shape
+// chain. Tests then ingest events and assert the preview emits the same
+// totals the cycle scan would produce — the parity guarantee the whole
+// feature rests on.
+//
+// Mirrors customerUsageFixture (see internal/usage/customer_usage_integration_test.go)
+// but stops short of running RunCycle — preview composes off the engine's
+// previewWithWindow path which is read-only by construction.
+type previewFixture struct {
+	db          *postgres.DB
+	tenantID    string
+	customerSvc *customer.Service
+	pricingSvc  *pricing.Service
+	subStore    *subscription.PostgresStore
+	subSvc      *subscription.Service
+	usageSvc    *usage.Service
+	preview     *billing.PreviewService
+	engine      *billing.Engine
+}
+
+func newPreviewFixture(t *testing.T, name string) *previewFixture {
+	t.Helper()
+	db := testutil.SetupTestDB(t)
+	tenantID := testutil.CreateTestTenant(t, db, name)
+
+	customerStore := customer.NewPostgresStore(db)
+	customerSvc := customer.NewService(customerStore)
+	pricingStore := pricing.NewPostgresStore(db)
+	pricingSvc := pricing.NewService(pricingStore)
+	subStore := subscription.NewPostgresStore(db)
+	subSvc := subscription.NewService(subStore, nil)
+	usageStore := usage.NewPostgresStore(db)
+	usageSvc := usage.NewService(usageStore)
+	invoiceStore := invoice.NewPostgresStore(db)
+	settingsStore := tenant.NewSettingsStore(db)
+
+	engine := billing.NewEngine(
+		&subStoreAdapter{subStore},
+		&usageStoreAdapter{usageStore},
+		&pricingStoreAdapter{pricingStore},
+		&invoiceStoreAdapter{invoiceStore},
+		nil, settingsStore, nil, nil, nil,
+	)
+
+	preview := billing.NewPreviewService(engine, customerStore, subStore)
+
+	return &previewFixture{
+		db:          db,
+		tenantID:    tenantID,
+		customerSvc: customerSvc,
+		pricingSvc:  pricingSvc,
+		subStore:    subStore,
+		subSvc:      subSvc,
+		usageSvc:    usageSvc,
+		preview:     preview,
+		engine:      engine,
+	}
+}
+
+// seedSubscription mirrors customer-usage's seedCustomerWithSub. Creates
+// a customer, a plan with the supplied meter, and an active subscription
+// with a current billing cycle of [from, to). Returns customer / plan /
+// sub IDs.
+func (f *previewFixture) seedSubscription(
+	t *testing.T,
+	ctx context.Context,
+	externalID, planCode, meterID string,
+	cycleStart, cycleEnd time.Time,
+) (custID, planID, subID string) {
+	t.Helper()
+
+	cust, err := f.customerSvc.Create(ctx, f.tenantID, customer.CreateInput{
+		ExternalID:  externalID,
+		DisplayName: externalID,
+		Email:       externalID + "@example.test",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	plan, err := f.pricingSvc.CreatePlan(ctx, f.tenantID, pricing.CreatePlanInput{
+		Code:            planCode,
+		Name:            planCode,
+		Currency:        "USD",
+		BillingInterval: domain.BillingMonthly,
+		BaseAmountCents: 0,
+		MeterIDs:        []string{meterID},
+	})
+	if err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+
+	subID = postgres.NewID("vlx_sub")
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, f.tenantID)
+	if err != nil {
+		t.Fatalf("begin sub tx: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	now := time.Now().UTC()
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO subscriptions (
+			id, tenant_id, code, display_name, customer_id, status, billing_time,
+			current_billing_period_start, current_billing_period_end, next_billing_at,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, 'active', 'anniversary', $6, $7, $7, $8, $8)
+	`, subID, f.tenantID, "code-"+externalID, planCode+"-sub", cust.ID,
+		cycleStart, cycleEnd, now)
+	if err != nil {
+		t.Fatalf("insert sub: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO subscription_items (id, tenant_id, subscription_id, plan_id, quantity, metadata, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, 1, '{}'::jsonb, $5, $5)
+	`, postgres.NewID("vlx_si"), f.tenantID, subID, plan.ID, now)
+	if err != nil {
+		t.Fatalf("insert sub item: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit sub: %v", err)
+	}
+	return cust.ID, plan.ID, subID
+}
+
+// countInvoiceRows counts invoice + invoice_line_item rows for the
+// fixture's tenant. Used by TestCreatePreview_NoWrites to assert the
+// preview path persists nothing — the standout property of this surface
+// vs. /v1/invoices/{id}/finalize.
+func (f *previewFixture) countInvoiceRows(t *testing.T, ctx context.Context) (invoices, lineItems int) {
+	t.Helper()
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, f.tenantID)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM invoices WHERE tenant_id = $1`, f.tenantID).Scan(&invoices); err != nil {
+		t.Fatalf("count invoices: %v", err)
+	}
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM invoice_line_items WHERE tenant_id = $1`, f.tenantID).Scan(&lineItems); err != nil {
+		t.Fatalf("count line items: %v", err)
+	}
+	return invoices, lineItems
+}
+
+// TestCreatePreview_SingleMeterFlatParity is the parity guarantee:
+// preview math == invoice math for the single-meter flat-pricing case.
+// Same fixture as TestCustomerUsage_SingleMeterFlatParity (100 events ×
+// qty=10 × 1¢ = 1000c) so a regression in one shows up in the other.
+func TestCreatePreview_SingleMeterFlatParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newPreviewFixture(t, "Create Preview Single Meter")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	rrv, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "tokens_flat", Name: "Tokens Flat",
+		Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("create rrv: %v", err)
+	}
+
+	meter, err := f.pricingSvc.CreateMeter(ctx, f.tenantID, pricing.CreateMeterInput{
+		Key: "tokens", Name: "Tokens", Unit: "tokens",
+		Aggregation: "sum", RatingRuleVersionID: rrv.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+
+	custID, _, subID := f.seedSubscription(t, ctx, "cus_preview_flat", "pln_flat", meter.ID, cycleStart, cycleEnd)
+
+	// 100 in-cycle events × qty=10 × 1¢ = 1000c.
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meter.ID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	res, err := f.preview.CreatePreview(ctx, f.tenantID, billing.CreatePreviewRequest{
+		CustomerID: custID,
+	})
+	if err != nil {
+		t.Fatalf("CreatePreview: %v", err)
+	}
+	if res.SubscriptionID != subID {
+		t.Errorf("subscription_id: got %q want %q", res.SubscriptionID, subID)
+	}
+	if !res.BillingPeriodStart.Equal(cycleStart) {
+		t.Errorf("billing_period_start: got %v want %v", res.BillingPeriodStart, cycleStart)
+	}
+	if !res.BillingPeriodEnd.Equal(cycleEnd) {
+		t.Errorf("billing_period_end: got %v want %v", res.BillingPeriodEnd, cycleEnd)
+	}
+	if len(res.Lines) != 1 {
+		t.Fatalf("lines: got %d want 1 (single-meter no-base-fee plan)", len(res.Lines))
+	}
+	if res.Lines[0].LineType != "usage" {
+		t.Errorf("line_type: got %q want usage", res.Lines[0].LineType)
+	}
+	if res.Lines[0].AmountCents != 1000 {
+		t.Errorf("amount_cents: got %d want 1000", res.Lines[0].AmountCents)
+	}
+	if !res.Lines[0].Quantity.Equal(decimal.NewFromInt(1000)) {
+		t.Errorf("quantity: got %s want 1000", res.Lines[0].Quantity.String())
+	}
+	if len(res.Totals) != 1 {
+		t.Fatalf("totals: got %d want 1", len(res.Totals))
+	}
+	if res.Totals[0].Currency != "USD" || res.Totals[0].AmountCents != 1000 {
+		t.Errorf("totals[0]: got %+v want USD/1000", res.Totals[0])
+	}
+}
+
+// TestCreatePreview_MultiDimDimensionMatchEcho proves a multi-dim meter
+// emits one line per (meter, rule) pair with dimension_match echoed.
+// Same fixture as TestCustomerUsage_MultiDimDimensionMatchEcho (1000 input
+// @3¢ + 100 output @5¢ = 3500c).
+func TestCreatePreview_MultiDimDimensionMatchEcho(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newPreviewFixture(t, "Create Preview Multi Dim")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-24 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	rrvIn, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "tokens_input", Name: "Input", Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 3,
+	})
+	if err != nil {
+		t.Fatalf("create rrv input: %v", err)
+	}
+	rrvOut, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "tokens_output", Name: "Output", Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 5,
+	})
+	if err != nil {
+		t.Fatalf("create rrv output: %v", err)
+	}
+
+	meter, err := f.pricingSvc.CreateMeter(ctx, f.tenantID, pricing.CreateMeterInput{
+		Key: "tokens_dim", Name: "Tokens Dim", Unit: "tokens",
+		Aggregation: "sum", RatingRuleVersionID: rrvIn.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+
+	if _, err := f.pricingSvc.UpsertMeterPricingRule(ctx, f.tenantID, pricing.UpsertMeterPricingRuleInput{
+		MeterID: meter.ID, RatingRuleVersionID: rrvIn.ID,
+		DimensionMatch:  map[string]any{"operation": "input"},
+		AggregationMode: domain.AggSum, Priority: 10,
+	}); err != nil {
+		t.Fatalf("upsert mpr input: %v", err)
+	}
+	if _, err := f.pricingSvc.UpsertMeterPricingRule(ctx, f.tenantID, pricing.UpsertMeterPricingRuleInput{
+		MeterID: meter.ID, RatingRuleVersionID: rrvOut.ID,
+		DimensionMatch:  map[string]any{"operation": "output"},
+		AggregationMode: domain.AggSum, Priority: 10,
+	}); err != nil {
+		t.Fatalf("upsert mpr output: %v", err)
+	}
+
+	custID, _, _ := f.seedSubscription(t, ctx, "cus_preview_dim", "pln_dim", meter.ID, cycleStart, cycleEnd)
+
+	// 10 input events qty=100 = 1000 input units → 3000c.
+	for i := 0; i < 10; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meter.ID, Quantity: decimal.NewFromInt(100),
+			Dimensions: map[string]any{"operation": "input"}, Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest input %d: %v", i, err)
+		}
+	}
+	// 5 output events qty=20 = 100 output units → 500c.
+	for i := 0; i < 5; i++ {
+		ts := cycleStart.Add(time.Duration(i+11) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meter.ID, Quantity: decimal.NewFromInt(20),
+			Dimensions: map[string]any{"operation": "output"}, Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest output %d: %v", i, err)
+		}
+	}
+
+	res, err := f.preview.CreatePreview(ctx, f.tenantID, billing.CreatePreviewRequest{
+		CustomerID: custID,
+	})
+	if err != nil {
+		t.Fatalf("CreatePreview: %v", err)
+	}
+	if len(res.Lines) < 2 {
+		t.Fatalf("lines: got %d want at least 2 (one per rule)", len(res.Lines))
+	}
+
+	var totalCents int64
+	dimMatchSeen := 0
+	for _, line := range res.Lines {
+		if line.LineType != "usage" {
+			continue
+		}
+		if line.DimensionMatch == nil {
+			t.Errorf("line %q dimension_match must echo the meter pricing rule's filter", line.RuleKey)
+			continue
+		}
+		dimMatchSeen++
+		totalCents += line.AmountCents
+	}
+	if dimMatchSeen < 2 {
+		t.Fatalf("expected dimension_match on at least 2 lines, got %d", dimMatchSeen)
+	}
+	// 1000 input × 3¢ + 100 output × 5¢ = 3500c.
+	if totalCents != 3500 {
+		t.Errorf("total cents: got %d want 3500 (1000×3 + 100×5)", totalCents)
+	}
+	if len(res.Totals) != 1 || res.Totals[0].Currency != "USD" || res.Totals[0].AmountCents != 3500 {
+		t.Errorf("totals: got %+v want USD/3500", res.Totals)
+	}
+}
+
+// TestCreatePreview_NoWrites is the standout property of this surface:
+// the preview composes reads only. Counts invoices + invoice_line_items
+// before and after a CreatePreview call and asserts unchanged.
+func TestCreatePreview_NoWrites(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newPreviewFixture(t, "Create Preview No Writes")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-12 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	rrv, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "x", Name: "x", Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("create rrv: %v", err)
+	}
+	meter, err := f.pricingSvc.CreateMeter(ctx, f.tenantID, pricing.CreateMeterInput{
+		Key: "x", Name: "x", Unit: "u", Aggregation: "sum", RatingRuleVersionID: rrv.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+
+	custID, _, _ := f.seedSubscription(t, ctx, "cus_nowrites", "pln_nowrites", meter.ID, cycleStart, cycleEnd)
+
+	for i := 0; i < 5; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meter.ID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	beforeInvoices, beforeLineItems := f.countInvoiceRows(t, ctx)
+
+	if _, err := f.preview.CreatePreview(ctx, f.tenantID, billing.CreatePreviewRequest{CustomerID: custID}); err != nil {
+		t.Fatalf("CreatePreview: %v", err)
+	}
+
+	afterInvoices, afterLineItems := f.countInvoiceRows(t, ctx)
+
+	if afterInvoices != beforeInvoices {
+		t.Errorf("invoices row count drifted: before=%d after=%d (preview must not persist)", beforeInvoices, afterInvoices)
+	}
+	if afterLineItems != beforeLineItems {
+		t.Errorf("invoice_line_items row count drifted: before=%d after=%d (preview must not persist)", beforeLineItems, afterLineItems)
+	}
+}
+
+// TestCreatePreview_CrossTenantIsolation confirms RLS hides the customer
+// from a different tenant — the lookup surfaces ErrNotFound, which the
+// handler maps to 404. Same property customer-usage relies on.
+func TestCreatePreview_CrossTenantIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newPreviewFixture(t, "Create Preview Cross Tenant A")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	rrv, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "x", Name: "x", Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("create rrv: %v", err)
+	}
+	meter, err := f.pricingSvc.CreateMeter(ctx, f.tenantID, pricing.CreateMeterInput{
+		Key: "x", Name: "x", Unit: "u", Aggregation: "sum", RatingRuleVersionID: rrv.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-24 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+	custA, _, _ := f.seedSubscription(t, ctx, "cus_xtenA", "pln_a", meter.ID, cycleStart, cycleEnd)
+
+	tenantB := testutil.CreateTestTenant(t, f.db, "Create Preview Cross Tenant B")
+	_, err = f.preview.CreatePreview(ctx, tenantB, billing.CreatePreviewRequest{CustomerID: custA})
+	if err == nil {
+		t.Fatal("expected not-found error for cross-tenant lookup")
+	}
+}
+
+// TestCreatePreview_CustomerHasNoSubscription asserts the documented
+// coded error for the empty-customer case — symmetric with the
+// customer-usage surface so the dashboard's empty-state branch covers
+// both reads.
+func TestCreatePreview_CustomerHasNoSubscription(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newPreviewFixture(t, "Create Preview No Sub")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cust, err := f.customerSvc.Create(ctx, f.tenantID, customer.CreateInput{
+		ExternalID: "cus_nosub", DisplayName: "No Sub", Email: "nosub@example.test",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	_, err = f.preview.CreatePreview(ctx, f.tenantID, billing.CreatePreviewRequest{CustomerID: cust.ID})
+	if err == nil {
+		t.Fatal("expected error when customer has no subscription")
+	}
+	if errs.Code(err) != "customer_has_no_subscription" {
+		t.Errorf("error code: got %q want customer_has_no_subscription", errs.Code(err))
+	}
+}
+
+// TestCreatePreview_ExplicitSubscriptionWrongCustomer is the cross-customer
+// safety check: passing an ID that belongs to a different customer in the
+// same tenant surfaces as 422 invalid_request, not as a silent preview of
+// the wrong sub.
+func TestCreatePreview_ExplicitSubscriptionWrongCustomer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newPreviewFixture(t, "Create Preview Wrong Customer")
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	rrv, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "x", Name: "x", Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("create rrv: %v", err)
+	}
+	meter, err := f.pricingSvc.CreateMeter(ctx, f.tenantID, pricing.CreateMeterInput{
+		Key: "x", Name: "x", Unit: "u", Aggregation: "sum", RatingRuleVersionID: rrv.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-24 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	_, _, subA := f.seedSubscription(t, ctx, "cus_wrong_a", "pln_wrong_a", meter.ID, cycleStart, cycleEnd)
+	custB, _, _ := f.seedSubscription(t, ctx, "cus_wrong_b", "pln_wrong_b", meter.ID, cycleStart, cycleEnd)
+
+	// Customer B asking for Customer A's subscription — must reject.
+	_, err = f.preview.CreatePreview(ctx, f.tenantID, billing.CreatePreviewRequest{
+		CustomerID:     custB,
+		SubscriptionID: subA,
+	})
+	if err == nil {
+		t.Fatal("expected error when subscription does not belong to customer")
+	}
+	if got := errs.Field(err); got != "subscription_id" {
+		t.Errorf("field: got %q want subscription_id", got)
+	}
+}

--- a/internal/billing/preview_wire_shape_test.go
+++ b/internal/billing/preview_wire_shape_test.go
@@ -1,0 +1,236 @@
+package billing
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestWireShape_SnakeCase pins the JSON contract Track B's cost dashboard
+// + projected-bill panel depend on. Drift here (e.g. dropping a json:"…"
+// tag and falling back to PascalCase, or an empty slice marshalling as
+// null) breaks the frontend at runtime, so we marshal a fully-populated
+// PreviewResult and assert:
+//
+//   - Every documented snake_case key is present at the right level.
+//   - No PascalCase keys leak through (caught by the json:"…" tags
+//     dropping off a field, which has happened before).
+//   - Slice fields marshal as JSON arrays even when empty — clients can
+//     iterate without null guards.
+//   - Decimal quantity round-trips as a string (per ADR-005), not a
+//     JSON number that would lose precision on large fractional values.
+//
+// This is the merge gate for /v1/invoices/create_preview. See
+// docs/design-create-preview.md.
+func TestWireShape_SnakeCase(t *testing.T) {
+	t.Run("FullyPopulated", func(t *testing.T) {
+		result := PreviewResult{
+			CustomerID:         "vlx_cus_abc",
+			SubscriptionID:     "vlx_sub_xyz",
+			PlanName:           "AI API Pro",
+			BillingPeriodStart: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			BillingPeriodEnd:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			Lines: []PreviewLine{
+				{
+					LineType:        "base_fee",
+					Description:     "AI API Pro - base fee (qty 1)",
+					Currency:        "USD",
+					Quantity:        decimal.NewFromInt(1),
+					UnitAmountCents: 0,
+					AmountCents:     0,
+				},
+				{
+					LineType:            "usage",
+					Description:         "Tokens - input (cached)",
+					MeterID:             "vlx_mtr_tokens",
+					RatingRuleVersionID: "vlx_rrv_input",
+					RuleKey:             "gpt4_input_uncached",
+					DimensionMatch:      map[string]any{"model": "gpt-4", "operation": "input", "cached": false},
+					Currency:            "USD",
+					Quantity:            decimal.RequireFromString("1234567.891234"),
+					UnitAmountCents:     0,
+					AmountCents:         3000,
+					PricingMode:         "flat",
+				},
+			},
+			Totals: []PreviewTotal{
+				{Currency: "USD", AmountCents: 3000},
+			},
+			Warnings:    []string{},
+			GeneratedAt: time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC),
+		}
+
+		blob, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		// Top-level snake_case keys — the cost dashboard reads every one.
+		topLevel := []string{
+			"customer_id",
+			"subscription_id",
+			"plan_name",
+			"billing_period_start",
+			"billing_period_end",
+			"lines",
+			"totals",
+			"warnings",
+			"generated_at",
+		}
+		for _, k := range topLevel {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("response missing %q (raw keys=%v)", k, mapKeys(raw))
+			}
+		}
+
+		// Forbidden PascalCase keys at top level. Drop a json tag and
+		// these would slip through.
+		for _, k := range []string{
+			"CustomerID", "SubscriptionID", "PlanName",
+			"BillingPeriodStart", "BillingPeriodEnd",
+			"Lines", "Totals", "Warnings", "GeneratedAt",
+		} {
+			if _, ok := raw[k]; ok {
+				t.Errorf("response leaked PascalCase key %q", k)
+			}
+		}
+
+		// lines[] must be a JSON array, never null.
+		linesAny, ok := raw["lines"].([]any)
+		if !ok {
+			t.Fatalf("lines must marshal as JSON array, got %T", raw["lines"])
+		}
+		if len(linesAny) != 2 {
+			t.Fatalf("expected 2 lines, got %d", len(linesAny))
+		}
+
+		// Per-line snake_case checks. The cost dashboard's per-rule
+		// breakdown reads every key on the usage line.
+		baseLine, ok := linesAny[0].(map[string]any)
+		if !ok {
+			t.Fatalf("base line not an object: %T", linesAny[0])
+		}
+		for _, k := range []string{"line_type", "description", "currency", "quantity", "unit_amount_cents", "amount_cents"} {
+			if _, ok := baseLine[k]; !ok {
+				t.Errorf("base line missing %q (keys=%v)", k, mapKeys(baseLine))
+			}
+		}
+		// Optional fields on a base_fee line: meter_id, rating_rule_version_id,
+		// rule_key, dimension_match, pricing_mode. They should be omitted
+		// (omitempty) when empty rather than marshaled as zero values.
+		for _, k := range []string{"meter_id", "rating_rule_version_id", "rule_key", "dimension_match", "pricing_mode"} {
+			if _, ok := baseLine[k]; ok {
+				t.Errorf("base_fee line should omit empty %q (got %v)", k, baseLine[k])
+			}
+		}
+
+		usageLine, ok := linesAny[1].(map[string]any)
+		if !ok {
+			t.Fatalf("usage line not an object: %T", linesAny[1])
+		}
+		for _, k := range []string{
+			"line_type", "description", "meter_id", "rating_rule_version_id",
+			"rule_key", "dimension_match", "currency", "quantity",
+			"unit_amount_cents", "amount_cents", "pricing_mode",
+		} {
+			if _, ok := usageLine[k]; !ok {
+				t.Errorf("usage line missing %q (keys=%v)", k, mapKeys(usageLine))
+			}
+		}
+		// quantity must be a JSON string per ADR-005 — large fractional
+		// AI-usage primitives (GPU-hours, cached-token ratios) lose
+		// precision if marshaled as JSON number. shopspring/decimal
+		// normalizes trailing zeros in MarshalJSON, so we round-trip
+		// the meaningful digits and assert exact equality.
+		qtyStr, isString := usageLine["quantity"].(string)
+		if !isString {
+			t.Fatalf("quantity must marshal as JSON string (decimal precision), got %T", usageLine["quantity"])
+		}
+		if qtyStr != "1234567.891234" {
+			t.Errorf("quantity precision lost: got %q want %q", qtyStr, "1234567.891234")
+		}
+		// dimension_match must be a JSON object — preserves the rule's
+		// match expression for multi-dim drill-down.
+		if _, isMap := usageLine["dimension_match"].(map[string]any); !isMap {
+			t.Errorf("dimension_match must marshal as JSON object, got %T", usageLine["dimension_match"])
+		}
+
+		// totals[] is always-array; one entry per currency.
+		totalsAny, ok := raw["totals"].([]any)
+		if !ok {
+			t.Fatalf("totals must marshal as JSON array, got %T", raw["totals"])
+		}
+		if len(totalsAny) != 1 {
+			t.Fatalf("expected 1 total entry, got %d", len(totalsAny))
+		}
+		total0, ok := totalsAny[0].(map[string]any)
+		if !ok {
+			t.Fatalf("totals[0] not an object: %T", totalsAny[0])
+		}
+		for _, k := range []string{"currency", "amount_cents"} {
+			if _, ok := total0[k]; !ok {
+				t.Errorf("totals[0] missing %q (keys=%v)", k, mapKeys(total0))
+			}
+		}
+
+		// warnings[] empty must be [] not null. Same idiom as
+		// customer-usage so the dashboard's per-meter warning rendering
+		// can iterate without a null guard.
+		warnings, ok := raw["warnings"].([]any)
+		if !ok {
+			t.Fatalf("warnings must marshal as JSON array even when empty, got %T", raw["warnings"])
+		}
+		if len(warnings) != 0 {
+			t.Errorf("warnings should be empty in this fixture, got %d", len(warnings))
+		}
+	})
+
+	t.Run("EmptyResultSlicesAreArrays", func(t *testing.T) {
+		// A result with zero lines / zero totals / zero warnings still
+		// must marshal to []s, not nulls — empty-state UI iterates over
+		// the slices directly and would crash on a null.
+		result := PreviewResult{
+			CustomerID:     "vlx_cus_abc",
+			SubscriptionID: "vlx_sub_xyz",
+			Lines:          []PreviewLine{},
+			Totals:         []PreviewTotal{},
+			Warnings:       []string{},
+		}
+
+		blob, err := json.Marshal(result)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		for _, k := range []string{"lines", "totals", "warnings"} {
+			arr, ok := raw[k].([]any)
+			if !ok {
+				t.Errorf("%q must marshal as JSON array even when empty, got %T", k, raw[k])
+				continue
+			}
+			if len(arr) != 0 {
+				t.Errorf("%q should be empty in this fixture, got %d entries", k, len(arr))
+			}
+		}
+	})
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -249,6 +249,14 @@ export const api = {
     apiRequest<SubscriptionItem>('DELETE', `/subscriptions/${id}/items/${itemID}/pending-change`),
   invoicePreview: (subscriptionId: string) =>
     apiRequest<InvoicePreview>('GET', `/billing/preview/${subscriptionId}`),
+  // Stripe Tier 1 parity for Invoice.upcoming. Same shape as the debug
+  // route above; composes against customer + subscription + period.
+  // Pass {customer_id} and the server picks the primary active sub +
+  // current cycle. Pass {customer_id, subscription_id} to preview a
+  // specific sub. Pass {customer_id, period: {from, to}} to preview an
+  // explicit window. See docs/design-create-preview.md.
+  createInvoicePreview: (data: { customer_id: string; subscription_id?: string; period?: { from: string; to: string } }) =>
+    apiRequest<InvoicePreview>('POST', '/invoices/create_preview', data),
 
   // Billing profile
   getBillingProfile: (customerId: string) =>
@@ -814,16 +822,43 @@ export interface StripeProviderCredentials {
   updated_at: string
 }
 
+// InvoicePreview is the response shape for both /v1/billing/preview/{id}
+// (in-app debug route) and /v1/invoices/create_preview (Stripe Tier 1
+// surface). Per-(meter, rule) lines mean multi-dim meters render one row
+// per rule with dimension_match echoed; totals[] is always-array (one
+// entry per distinct currency, even when there's only one) so a single
+// reader handles both shapes. quantity is a decimal STRING per ADR-005
+// — fractional AI-usage primitives (GPU-hours, cached-token ratios)
+// round-trip without precision loss.
 export interface InvoicePreview {
   customer_id: string
   subscription_id: string
   plan_name: string
-  currency: string
   billing_period_start: string
   billing_period_end: string
-  lines: { line_type: string; description: string; meter_id?: string; quantity: number; unit_amount_cents: number; amount_cents: number; pricing_mode?: string }[]
-  subtotal_cents: number
+  lines: InvoicePreviewLine[]
+  totals: InvoicePreviewTotal[]
+  warnings: string[]
   generated_at: string
+}
+
+export interface InvoicePreviewLine {
+  line_type: string
+  description: string
+  meter_id?: string
+  rating_rule_version_id?: string
+  rule_key?: string
+  dimension_match?: Record<string, unknown>
+  currency: string
+  quantity: string
+  unit_amount_cents: number
+  amount_cents: number
+  pricing_mode?: string
+}
+
+export interface InvoicePreviewTotal {
+  currency: string
+  amount_cents: number
 }
 
 export interface CustomerDunningOverride {

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -18,6 +18,20 @@ const entries: {
 }[] = [
   {
     date: '2026-04-26',
+    title: 'Create-preview endpoint — Stripe Tier 1 invoice.upcoming parity',
+    tag: 'feature',
+    body: 'POST /v1/invoices/create_preview returns the same totals the cycle scan would bill — without writing a row. Multi-dim aware by construction: the preview path runs through usage.AggregateByPricingRules (LATERAL JOIN with priority + claim across the five aggregation modes), so a meter with cached-input vs uncached vs output rules previews into the same buckets the invoice will land in. Mounted under PermInvoiceRead. Both the in-app debug surface (/v1/billing/preview/{id}) and the new Tier 1 surface return one shape so TypeScript clients and dashboards share one type.',
+    bullets: [
+      'No-writes guarantee: preview never inserts an invoice or line; integration test counts invoice + invoice_line rows before/after and asserts zero diff.',
+      'Period defaults to the customer\'s active subscription cycle; explicit ?from=&to= bounds (RFC 3339) override; partial bounds are rejected (must be both or neither). customer_has_no_subscription returns as a coded error so the UI prompts for an explicit window.',
+      'Subscription resolution: explicit subscription_id is honored and cross-customer subscription IDs are rejected with 404; otherwise the engine picks the customer\'s active/trialing subscription with the latest cycle start.',
+      'Always-array totals shape: response carries totals: [{currency, cents}] even for single-currency tenants, with multi-currency just adding entries — same wire shape as customer-usage so dashboards iterate uniformly.',
+      'Route ordering: /invoices/create_preview is mounted before /invoices/{id} so chi picks the more-specific pattern (otherwise "create_preview" would be captured as an invoice ID).',
+      '16 unit tests + 7 integration tests pin the contract: single-meter parity (1000c for 100 events × qty=10 × 1¢), multi-dim dimension echo (3500c across two rules), no-writes row-count diff, cross-tenant 404 via RLS, no-sub coded error, cross-customer subscription rejection, plus a TestWireShape_SnakeCase regression test that asserts all 9 top-level keys are snake_case and lines/totals/warnings always marshal as arrays (never null).',
+    ],
+  },
+  {
+    date: '2026-04-26',
     title: 'Customer usage endpoint — one call answers "what did this customer use?"',
     tag: 'feature',
     body: 'GET /v1/customers/{id}/usage composes customer + active subscriptions + pricing into a single response: per-meter quantities, per-rule cents, multi-currency totals, and the period that produced them. Same code path the cycle scan uses to bill — dashboard math is invoice math, by construction. Default period follows the customer\'s current cycle; explicit ?from=&to= bounds (RFC 3339) override, capped at one year. Mounts as a sibling under /v1/customers/{id}, behind PermUsageRead.',

--- a/web-v2/src/pages/SubscriptionDetail.tsx
+++ b/web-v2/src/pages/SubscriptionDetail.tsx
@@ -660,16 +660,18 @@ export default function SubscriptionDetailPage() {
                 {preview.lines.map((line, i) => (
                   <TableRow key={i}>
                     <TableCell>{line.description}</TableCell>
-                    <TableCell className="text-right">{line.quantity}</TableCell>
-                    <TableCell className="text-right font-medium">{formatCents(line.amount_cents)}</TableCell>
+                    <TableCell className="text-right tabular-nums">{Number(line.quantity).toLocaleString(undefined, { maximumFractionDigits: 6 })}</TableCell>
+                    <TableCell className="text-right font-medium">{formatCents(line.amount_cents, line.currency)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>
               <tfoot>
-                <TableRow className="border-t-2">
-                  <TableCell colSpan={2} className="text-right font-semibold">Subtotal</TableCell>
-                  <TableCell className="text-right font-semibold">{formatCents(preview.subtotal_cents)}</TableCell>
-                </TableRow>
+                {preview.totals.map(t => (
+                  <TableRow key={t.currency} className="border-t-2">
+                    <TableCell colSpan={2} className="text-right font-semibold">Subtotal{preview.totals.length > 1 ? ` (${t.currency})` : ''}</TableCell>
+                    <TableCell className="text-right font-semibold">{formatCents(t.amount_cents, t.currency)}</TableCell>
+                  </TableRow>
+                ))}
               </tfoot>
             </Table>
           ) : previewError ? (


### PR DESCRIPTION
## Summary

`POST /v1/invoices/create_preview` returns the same totals the cycle scan would bill — without writing a row. Closes Stripe Tier 1 parity gap (formerly `Invoice.upcoming`).

Multi-dim aware by construction: the preview path runs through `usage.AggregateByPricingRules` (LATERAL JOIN with priority + claim across the five aggregation modes), so a meter with cached-input vs uncached vs output rules previews into the same buckets the invoice will land in.

Both the in-app debug surface (`/v1/billing/preview/{id}`) and the new Tier 1 surface return one shape — TypeScript clients and dashboards share one type.

## What ships

- **`docs/design-create-preview.md`** — RFC with wire shape, error code matrix, no-writes guarantee, route mounting precedence.
- **`internal/billing/preview.go` refactor** — preview walks every active subscription's pricing rules. New per-line shape echoes the rule's canonical `dimension_match`; quantity is decimal `string`; totals are always-array `[{currency, cents}]`.
- **`internal/billing/preview_create.go`** — `PreviewService` composing the engine with two narrow per-domain interfaces (`CustomerLookup`, `SubscriptionLister`). Customer existence then subscription resolution (explicit ID with cross-customer rejection vs implicit primary pick) then period resolution then `engine.previewWithWindow`.
- **`internal/billing/create_preview_handler.go`** — `CreatePreviewHandler` with `Routes()` returning chi router. Empty body OK (defaults), malformed JSON rejected; period parsed via RFC 3339.
- **`internal/api/router.go`** — wired before `/invoices/{id}` mount so chi picks the more-specific pattern. Mounted under `PermInvoiceRead`.
- **TS consumer updates** — `web-v2/src/lib/api.ts` `InvoicePreview` interface updated to new shape; `web-v2/src/pages/SubscriptionDetail.tsx` re-rendered.
- **CHANGELOG.md + `web-v2/src/pages/Changelog.tsx` + `docs/parallel-handoff.md`** — entries on all three surfaces per `feedback_changelog_discipline`.

## Test coverage

- **16 unit tests** (`preview_create_test.go`): `TestResolveCreatePreviewPeriod` (6 cases), `TestPickPrimarySubscription` (6), `TestPreviewService_ResolveSubscription` (5), `TestCreatePreview_BlankCustomerID`, `TestCreatePreview_CustomerNotFound`, `TestDecodeCreatePreviewRequest` (7), `TestComputePreviewTotals` (4).
- **7 integration tests** (`preview_integration_test.go`) against real Postgres:
  - `TestCreatePreview_SingleMeterFlatParity` — 100 events × qty=10 × 1¢ = 1000c
  - `TestCreatePreview_MultiDimDimensionMatchEcho` — 1000 input @3¢ + 100 output @5¢ = 3500c, both rules echoed
  - `TestCreatePreview_NoWrites` — counts invoice + invoice_line rows before/after, zero diff
  - `TestCreatePreview_CrossTenantIsolation` — tenant B's key vs tenant A's customer 404s via RLS
  - `TestCreatePreview_CustomerHasNoSubscription` — coded error returned
  - `TestCreatePreview_ExplicitSubscriptionWrongCustomer` — cross-customer subscription ID rejected
- **`TestWireShape_SnakeCase` is the merge gate** (`preview_wire_shape_test.go`): asserts all 9 top-level keys are snake_case, no PascalCase leaks, lines/totals/warnings always marshal as `[]` (never `null`), `quantity` is a JSON string, `dimension_match` is an object.

## Inline decisions

- **Compose `PreviewService` against `Engine`** (not reimplement per-meter walk) so the create_preview surface and the existing in-app debug route share one code path — preview math == invoice math by construction.
- **Mount `/invoices/create_preview` before `/invoices`** in router — chi catches "create_preview" as `{id}` otherwise.
- **Update existing TS `InvoicePreview` rather than introduce a separate type** — both Velox preview surfaces now return the same shape.
- **Test fixture quantity `1234567.891234`** — shopspring `decimal.MarshalJSON` trims trailing zeros, so the assertion needs digits that survive normalization.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -short -count=1` pass
- [x] `go test -p 1 ./internal/billing/... -short=false -count=1` pass (3.88s, 7 integration tests)
- [x] `TestWireShape_SnakeCase` in suite (the merge gate)

Self-merge authorized once CI green AND `TestWireShape_SnakeCase` is in the suite — both conditions met locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)