### PR TITLE
feat(billing): billing thresholds — Stripe Tier 1 parity (Week 5c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,64 @@ Two surfaces mirror this file:
   atomicity-on-rollback verifying the alert-state-update is rolled
   back when outbox enqueue fails, RLS isolation). Migration 0057.
 
+- **Billing thresholds — Stripe Tier 1 parity hard-cap mid-cycle finalize** (2026-04-26) —
+  the fourth flagship developer-experience surface alongside customer-usage,
+  recipes, and create_preview (per `docs/design-billing-thresholds.md`,
+  `docs/positioning.md` pillar 1.4). Configures a per-subscription
+  hard cap on running cycle subtotal (`amount_gte`, integer cents) and/or
+  per-subscription-item quantity caps (`item_thresholds[]` with
+  `usage_gte` as a NUMERIC(38,12) decimal string, ADR-005). When usage
+  pushes the running total past any configured cap, the engine emits an
+  early-finalize invoice with `billing_reason='threshold'` mid-cycle —
+  the same charge-and-dunning chain a natural-cycle invoice goes
+  through, just before the period boundary. `reset_billing_cycle` (default
+  true, matching Stripe) controls whether the cycle resets after fire so
+  the next bill starts from fire-time, or whether the original cycle
+  continues with residual usage. PATCH `/v1/subscriptions/{id}/billing-thresholds`
+  with `{amount_gte, reset_billing_cycle?, item_thresholds[]}` writes the
+  configuration; DELETE clears it. Rejects multi-currency subs at the
+  handler layer (it's the only layer with a PlanReader), terminal subs at
+  the service layer, foreign / duplicate / blank `subscription_item_id` and
+  non-numeric / negative `usage_gte` values across both layers — so the
+  store sees only validated input. Engine path: a new `Engine.ScanThresholds`
+  tick runs in the scheduler between auto-charge retry and the natural
+  cycle scan (Step 0.5), pulling candidates via
+  `subs.ListWithThresholds(ctx, livemode, batch)` then calling
+  `evaluateThresholds` over the partial cycle window. Reuses
+  `previewWithWindow` so the running subtotal is the same figure the cycle
+  would bill — preview math == invoice math by construction (same
+  guarantee as create_preview). Per-item caps sum quantities across each
+  item's plan meters via `usage.AggregateByPricingRules` (the same
+  priority+claim LATERAL JOIN the cycle scan and customer-usage already
+  use), so multi-dim tenants get the same canonical aggregation. Idempotency
+  seam: a partial unique index on
+  `invoices(tenant_id, subscription_id, billing_period_start) WHERE
+  billing_reason='threshold'` makes a re-tick after a transient failure a
+  no-op — the second `CreateInvoiceWithLineItems` lands on
+  `errs.ErrAlreadyExists` and short-circuits without losing the row.
+  Skips terminal/trialing subs and `pause_collection` rows so the scan
+  doesn't emit a draft that can't be charged. Webhook event
+  `subscription.threshold_crossed` fires before the optional cycle reset.
+  Snake-case JSON, always-array slices, decimal-as-string usage_gte
+  enforced by `TestWireShape_SnakeCase`. Tests: 12 unit cases on the
+  service validation (empty body, negative amount, terminal sub, foreign
+  / duplicate / blank `subscription_item_id`, non-numeric / negative
+  `usage_gte`, default + explicit `reset_billing_cycle`), 7 unit cases
+  on `evaluateThresholds` + `ScanThresholds` (amount-cross, item-cross,
+  below-amount, below-item, terminal-sub gate, paused-collection gate,
+  no-candidates fast path), 6 integration cases against real Postgres
+  (amount-cross fires early with cycle reset, item-usage-cross fires,
+  re-tick idempotent, below-threshold no-fire, no-config-skipped,
+  reset_billing_cycle=false keeps cycle), plus 3 wire-shape cases on
+  the input + domain JSON contracts. Migration `0056_subscription_billing_thresholds`
+  adds two columns on `subscriptions` (`billing_threshold_amount_gte`,
+  `billing_threshold_reset_cycle`), a `subscription_item_thresholds`
+  table with RLS, the `billing_reason` column on `invoices` with a
+  CHECK constraint covering `'subscription_cycle' | 'subscription_create' |
+  'manual' | 'threshold' | NULL`, and the partial unique index. Cycle-scan
+  invoices now stamp `billing_reason='subscription_cycle'` so the
+  threshold reason isn't an outlier.
+
 - **Create-preview endpoint — Stripe Tier 1 parity for `Invoice.upcoming`** (2026-04-26) —
   the third flagship developer-experience surface alongside customer-usage
   and recipes (per `docs/design-create-preview.md`, `docs/positioning.md`

--- a/docs/design-billing-thresholds.md
+++ b/docs/design-billing-thresholds.md
@@ -1,0 +1,372 @@
+# Billing Thresholds — Technical Design
+
+> **Status:** Draft v1
+> **Owner:** Track A
+> **Last revised:** 2026-04-26
+> **Implementation window:** Week 5c of `docs/90-day-plan.md`
+> **Related:** `docs/design-create-preview.md` (Week 5b — same composition, same wire conventions), `docs/design-multi-dim-meters.md` (Week 2 dependency — `usage.AggregateByPricingRules`), `docs/positioning.md` pillar 1.5 (early-warning surfaces for cost overruns)
+
+## Motivation
+
+Stripe ships **billing thresholds** as Tier 1 — a tenant configures a per-subscription cap (`amount_gte` in cents, or `usage_gte` per item in units), and when the in-cycle running total crosses the threshold the engine **finalizes an invoice early**, optionally **resets the billing cycle** (so the next cycle starts at zero), and emits a webhook event. This shields the tenant's customers from runaway bills mid-cycle, and shields Velox tenants from collection risk on customers whose usage suddenly explodes.
+
+Velox already has every primitive to do this:
+
+- The cycle scan (`Engine.RunCycle` → `Engine.billSubscription` → `CreateInvoiceWithLineItems` → `advanceCycleOrCancel`) already builds line items from the partial-cycle window, prices them via `domain.ComputeAmountCents`, finalizes the invoice, and rolls the cycle forward.
+- `usage.AggregateByPricingRules` (Week 2) already computes the running total over an arbitrary window, including for multi-dim meters.
+- The scheduler already runs a billing tick under an advisory lock (`s.billingLockKey`) that gates exactly-one finalize per (subscription, cycle).
+
+The slice is composition: **a mid-cycle scan tick** that, for every subscription with thresholds configured, computes the partial-cycle total via the same aggregation path the cycle scan uses, and when the threshold is crossed, **calls into the existing finalize-cycle code path early** with `billing_reason="threshold"`. We do **not** duplicate the build-line-items or advance-cycle code — same code path, different entry point.
+
+The Track B unblock: the cost dashboard's projected-bill line gets a new "approaching threshold" indicator (red bar at 80%, lock icon at 100%) reading from a new `subscription.billing_thresholds` field on the existing GET endpoint.
+
+## Goals
+
+- **Per-subscription threshold configuration.** Tenants set `billing_thresholds` on a subscription via `PATCH /v1/subscriptions/{id}`. Two threshold types: `amount_gte` (currency-major-unit-cents int64) and `item_thresholds[]` (per-item `usage_gte` decimal). Either alone or both — first to fire wins.
+- **Mid-cycle scan that fires the existing finalize path.** When a threshold crosses, the engine emits the same line set the next cycle scan would have emitted, finalizes with `billing_reason="threshold"`, and (when `reset_billing_cycle=true`) rolls the cycle forward as if the period had ended naturally.
+- **Idempotent under retry.** The scheduler's existing advisory-lock leader gating already prevents two ticks from doing the same work; the threshold scan inherits this. Within a single tick, a subscription whose threshold has already fired in the current cycle is skipped (no second invoice).
+- **Multi-dim parity.** `item_thresholds[]` use `usage.AggregateByPricingRules` so a multi-dim meter's running total respects rule priority + claim semantics, identical to the cycle scan.
+- **Webhook event.** `subscription.threshold_crossed` fires when the threshold causes the early finalize. Standard webhook outbox path; standard signature.
+- **Wire-contract clean.** Snake-case JSON, decimal-string `usage_gte`, integer-cents `amount_gte`, always-array `item_thresholds`. Same ergonomics as preview/customer-usage.
+
+## Non-goals (deferred)
+
+- **Plan-level thresholds.** Stripe lets you configure thresholds on a price; Velox v1 attaches them to a subscription only. Per-plan defaults are a tenant-level concern that doesn't have a good home yet, and reproducing the precedence rule (sub overrides plan overrides product) invites the kind of decision tree that has to be unwound when wrong. Real consumer first.
+- **Currency conversion for cross-currency thresholds.** A subscription with multiple line currencies cannot have a single `amount_gte`; v1 rejects multi-currency subscriptions with `amount_gte` set (validated at PATCH time). Multi-currency tenants surface as a documented edge in the changelog.
+- **Threshold-driven email/dashboard alerts (the soft-warning path).** That's Week 5d (billing alerts); separate slice, separate sibling worktree, separate event family. The threshold here is the **hard cap that fires an invoice**, not the "you've used 80% of your monthly $X" soft notification.
+- **Resetting the cycle to a partial-period boundary.** When `reset_billing_cycle=true`, the new cycle starts at the moment the threshold fired and runs for one full cycle's duration (calendar-month-equivalent). We do not preserve the original anniversary day — that's a Stripe quirk we can add later if a real consumer asks.
+- **Coupon / credit application to the threshold-fired invoice.** Same boundary as create_preview: v1 finalizes subtotal-only thresholds. Discounts and credits apply at finalize via the existing pipeline if configured on the subscription, but the threshold *check* is computed against subtotal — discount+credit could prevent a true threshold cross from firing, which is the wrong shape (the customer's *raw* spend is what tenants want capped). Documented in changelog.
+
+## Today's surface (in repo)
+
+Everything we need already exists; this slice composes:
+
+- `internal/billing/engine.go::Engine.billSubscription(ctx, sub, period, billingReason)` — already builds line items from base fee + per-meter aggregation, calls `CreateInvoiceWithLineItems`, applies tax + coupon. Threshold scan reuses this with `billingReason="threshold"`.
+- `internal/billing/engine.go::Engine.advanceCycleOrCancel(ctx, sub, periodEnd, ...)` — rolls the subscription's cycle forward to the next period. Threshold scan reuses with the *crossed-at* time as the new `current_billing_period_start`.
+- `internal/usage/service.go::Service.AggregateByPricingRules(ctx, tenantID, customerID, meterID, defaultMode, from, to)` — partial-cycle aggregation. Same window as the cycle scan, just computed at tick-time-now instead of period-end.
+- `internal/billing/scheduler.go::Scheduler.runBillingCycleForMode(ctx, livemode)` — leader-gated under `s.billingLockKey`. New step inserted between step 0 (reconcile) and step 1 (RunCycle): scan thresholds.
+- `internal/subscription/store.go::Store` — extended with `SetBillingThresholds`, `ClearBillingThresholds`, and `ListWithThresholds` (the candidate-set query for the scan).
+- `internal/domain/webhook_outbound.go` — extended with `EventSubscriptionThresholdCrossed`.
+
+The only **new** code is:
+
+1. A `BillingThresholds` domain type + JSON/wire shape.
+2. A migration adding columns to `subscriptions` and a `subscription_item_thresholds` aux table.
+3. The new `billing_reason` column on `invoices` (with `'threshold'` in the CHECK constraint — also covers the existing implicit reasons `'subscription_cycle'` and `'manual'`).
+4. The threshold scan loop in `internal/billing/threshold_scan.go`.
+5. The `PATCH /v1/subscriptions/{id}` route (the existing handler doesn't have an item-level PATCH for the subscription itself yet; only items have one).
+
+## Wire contract
+
+> **Conventions** (consistent with `/v1/*`, see `docs/design-customer-usage.md` § wire-contract and `docs/design-create-preview.md`):
+>
+> - **Snake-case JSON keys.**
+> - **Decimal `usage_gte` marshals as a precise string** (`"1000000.000000000000"`) per ADR-005.
+> - **Integer-cents `amount_gte`.**
+> - **Always-array `item_thresholds`.** Even when zero or one entry. (The dashboard's `.map()` over the array works in all cases.)
+
+### `PATCH /v1/subscriptions/{id}`
+
+```http
+PATCH /v1/subscriptions/{id}
+Authorization: Bearer <secret_key>
+Content-Type: application/json
+
+{
+  "billing_thresholds": {
+    "amount_gte": 100000,
+    "reset_billing_cycle": true,
+    "item_thresholds": [
+      { "subscription_item_id": "vlx_subi_abc", "usage_gte": "1000000" }
+    ]
+  }
+}
+```
+
+To clear: `{"billing_thresholds": null}`.
+
+`amount_gte` is the running cycle subtotal (integer cents in the subscription's currency). When the partial-cycle subtotal **crosses** this threshold (i.e., this tick the running total is `>= amount_gte` and the previous tick was `<` or there was no previous tick), the engine fires an early finalize.
+
+`item_thresholds[].usage_gte` is the running cycle quantity for the single meter rated by the item's plan. When the item's running quantity crosses this, same early-finalize fires. Item thresholds are scoped to the item's plan's *meter* — a base-fee-only plan cannot have an item threshold (validated at PATCH time).
+
+`reset_billing_cycle` (default `true`) controls whether the cycle resets after the early finalize. `false` keeps the cycle running on its original schedule; the threshold-fired invoice is one extra invoice within the cycle and the cycle's natural-boundary invoice still fires at period end (whatever residual usage accumulated between the threshold fire and the period end).
+
+`item_thresholds` is an array; subscriptions with multiple items can configure per-item caps.
+
+Response: the full updated subscription, hydrated with items and thresholds.
+
+```json
+{
+  "id": "vlx_sub_xyz",
+  "customer_id": "vlx_cus_abc",
+  "status": "active",
+  ...,
+  "billing_thresholds": {
+    "amount_gte": 100000,
+    "reset_billing_cycle": true,
+    "item_thresholds": [
+      { "subscription_item_id": "vlx_subi_abc", "usage_gte": "1000000.000000000000" }
+    ]
+  }
+}
+```
+
+### Error shapes
+
+- `404 subscription_not_found` — subscription ID does not exist for the tenant.
+- `400 invalid_request` — `amount_gte <= 0`, or `usage_gte` non-positive, or `item_thresholds[].subscription_item_id` not on this subscription, or both `billing_thresholds` set and the subscription has multiple line currencies (multi-currency cap not supported in v1).
+- `409 invalid_state` — subscription is canceled or archived (no point setting a threshold on a terminal subscription).
+
+### Webhook event
+
+`subscription.threshold_crossed` fires immediately after the threshold-fired invoice transitions to `finalized`. Payload includes the subscription, the invoice ID, and the threshold definition that fired. Standard outbox path; same signing.
+
+## Internals
+
+### Threshold scan tick
+
+```go
+// internal/billing/threshold_scan.go (sketch)
+func (e *Engine) ScanThresholds(ctx context.Context, batchSize int) error {
+    subs, err := e.subs.ListWithThresholds(ctx, e.livemode, batchSize)
+    if err != nil { return err }
+
+    for _, sub := range subs {
+        if err := e.scanOneThreshold(ctx, sub); err != nil {
+            // log + continue; next tick will retry
+            slog.Error("threshold scan failed", "sub", sub.ID, "err", err)
+        }
+    }
+    return nil
+}
+
+func (e *Engine) scanOneThreshold(ctx context.Context, sub domain.Subscription) error {
+    // Skip subs that don't bill mid-cycle (no current period)
+    if sub.CurrentBillingPeriodStart == nil { return nil }
+
+    now := e.effectiveNow(sub)
+    from := *sub.CurrentBillingPeriodStart
+    to := now
+
+    // Partial-cycle subtotal across all priced lines (same shape as billSubscription).
+    runningSubtotal, runningPerItem, err := e.computePartialCycleTotals(ctx, sub, from, to)
+    if err != nil { return err }
+
+    crossed, reason := evaluateThresholds(sub.BillingThresholds, runningSubtotal, runningPerItem)
+    if !crossed { return nil }
+
+    // Re-fetch sub under tx to avoid double-fire in the rare case the
+    // previous tick crossed the threshold but failed before advance.
+    return e.fireThreshold(ctx, sub, from, to, reason)
+}
+```
+
+`evaluateThresholds` compares running totals against the configured thresholds. It returns `(crossed, reason)` where `reason` documents which threshold tripped (used in the line item description and the webhook payload).
+
+`fireThreshold` opens a tx, claims the subscription via the existing advisory lock keyed on `(billing, sub.ID)`, calls `Engine.billSubscription(ctx, sub, period, "threshold")`, and when `reset_billing_cycle=true` calls `advanceCycleOrCancel(ctx, sub, now, ...)` so the new cycle starts at `now`.
+
+The advisory-lock claim is the **idempotency seam** — if a previous tick already fired the threshold for the current cycle, the cycle has already advanced; this tick's `from` is the new (post-advance) period start, and the running totals start at zero. The threshold can fire again in the new cycle, which is correct.
+
+### Per-cycle once-fired guard
+
+The naive failure mode: a tick crosses the threshold, `billSubscription` succeeds, but `advanceCycleOrCancel` fails (DB blip). The next tick would re-aggregate the same window, see the threshold still crossed, and try to fire again — producing a duplicate invoice.
+
+The guard: `Engine.fireThreshold` uses the **existing** invoice-source-key dedup column on the `invoices` table. We add a new natural key `(tenant, subscription, cycle_start, billing_reason='threshold')` via a partial unique index — at most one threshold-fired invoice per cycle. The next tick's `INSERT … ON CONFLICT DO NOTHING` returns the existing row, the engine notices "already fired this cycle" and short-circuits before computing line items. Cycle reset is idempotent because it's keyed on `current_billing_period_start <= now` (re-running on an already-advanced row leaves it unchanged).
+
+We don't need a new "threshold_fired_at" column — the existence of a finalized invoice with `billing_reason='threshold'` and the matching `billing_period_start` IS the marker.
+
+### Scheduler wiring
+
+`Scheduler.runBillingCycleForMode` already runs under `s.billingLockKey`. We add a step `0.5` between reconcile and the cycle scan:
+
+```go
+// step 0.5: threshold scan (mid-cycle early finalize)
+if err := s.engine.ScanThresholds(ctx, 100); err != nil {
+    slog.Error("threshold scan", "err", err)
+    // continue — cycle scan still runs
+}
+```
+
+Same lock, same fan-out per livemode. If one tick of the threshold scan takes longer than the tick interval, the next tick is gated by the leader lock — no double-execution.
+
+### Migration
+
+`0056_subscription_billing_thresholds.up.sql`:
+
+```sql
+-- Per-subscription billing thresholds. amount_gte is integer cents
+-- (subscription currency); reset_billing_cycle controls whether the
+-- cycle resets after the threshold fires. NULL on either column = no
+-- amount-based threshold configured.
+ALTER TABLE subscriptions
+    ADD COLUMN billing_threshold_amount_gte BIGINT,
+    ADD COLUMN billing_threshold_reset_cycle BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD CONSTRAINT subscriptions_billing_threshold_amount_gte_check
+        CHECK (billing_threshold_amount_gte IS NULL OR billing_threshold_amount_gte > 0);
+
+-- Per-item usage thresholds. One row per (subscription, item) pair
+-- with a quantity threshold. NUMERIC(38,12) keeps decimal precision
+-- consistent with the rest of usage rating.
+CREATE TABLE subscription_item_thresholds (
+    subscription_id        TEXT NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    subscription_item_id   TEXT NOT NULL REFERENCES subscription_items(id) ON DELETE CASCADE,
+    tenant_id              TEXT NOT NULL,
+    usage_gte              NUMERIC(38, 12) NOT NULL CHECK (usage_gte > 0),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (subscription_item_id)
+);
+
+CREATE INDEX idx_subscription_item_thresholds_subscription
+    ON subscription_item_thresholds (subscription_id);
+
+ALTER TABLE subscription_item_thresholds ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON subscription_item_thresholds
+    FOR ALL TO velox_app
+    USING (tenant_id = current_setting('app.tenant_id', TRUE))
+    WITH CHECK (tenant_id = current_setting('app.tenant_id', TRUE));
+
+-- Threshold-fired invoices. New billing_reason column + the existing
+-- implicit reasons. CHECK constraint allows NULL for legacy rows.
+ALTER TABLE invoices
+    ADD COLUMN billing_reason TEXT,
+    ADD CONSTRAINT invoices_billing_reason_check
+        CHECK (billing_reason IS NULL OR billing_reason IN (
+            'subscription_cycle', 'subscription_create', 'manual', 'threshold'
+        ));
+
+-- Partial unique index: at most one threshold-fired invoice per
+-- (tenant, subscription, cycle_start) pair. Idempotency seam for the
+-- re-tick-after-failed-advance case.
+CREATE UNIQUE INDEX idx_invoices_threshold_unique_per_cycle
+    ON invoices (tenant_id, subscription_id, billing_period_start)
+    WHERE billing_reason = 'threshold';
+
+-- Scan candidate index: subscriptions with thresholds configured.
+CREATE INDEX idx_subscriptions_billing_thresholds_amount
+    ON subscriptions (id)
+    WHERE billing_threshold_amount_gte IS NOT NULL;
+```
+
+`0056_subscription_billing_thresholds.down.sql`:
+
+```sql
+DROP INDEX IF EXISTS idx_subscriptions_billing_thresholds_amount;
+DROP INDEX IF EXISTS idx_invoices_threshold_unique_per_cycle;
+ALTER TABLE invoices
+    DROP CONSTRAINT IF EXISTS invoices_billing_reason_check,
+    DROP COLUMN IF EXISTS billing_reason;
+DROP TABLE IF EXISTS subscription_item_thresholds;
+ALTER TABLE subscriptions
+    DROP CONSTRAINT IF EXISTS subscriptions_billing_threshold_amount_gte_check,
+    DROP COLUMN IF EXISTS billing_threshold_reset_cycle,
+    DROP COLUMN IF EXISTS billing_threshold_amount_gte;
+```
+
+### Invoice domain extension
+
+`internal/domain/invoice.go`:
+
+```go
+type InvoiceBillingReason string
+
+const (
+    BillingReasonSubscriptionCycle  InvoiceBillingReason = "subscription_cycle"
+    BillingReasonSubscriptionCreate InvoiceBillingReason = "subscription_create"
+    BillingReasonManual             InvoiceBillingReason = "manual"
+    BillingReasonThreshold          InvoiceBillingReason = "threshold"
+)
+
+// In Invoice struct:
+BillingReason InvoiceBillingReason `json:"billing_reason,omitempty"`
+```
+
+The existing `billSubscription` accepts a new `billingReason` parameter; existing callers pass `BillingReasonSubscriptionCycle` and `BillingReasonSubscriptionCreate` (the proration paths become `BillingReasonSubscriptionCycle` for now — they're cycle-driven). The threshold scan passes `BillingReasonThreshold`.
+
+## Tests
+
+### Unit tests
+
+- `evaluateThresholds` table-driven: amount-only crossed, amount-only not crossed, item-only crossed (single item), item-only crossed (multi-item, only second crosses), both configured, multi-currency rejected.
+- `Service.SetBillingThresholds` validation: `amount_gte <= 0` → invalid_request, `usage_gte` non-positive-decimal → invalid_request, `subscription_item_id` not on sub → invalid_request, multi-currency sub with `amount_gte` → invalid_request, terminal sub → invalid_state.
+- `decodeBillingThresholds` (handler-level JSON parse): null clears, empty `item_thresholds` accepted, decimal-string `usage_gte` round-trips precisely.
+- **`TestWireShape_SnakeCase` (the merge gate):** marshal a real Subscription with thresholds set, assert every required snake_case key (`billing_thresholds`, `amount_gte`, `reset_billing_cycle`, `item_thresholds`, `subscription_item_id`, `usage_gte`), assert no PascalCase leaks, assert empty `item_thresholds` marshals as `[]` not `null`, assert `usage_gte` marshals as a string with exact value `"1000000.000000000000"` (no float coercion).
+
+### Integration tests (real Postgres)
+
+- `TestThresholdAmountCrossesFinalizesEarly` — seed a sub with `amount_gte=1000`, push usage events totaling 1500 cents, run a tick. Assert: finalized invoice exists with `billing_reason='threshold'`, cycle has advanced (`current_billing_period_start` is now `>= tick-time`), webhook outbox has `subscription.threshold_crossed` row.
+- `TestThresholdItemCrossesFinalizesEarly` — same as above but with `item_thresholds[0].usage_gte=1000` units, push 1500 units across the meter.
+- `TestThresholdReTickIsIdempotent` — fire the threshold once, run the scan again immediately. Assert: only one invoice was created (same ID), no duplicate webhook event.
+- `TestThresholdResetFalseKeepsOriginalCycle` — `reset_billing_cycle=false`. Threshold fires, `current_billing_period_start` is unchanged, the cycle scan at period end still produces a second invoice.
+- `TestThresholdMultiDimRespectsRules` — multi-dim meter with two rules (input @3¢, output @5¢), `amount_gte=1000`. Push usage that totals 1100 across both rules; threshold fires. Assert the threshold-fired invoice's lines mirror the cycle scan's per-rule line set.
+- `TestThresholdSkipsTerminalSubscription` — a canceled sub with thresholds set is skipped by the scan tick.
+- `TestThresholdSkipsTrialingSubscription` — a trialing sub with thresholds set is skipped (no current period until activated).
+
+## Performance
+
+- Per-tick: 1 indexed query for candidate subs (filtered by `billing_threshold_amount_gte IS NOT NULL OR EXISTS (item_thresholds)`), then 1 `AggregateByPricingRules` call per meter per candidate sub. For a tenant with 10K subs and a 100-batch tick, that's at most 100 aggregation calls per minute — well under the cycle scan's existing budget.
+- Tick interval: piggybacks on the existing scheduler tick (`s.tickInterval`, default 30s). No new ticker.
+- The "did the threshold cross since last tick?" check is **not** implemented — we just check "is the threshold currently crossed?". A tick that ran during the cross window will fire it; a tick that runs after `fireThreshold` already advanced the cycle will see the new (post-advance) running total which starts at zero. The unique partial index on `(tenant, subscription, billing_period_start)` is the duplicate-prevention seam, not a "since last tick" check.
+
+## Decimal & numeric considerations
+
+`usage_gte` is `NUMERIC(38, 12)` in Postgres and `decimal.Decimal` in Go, marshaled as a JSON string per ADR-005. `amount_gte` is `BIGINT` in Postgres and `int64` in Go; integer cents.
+
+The `item_thresholds` array is an aux table because per-item config doesn't compose cleanly into a single row's columns and JSONB on a hot-path-aggregation row is a footgun (no per-item indexes, query plans surprise people). One row per item is the same shape as `subscription_items` itself.
+
+## Open questions
+
+1. **Should `reset_billing_cycle=false` be supported in v1?** Stripe allows it. **Proposal: yes.** Simple to implement (just skip the `advanceCycleOrCancel` call), and it covers the tenant case "I want a hard cap *plus* a normal monthly bill" — the threshold-fire becomes an extra invoice rather than a cycle boundary. The integration test confirms the second invoice fires at period end.
+2. **Should the threshold-fired invoice's `billing_period_end` be the original cycle end or the fire time?** **Proposal: the fire time.** Stripe-equivalent: the invoice's billing period is the partial cycle that produced the spend. The new cycle (when reset_billing_cycle=true) starts at fire time and gets a fresh natural cycle end. When reset_billing_cycle=false, the second invoice's billing period is `(fire_time, original_period_end)`, which means the period covered by the threshold-fired invoice is `(period_start, fire_time)`.
+3. **Should we support `usage_gte` as an integer instead of a decimal?** Stripe uses integer "quantity" for usage thresholds. **Proposal: decimal.** Velox already exposes decimal quantities in customer-usage and create_preview; consistency matters. A tenant who wants integer behavior just sets `"1000.000000000000"`. The aggregation always returns a decimal anyway.
+4. **Should we preview the threshold-fire in `create_preview`?** **Proposal: defer to v2.** The preview's job is "what will the natural-cycle invoice look like"; a threshold-fired invoice is a separate event. We could add a `would_threshold_fire: true` flag but it muddles the response shape. Real consumer first.
+5. **Should the threshold scan run independently of the cycle scan tick interval?** **Proposal: same tick.** A separate ticker would mean a second advisory-lock domain, more code paths to debug. The existing 30s tick is granular enough that the worst-case delay between threshold-cross and finalize is 30s — well within tenant tolerance for "early finalize", which is a soft-real-time event not a hard-real-time one.
+6. **Should we emit `subscription.threshold_warning` at 80% of threshold?** That's Week 5d (billing alerts) — different feature. Linked, but not co-shipped.
+7. **Should `amount_gte` be denominated in the subscription's currency or platform-canonical USD?** **Proposal: subscription currency.** A multi-currency tenant configures different thresholds per currency (different subscriptions). Avoids FX conversion in the hot scan path.
+
+## Implementation checklist (Week 5c)
+
+- [ ] `internal/domain/subscription.go` — add `BillingThresholds` struct + `SubscriptionItemThreshold`, attach to `Subscription`.
+- [ ] `internal/domain/invoice.go` — add `InvoiceBillingReason` enum + `BillingReason` field on `Invoice`.
+- [ ] `internal/platform/migrate/sql/0056_subscription_billing_thresholds.{up,down}.sql` — schema.
+- [ ] `internal/subscription/store.go` — extend interface with `SetBillingThresholds`, `ClearBillingThresholds`, `ListWithThresholds`.
+- [ ] `internal/subscription/postgres.go` — implementations.
+- [ ] `internal/subscription/service.go` — validation + `SetBillingThresholds` method.
+- [ ] `internal/subscription/handler.go` — `PATCH /v1/subscriptions/{id}` route.
+- [ ] `internal/billing/threshold_scan.go` — `Engine.ScanThresholds` + `scanOneThreshold` + `fireThreshold`.
+- [ ] `internal/billing/scheduler.go` — wire `ScanThresholds` into `runBillingCycleForMode`.
+- [ ] `internal/billing/engine.go` — extend `billSubscription` with `billing_reason` parameter.
+- [ ] `internal/invoice/postgres.go` — extend `CreateInvoiceWithLineItems` to persist `billing_reason`.
+- [ ] `internal/domain/webhook_outbound.go` — add `EventSubscriptionThresholdCrossed`.
+- [ ] `internal/subscription/wire_shape_test.go` — `TestWireShape_SnakeCase` regression (the merge gate).
+- [ ] Unit tests for service validation + handler PATCH path + `evaluateThresholds`.
+- [ ] Integration tests covering the seven scenarios listed above.
+- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B) entries.
+- [ ] `docs/parallel-handoff.md` Track A entry.
+
+## Track B unblock
+
+Track B can wire the cost dashboard's "approaching threshold" indicator off the existing GET /v1/subscriptions/{id} response (which now includes `billing_thresholds`) plus the existing `customer-usage` projected-bill total. Math is `100 * customer_usage.totals[0].amount_cents / billing_thresholds.amount_gte` for the percentage.
+
+The dashboard call:
+
+```ts
+const sub = await api.getSubscription(subscriptionID)
+const usage = await api.customerUsage({ customer_id: sub.customer_id })
+const pct = sub.billing_thresholds
+  ? Math.min(100, 100 * usage.totals[0].amount_cents / sub.billing_thresholds.amount_gte)
+  : null
+```
+
+The dashboard shape:
+
+- **Threshold progress bar** under the projected-bill line. Color: green < 50%, amber 50-80%, red > 80%, lock icon at 100%.
+- **Edit-threshold modal** (gear icon next to the bar) lets tenants set/clear the threshold via the new PATCH route.
+
+Track B implements the UI; the API stabilizes in this slice.
+
+## Review status
+
+- **Track A author:** drafted 2026-04-26 alongside the implementation
+- **Track B review:** pending — UI wedge can scaffold against this design without waiting
+- **Human review:** pending — flag any open question to revisit

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -400,3 +400,41 @@ Track A merged PR #20 (multi-dim backend, 12 commits) into `main` at 18:25:30Z. 
 - **Open for human review:**
   - PR to be opened on `feat/backend-week5d-billing-alerts` once final commit lands.
 - **Next session (Track A):** drive PR to green, self-merge per authorization (CI green AND `TestWireShape_SnakeCase` + integration suite — both conditions met), then queue the next blocker per 90-day plan.
+
+---
+
+## 2026-04-26 (Sun) — Track A: billing thresholds backend (Week 5c)
+
+### Track A
+- **Branch:** `feat/backend-week5c-billing-thresholds` (off `main` post-create_preview merge).
+- **Goal:** close the Stripe Tier 1 parity gap on **billing thresholds** (Stripe's `subscription.billing_thresholds`). Mid-cycle hard-cap finalize: when usage crosses a configured `amount_gte` (cents) or per-item `usage_gte` (decimal), engine emits an early-finalize invoice with `billing_reason='threshold'` instead of waiting for the cycle boundary. Same charge-and-dunning flow as a natural-cycle invoice — just earlier. Configurable `reset_billing_cycle` (default true, Stripe-parity) controls whether the cycle resets after fire.
+- **Shipped (7 commits):**
+  - **`docs/design-billing-thresholds.md`** — RFC with wire shape (snake-case, `usage_gte` as JSON string, always-array `item_thresholds`), engine path, idempotency seam (partial unique index on `invoices(tenant, sub, billing_period_start) WHERE billing_reason='threshold'`), error codes, test plan.
+  - **Migration `0056_subscription_billing_thresholds`** — two columns on `subscriptions` (`billing_threshold_amount_gte`, `billing_threshold_reset_cycle`), `subscription_item_thresholds` table with RLS, `billing_reason` column on `invoices` + CHECK constraint covering `subscription_cycle | subscription_create | manual | threshold | NULL`, partial unique index for idempotency.
+  - **`internal/domain` types** — `SubscriptionItemThreshold`, `BillingThresholds`, `InvoiceBillingReason` enum (`subscription_cycle | subscription_create | manual | threshold`), `EventSubscriptionThresholdCrossed = "subscription.threshold_crossed"`.
+  - **`internal/subscription` store + service + handler** — `SetBillingThresholds`, `ClearBillingThresholds`, `ListWithThresholds` on the `Store` interface; postgres impls with `hydrateThresholds` over the new aux table; service rejects empty body / negative amount / terminal sub / foreign / duplicate / blank `subscription_item_id` / non-numeric / negative `usage_gte`; handler exposes `PUT /v1/subscriptions/{id}/billing-thresholds` and `DELETE /v1/subscriptions/{id}/billing-thresholds`. Multi-currency rejection lives at the handler (only layer with a `PlanReader`).
+  - **`internal/billing/threshold_scan.go`** — `Engine.ScanThresholds` entry, `Engine.scanOneThreshold` per-sub gate (skips terminal/trialing/paused-collection), `Engine.evaluateThresholds` reuses `previewWithWindow` over the partial cycle for running-subtotal + line items + per-item-cap quantity sum via `usage.AggregateByPricingRules`, `Engine.fireThreshold` composes the same coupon → tax → credit → auto-charge chain as `billSubscription` and stamps `BillingReason: domain.BillingReasonThreshold`. Idempotent skip on `errs.ErrAlreadyExists` from the partial unique index.
+  - **`internal/billing/scheduler.go` Step 0.5** — `s.engine.ScanThresholds(ctx, s.batch)` runs between auto-charge retry and the natural cycle scan, so a threshold-fired invoice and (when `reset_billing_cycle=true`) the cycle advance both land on the same tick.
+  - **`internal/invoice/postgres.go`** — `billing_reason` column read + write through `Create` and `CreateWithLineItems`; `invCols` extended; `scanInvDest` extended.
+  - **Cycle-scan invoices now stamp `BillingReason: domain.BillingReasonSubscriptionCycle`** so the threshold reason isn't an outlier — every invoice now has a non-null reason after this lands.
+- **Tests (all green; full suite: `go test -p 1 ./... -short=false`):**
+  - 12 unit cases on `Service.SetBillingThresholds` validation paths + 2 cases on `ClearBillingThresholds` idempotency.
+  - 7 unit cases on `evaluateThresholds` + `ScanThresholds` (amount-cross, item-cross, below-amount, below-item, terminal-sub gate, paused-collection gate, no-candidates fast path).
+  - 6 integration cases against real Postgres (amount-cross fires early with cycle reset, item-usage-cross fires, re-tick idempotent via partial unique index, below-threshold no-fire, no-config-skipped, reset_billing_cycle=false keeps cycle).
+  - 3 wire-shape cases in `TestWireShape_SnakeCase` (input shape, domain shape, empty `item_thresholds[]` always-array).
+  - All pre-existing tests pass.
+- **Decisions made inline (per `feedback_feat8_autonomy`):**
+  - **Reuse `previewWithWindow` for the running subtotal:** preview math == invoice math by construction (same guarantee as create_preview). The threshold scan and cycle scan agree on what "running total" means.
+  - **Per-item caps sum across each item's plan meters:** Velox items don't have Stripe's 1:1 item-to-price model — items reference a plan, plans reference meters. So per-item cap = sum of all meter quantities under the item's plan during the partial cycle. Same priority+claim resolver via `AggregateByPricingRules`.
+  - **Idempotency seam = partial unique index, not application-level lock:** keeps the invariant in the schema; a re-tick after a transient crash lands on `errs.ErrAlreadyExists` and short-circuits without losing the row.
+  - **Multi-currency rejection at handler, not service:** service stays currency-agnostic; the handler is the only layer with a `PlanReader` to look up the items' plans' currencies.
+  - **`reset_billing_cycle` defaults to `true` in service when caller omits the field** (Stripe parity, matches the column default in migration).
+- **Test status:**
+  - `go test ./... -short`: pass (54 packages).
+  - `go test -p 1 ./... -short=false`: pass (full integration suite).
+- **Blocking Track B on:** nothing.
+- **Track B can pick up:**
+  - **Billing thresholds UI** — render `subscription.billing_thresholds` on `SubscriptionDetail.tsx` and add a "Configure thresholds" dialog calling `PATCH /v1/subscriptions/{id}/billing-thresholds`. The wire shape is locked by `TestWireShape_SnakeCase` (snake_case keys, `usage_gte` as decimal string, always-array `item_thresholds`).
+  - **Threshold-crossed timeline event** — `subscription.threshold_crossed` webhook is dispatched on every fire; surface in the dashboard activity feed.
+- **Open for human review:** PR to be opened on `feat/backend-week5c-billing-thresholds` once final commit lands.
+- **Next session (Track A):** drive PR to green, self-merge per authorization (CI green AND `TestWireShape_SnakeCase` in suite — both conditions met), then continue Week 5d (billing alerts) — sibling agent already running on `feat/backend-week5d-billing-alerts` with migration 0057.

--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -152,6 +152,14 @@ type SubscriptionReader interface {
 	// level: re-running on a row already 'active' returns InvalidState
 	// (caller swallows it as benign).
 	ActivateAfterTrial(ctx context.Context, tenantID, id string, at time.Time) (domain.Subscription, error)
+
+	// ListWithThresholds returns active+trialing subscriptions in the given
+	// livemode partition that have at least one billing threshold configured
+	// (amount or per-item). Drives the threshold scan tick — each row is
+	// rated against its current partial-cycle running totals to decide
+	// whether to fire an early finalize. Hydrated with Items and
+	// BillingThresholds so the scan doesn't issue per-sub follow-up reads.
+	ListWithThresholds(ctx context.Context, livemode bool, limit int) ([]domain.Subscription, error)
 }
 
 // UsageAggregator aggregates usage events for a billing period. Returns
@@ -1207,6 +1215,7 @@ func (e *Engine) billSubscription(ctx context.Context, sub domain.Subscription) 
 		IssuedAt:           &now,
 		DueAt:              &dueAt,
 		NetPaymentTermDays: netDays,
+		BillingReason:      domain.BillingReasonSubscriptionCycle,
 	}, lineItems)
 	if err != nil {
 		// Idempotency: if this invoice already exists (UNIQUE violation on the

--- a/internal/billing/engine_integration_test.go
+++ b/internal/billing/engine_integration_test.go
@@ -52,6 +52,10 @@ func (a *subStoreAdapter) ActivateAfterTrial(ctx context.Context, tenantID, id s
 	return a.store.ActivateAfterTrial(ctx, tenantID, id, at)
 }
 
+func (a *subStoreAdapter) ListWithThresholds(ctx context.Context, livemode bool, limit int) ([]domain.Subscription, error) {
+	return a.store.ListWithThresholds(ctx, livemode, limit)
+}
+
 // pricingStoreAdapter wraps pricing.PostgresStore to implement billing.PricingReader
 type pricingStoreAdapter struct {
 	store *pricing.PostgresStore

--- a/internal/billing/engine_test.go
+++ b/internal/billing/engine_test.go
@@ -161,6 +161,14 @@ func (m *mockSubs) ApplyDuePendingItemPlansAtomic(_ context.Context, _, id strin
 	return applied, nil
 }
 
+func (m *mockSubs) ListWithThresholds(_ context.Context, _ bool, _ int) ([]domain.Subscription, error) {
+	// Engine unit tests focus on the natural cycle; the threshold scan path
+	// is exercised via threshold_scan_test.go (which uses its own mock that
+	// returns the configured candidate set). Returning empty here keeps
+	// existing tests compatible without exercising the threshold path.
+	return nil, nil
+}
+
 type mockUsage struct {
 	totals map[string]int64 // meterID -> quantity (test inputs stay int for readability)
 }

--- a/internal/billing/scheduler.go
+++ b/internal/billing/scheduler.go
@@ -262,6 +262,18 @@ func (s *Scheduler) runBillingCycleForMode(ctx context.Context, live bool) {
 		}
 	}
 
+	// 0.5 Billing thresholds — Stripe-parity hard-cap scan. Runs before the
+	// natural cycle so a threshold-fired invoice and (when reset_billing_cycle
+	// is true) the cycle advance both land on this tick. The partial unique
+	// index on invoices(tenant, sub, billing_period_start) WHERE
+	// billing_reason='threshold' makes this idempotent under retry.
+	if fired, tErrs := s.engine.ScanThresholds(ctx, s.batch); fired > 0 || len(tErrs) > 0 {
+		slog.Info("threshold scan", "mode", mode, "fired", fired, "errors", len(tErrs))
+		for _, err := range tErrs {
+			slog.Error("threshold scan error", "mode", mode, "error", err)
+		}
+	}
+
 	// 1. Billing cycle — generate invoices
 	generated, errs := s.engine.RunCycle(ctx, s.batch)
 	if len(errs) > 0 {

--- a/internal/billing/threshold_scan.go
+++ b/internal/billing/threshold_scan.go
@@ -36,6 +36,7 @@ type thresholdEval struct {
 // resolved (charge + dunning entry) on the same tick it's emitted.
 //
 // Invariants:
+//
 //   - Idempotent under retry. The partial unique index on
 //     invoices(tenant_id, subscription_id, billing_period_start) WHERE
 //     billing_reason='threshold' guarantees at most one threshold invoice
@@ -450,13 +451,13 @@ func (e *Engine) fireThreshold(ctx context.Context, sub domain.Subscription, eva
 	// effects.
 	if e.events != nil {
 		payload := map[string]any{
-			"subscription_id":   sub.ID,
-			"customer_id":       sub.CustomerID,
-			"invoice_id":        inv.ID,
-			"running_subtotal":  eval.RunningSubtotal,
-			"crossed_amount":    eval.CrossedAmount,
-			"crossed_item_id":   eval.CrossedItemID,
-			"reset_cycle":       sub.BillingThresholds.ResetBillingCycle,
+			"subscription_id":  sub.ID,
+			"customer_id":      sub.CustomerID,
+			"invoice_id":       inv.ID,
+			"running_subtotal": eval.RunningSubtotal,
+			"crossed_amount":   eval.CrossedAmount,
+			"crossed_item_id":  eval.CrossedItemID,
+			"reset_cycle":      sub.BillingThresholds.ResetBillingCycle,
 		}
 		if err := e.events.Dispatch(ctx, sub.TenantID, domain.EventSubscriptionThresholdCrossed, payload); err != nil {
 			slog.Error("threshold scan: dispatch subscription.threshold_crossed failed",

--- a/internal/billing/threshold_scan.go
+++ b/internal/billing/threshold_scan.go
@@ -1,0 +1,499 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+)
+
+// thresholdEval is the decision the scan reaches for one subscription. When
+// CrossedAny is true the engine fires an early finalize via fireThreshold;
+// otherwise the row is left alone until the next tick. RunningSubtotal and
+// PerItemRunning are kept in the struct so the firing path can reuse the
+// already-computed lines instead of re-aggregating after the decision.
+type thresholdEval struct {
+	CrossedAny      bool
+	CrossedAmount   bool
+	CrossedItem     bool
+	CrossedItemID   string
+	RunningSubtotal int64
+	LineItems       []domain.InvoiceLineItem
+	InvoiceCurrency string
+}
+
+// ScanThresholds finds every subscription with a billing threshold configured
+// and fires an early-finalize invoice for each one whose in-cycle running
+// total has crossed the cap. Called by the scheduler between the auto-charge
+// retry sweep and the natural cycle scan so a threshold-fired invoice is
+// resolved (charge + dunning entry) on the same tick it's emitted.
+//
+// Invariants:
+//   - Idempotent under retry. The partial unique index on
+//     invoices(tenant_id, subscription_id, billing_period_start) WHERE
+//     billing_reason='threshold' guarantees at most one threshold invoice
+//     per cycle. A second tick that observes the same crossed state lands
+//     on errs.ErrAlreadyExists and short-circuits.
+//
+//   - Mode-scoped via ctx livemode. The scheduler fans out per-mode before
+//     calling, so the candidate fetch (ListWithThresholds) honours the same
+//     RLS partition as the natural cycle scan.
+//
+// Returns the count of fired invoices and any errors encountered. Per-sub
+// errors do not abort the whole scan — they're collected and returned so
+// the operator dashboard can flag stuck rows without losing throughput.
+func (e *Engine) ScanThresholds(ctx context.Context, batchSize int) (int, []error) {
+	if batchSize <= 0 {
+		batchSize = 50
+	}
+
+	candidates, err := e.subs.ListWithThresholds(ctx, postgres.Livemode(ctx), batchSize)
+	if err != nil {
+		return 0, []error{fmt.Errorf("list candidates: %w", err)}
+	}
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	fired := 0
+	var errsOut []error
+	for _, sub := range candidates {
+		didFire, err := e.scanOneThreshold(ctx, sub)
+		if err != nil {
+			slog.Error("threshold scan failed for subscription",
+				"subscription_id", sub.ID,
+				"tenant_id", sub.TenantID,
+				"error", err,
+			)
+			errsOut = append(errsOut, fmt.Errorf("subscription %s: %w", sub.ID, err))
+			continue
+		}
+		if didFire {
+			fired++
+		}
+	}
+
+	if fired > 0 {
+		slog.Info("threshold scan fired invoices", "count", fired)
+	}
+	return fired, errsOut
+}
+
+// scanOneThreshold evaluates a single subscription. Builds running line items
+// over the partial cycle [period_start, now), checks each configured cap,
+// and — when crossed — fires the early finalize via fireThreshold.
+func (e *Engine) scanOneThreshold(ctx context.Context, sub domain.Subscription) (bool, error) {
+	if sub.BillingThresholds == nil {
+		return false, nil
+	}
+	if sub.Status != domain.SubscriptionActive && sub.Status != domain.SubscriptionTrialing {
+		return false, nil
+	}
+	if sub.CurrentBillingPeriodStart == nil || sub.CurrentBillingPeriodEnd == nil {
+		return false, nil
+	}
+	// Trialing subs are skipped at the natural cycle level too — there's no
+	// invoice to fire, so a threshold "cross" during trial would just emit a
+	// zero-amount draft. Defer until status flips.
+	if sub.Status == domain.SubscriptionTrialing {
+		return false, nil
+	}
+	// pause_collection neuters the financial side; firing a threshold under
+	// pause would emit a draft that can't be charged or dunned. Skip — the
+	// scan resumes when collection does.
+	if sub.PauseCollection != nil {
+		return false, nil
+	}
+
+	now := e.effectiveNow(ctx, sub)
+	periodStart := *sub.CurrentBillingPeriodStart
+	if !now.After(periodStart) {
+		return false, nil
+	}
+
+	eval, err := e.evaluateThresholds(ctx, sub, periodStart, now)
+	if err != nil {
+		return false, fmt.Errorf("evaluate: %w", err)
+	}
+	if !eval.CrossedAny {
+		return false, nil
+	}
+
+	return e.fireThreshold(ctx, sub, eval, periodStart, now)
+}
+
+// evaluateThresholds computes the partial-cycle running totals for a sub and
+// reports whether any configured cap has been crossed. Reuses
+// previewWithWindow's per-item base-fee + per-(meter, rule) usage line
+// computation so the scan and the cycle scan agree on what "running total"
+// means — fed to the same priority+claim LATERAL JOIN as the natural cycle.
+func (e *Engine) evaluateThresholds(ctx context.Context, sub domain.Subscription, periodStart, now time.Time) (thresholdEval, error) {
+	preview, err := e.previewWithWindow(ctx, sub, periodStart, now)
+	if err != nil {
+		return thresholdEval{}, err
+	}
+
+	// Roll up the running subtotal across the previewed lines. Multi-currency
+	// sub already filtered upstream at PATCH time, so we sum across all lines
+	// regardless of per-line currency — there's only one.
+	var running int64
+	currency := ""
+	lineItems := make([]domain.InvoiceLineItem, 0, len(preview.Lines))
+	for _, pl := range preview.Lines {
+		running += pl.AmountCents
+		if currency == "" {
+			currency = pl.Currency
+		}
+		var ps, pe *time.Time
+		if pl.LineType == "usage" {
+			s := periodStart
+			n := now
+			ps = &s
+			pe = &n
+		}
+		lineType := domain.InvoiceLineItemType(pl.LineType)
+		quantity := pl.Quantity.IntPart()
+		lineItems = append(lineItems, domain.InvoiceLineItem{
+			LineType:            lineType,
+			MeterID:             pl.MeterID,
+			Description:         pl.Description,
+			Quantity:            quantity,
+			UnitAmountCents:     pl.UnitAmountCents,
+			AmountCents:         pl.AmountCents,
+			TotalAmountCents:    pl.AmountCents,
+			Currency:            pl.Currency,
+			PricingMode:         pl.PricingMode,
+			RatingRuleVersionID: pl.RatingRuleVersionID,
+			BillingPeriodStart:  ps,
+			BillingPeriodEnd:    pe,
+		})
+	}
+
+	eval := thresholdEval{
+		RunningSubtotal: running,
+		LineItems:       lineItems,
+		InvoiceCurrency: currency,
+	}
+
+	// Amount cap: cycle subtotal in cents.
+	bt := sub.BillingThresholds
+	if bt.AmountGTE > 0 && running >= bt.AmountGTE {
+		eval.CrossedAny = true
+		eval.CrossedAmount = true
+	}
+
+	// Per-item caps: sum the running quantity across each item's plan
+	// meters during [periodStart, now). The meter quantity is the same
+	// figure the natural cycle would bill — pulled from the priority+claim
+	// resolver via AggregateByPricingRules. Item-to-meter is via the plan
+	// (item.plan_id -> plan.meter_ids). Cross-currency items already
+	// rejected upstream, so summing across plans is safe.
+	if !eval.CrossedAny && len(bt.ItemThresholds) > 0 {
+		// Build a map from subscription_item_id -> running quantity sum.
+		// The sum aggregates every meter on the item's plan.
+		itemRunning := make(map[string]decimal.Decimal, len(sub.Items))
+		for _, it := range sub.Items {
+			plan, err := e.pricing.GetPlan(ctx, sub.TenantID, it.PlanID)
+			if err != nil {
+				// Plan resolution errors are surfaced but don't kill the whole
+				// scan — fall through, the per-item check just won't fire on
+				// this row. The cycle scan will surface the same error later
+				// if the misconfig persists.
+				slog.Warn("threshold scan: get plan failed",
+					"subscription_id", sub.ID,
+					"item_id", it.ID,
+					"plan_id", it.PlanID,
+					"error", err,
+				)
+				continue
+			}
+			total := decimal.Zero
+			for _, meterID := range plan.MeterIDs {
+				meter, mErr := e.pricing.GetMeter(ctx, sub.TenantID, meterID)
+				if mErr != nil {
+					continue
+				}
+				defaultMode := mapMeterAggregation(meter.Aggregation)
+				aggs, aErr := e.usage.AggregateByPricingRules(ctx, sub.TenantID, sub.CustomerID, meterID, defaultMode, periodStart, now)
+				if aErr != nil {
+					continue
+				}
+				for _, agg := range aggs {
+					total = total.Add(agg.Quantity)
+				}
+			}
+			itemRunning[it.ID] = total
+		}
+		for _, t := range bt.ItemThresholds {
+			running, ok := itemRunning[t.SubscriptionItemID]
+			if !ok {
+				continue
+			}
+			if running.GreaterThanOrEqual(t.UsageGTE) {
+				eval.CrossedAny = true
+				eval.CrossedItem = true
+				eval.CrossedItemID = t.SubscriptionItemID
+				break
+			}
+		}
+	}
+
+	return eval, nil
+}
+
+// fireThreshold emits the early-finalize invoice and (when reset_billing_cycle
+// is true) advances the subscription's cycle as if the period had ended
+// naturally. Returns (true, nil) on a successful fire, (false, nil) when a
+// concurrent retry already produced the same invoice (idempotent skip).
+//
+// The invoice is built from the same line items evaluateThresholds already
+// computed — re-aggregating would risk a different running total if usage
+// landed between evaluate and fire. Tax + coupon + credit are applied via
+// the same paths the natural cycle uses so an early-finalize charge looks
+// identical to the customer.
+func (e *Engine) fireThreshold(ctx context.Context, sub domain.Subscription, eval thresholdEval, periodStart, now time.Time) (bool, error) {
+	if e.settings == nil {
+		return false, fmt.Errorf("settings reader required for invoice numbering")
+	}
+
+	// Resolve the items' plan map for cycle-advance interval and the planIDs
+	// list (coupon plan eligibility).
+	plans := make(map[string]domain.Plan, len(sub.Items))
+	planIDs := make([]string, 0, len(sub.Items))
+	for _, it := range sub.Items {
+		if _, ok := plans[it.PlanID]; ok {
+			continue
+		}
+		pl, err := e.pricing.GetPlan(ctx, sub.TenantID, it.PlanID)
+		if err != nil {
+			return false, fmt.Errorf("get plan %s: %w", it.PlanID, err)
+		}
+		plans[it.PlanID] = pl
+		planIDs = append(planIDs, it.PlanID)
+	}
+
+	invoiceCurrency := eval.InvoiceCurrency
+	if invoiceCurrency == "" {
+		// Empty preview lines (zero base fees, zero usage) would land here.
+		// In that case the running subtotal is zero so we shouldn't have
+		// reached the fire path — defensive bail.
+		return false, fmt.Errorf("no invoice currency resolved for threshold fire")
+	}
+	if e.profiles != nil {
+		if bp, err := e.profiles.GetBillingProfile(ctx, sub.TenantID, sub.CustomerID); err == nil && bp.Currency != "" {
+			invoiceCurrency = bp.Currency
+		}
+	}
+
+	// Coupon discount — same pattern as the cycle scan. Subscription scope
+	// wins over customer scope.
+	subtotal := eval.RunningSubtotal
+	var discountCents int64
+	var appliedRedemptionIDs []string
+	var appliedCustomerDiscountIDs []string
+	if e.coupons != nil && subtotal > 0 {
+		if sub.ID != "" {
+			d, err := e.coupons.ApplyToInvoice(ctx, sub.TenantID, sub.ID, sub.CustomerID, invoiceCurrency, planIDs, subtotal)
+			if err != nil {
+				slog.Warn("threshold scan: coupon apply failed, proceeding without discount",
+					"error", err, "subscription_id", sub.ID)
+			} else {
+				discountCents = d.Cents
+				appliedRedemptionIDs = d.RedemptionIDs
+			}
+		}
+		if discountCents == 0 && sub.CustomerID != "" {
+			d, err := e.coupons.ApplyToInvoiceForCustomer(ctx, sub.TenantID, sub.CustomerID, invoiceCurrency, planIDs, subtotal)
+			if err != nil {
+				slog.Warn("threshold scan: customer coupon apply failed",
+					"error", err, "customer_id", sub.CustomerID)
+			} else {
+				discountCents = d.Cents
+				appliedCustomerDiscountIDs = d.RedemptionIDs
+			}
+		}
+	}
+
+	taxApp, _ := e.ApplyTaxToLineItems(ctx, sub.TenantID, sub.CustomerID, invoiceCurrency, subtotal, discountCents, eval.LineItems)
+	totalWithTax := taxApp.SubtotalCents - taxApp.DiscountCents + taxApp.TaxAmountCents
+
+	netDays := 30
+	if ts, err := e.settings.Get(ctx, sub.TenantID); err == nil && ts.NetPaymentTerms > 0 {
+		netDays = ts.NetPaymentTerms
+	}
+
+	invoiceNumber, err := e.settings.NextInvoiceNumber(ctx, sub.TenantID)
+	if err != nil {
+		return false, fmt.Errorf("allocate invoice number: %w", err)
+	}
+
+	dueAt := now.AddDate(0, 0, netDays)
+
+	invStatus := domain.InvoiceFinalized
+	if taxApp.TaxStatus == domain.InvoiceTaxPending {
+		invStatus = domain.InvoiceDraft
+	}
+
+	// Emit the threshold invoice. The partial unique index on
+	// (tenant, sub, billing_period_start) WHERE billing_reason='threshold'
+	// is the idempotency seam — a re-tick lands on errs.ErrAlreadyExists
+	// and we short-circuit. Note: we use periodStart as the boundary key,
+	// not now, so two ticks fired against the same in-flight cycle dedup
+	// to the same row even though their wall-clock differs.
+	inv, err := e.invoices.CreateInvoiceWithLineItems(ctx, sub.TenantID, domain.Invoice{
+		CustomerID:         sub.CustomerID,
+		SubscriptionID:     sub.ID,
+		InvoiceNumber:      invoiceNumber,
+		Status:             invStatus,
+		PaymentStatus:      domain.PaymentPending,
+		Currency:           invoiceCurrency,
+		SubtotalCents:      taxApp.SubtotalCents,
+		DiscountCents:      taxApp.DiscountCents,
+		TaxRateBP:          taxApp.TaxRateBP,
+		TaxName:            taxApp.TaxName,
+		TaxCountry:         taxApp.TaxCountry,
+		TaxID:              taxApp.TaxID,
+		TaxAmountCents:     taxApp.TaxAmountCents,
+		TaxProvider:        taxApp.TaxProvider,
+		TaxCalculationID:   taxApp.TaxCalculationID,
+		TaxReverseCharge:   taxApp.TaxReverseCharge,
+		TaxExemptReason:    taxApp.TaxExemptReason,
+		TaxStatus:          taxApp.TaxStatus,
+		TaxDeferredAt:      taxApp.TaxDeferredAt,
+		TaxPendingReason:   taxApp.TaxPendingReason,
+		TotalAmountCents:   totalWithTax,
+		AmountDueCents:     totalWithTax,
+		BillingPeriodStart: periodStart,
+		BillingPeriodEnd:   now,
+		IssuedAt:           &now,
+		DueAt:              &dueAt,
+		NetPaymentTermDays: netDays,
+		BillingReason:      domain.BillingReasonThreshold,
+	}, eval.LineItems)
+	if err != nil {
+		if errors.Is(err, errs.ErrAlreadyExists) {
+			slog.Info("threshold invoice already exists for cycle (idempotent skip)",
+				"subscription_id", sub.ID,
+				"period_start", periodStart,
+			)
+			return false, nil
+		}
+		return false, fmt.Errorf("create threshold invoice: %w", err)
+	}
+
+	// Commit tax (Stripe parity) — matches the cycle scan's flow.
+	if inv.TaxProvider != "" && inv.TaxCalculationID != "" {
+		if err := e.CommitTax(ctx, sub.TenantID, inv.ID, inv.TaxCalculationID); err != nil {
+			slog.Warn("threshold scan: tax commit failed after invoice creation",
+				"error", err, "tenant_id", sub.TenantID, "invoice_id", inv.ID)
+		}
+	}
+
+	// Advance periods_applied on coupon redemptions. Same post-create timing
+	// rule as the cycle scan: do this only after the invoice is durably
+	// persisted.
+	if e.coupons != nil && len(appliedRedemptionIDs) > 0 {
+		if err := e.coupons.MarkPeriodsApplied(ctx, sub.TenantID, appliedRedemptionIDs); err != nil {
+			slog.Warn("threshold scan: coupon mark-periods-applied failed",
+				"invoice_id", inv.ID, "subscription_id", sub.ID, "error", err)
+		}
+	}
+	if e.coupons != nil && len(appliedCustomerDiscountIDs) > 0 {
+		if err := e.coupons.MarkCustomerDiscountPeriodsApplied(ctx, sub.TenantID, appliedCustomerDiscountIDs); err != nil {
+			slog.Warn("threshold scan: customer-discount mark-periods-applied failed",
+				"invoice_id", inv.ID, "customer_id", sub.CustomerID, "error", err)
+		}
+	}
+
+	// Apply customer credits before charging. Same shape as the cycle scan.
+	if e.credits != nil && totalWithTax > 0 {
+		if _, err := e.credits.ApplyToInvoice(ctx, sub.TenantID, sub.CustomerID, inv.ID, totalWithTax, inv.InvoiceNumber); err != nil {
+			slog.Warn("threshold scan: failed to apply credits", "invoice_id", inv.ID, "error", err)
+		}
+	}
+
+	// If credits covered 100%, mark as paid immediately.
+	if totalWithTax > 0 {
+		updatedInv, err := e.invoices.GetInvoice(ctx, sub.TenantID, inv.ID)
+		if err == nil && updatedInv.AmountDueCents <= 0 {
+			if _, err := e.invoices.MarkPaid(ctx, sub.TenantID, inv.ID, "", now); err != nil {
+				slog.Warn("threshold scan: failed to mark fully-credited invoice as paid",
+					"invoice_id", inv.ID, "error", err)
+			}
+		}
+	}
+
+	// Auto-charge: synchronous with timeout, same behaviour as the cycle scan.
+	if e.charger != nil && e.paymentSetups != nil && inv.AmountDueCents > 0 {
+		if ps, err := e.paymentSetups.GetPaymentSetup(ctx, sub.TenantID, sub.CustomerID); err == nil &&
+			ps.SetupStatus == domain.PaymentSetupReady && ps.StripeCustomerID != "" {
+			chargeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			chargeInv, err := e.invoices.GetInvoice(chargeCtx, sub.TenantID, inv.ID)
+			if err == nil && chargeInv.AmountDueCents > 0 {
+				if _, err := e.charger.ChargeInvoice(chargeCtx, sub.TenantID, chargeInv, ps.StripeCustomerID); err != nil {
+					_ = e.invoices.SetAutoChargePending(ctx, sub.TenantID, inv.ID, true)
+				}
+			}
+		}
+	}
+
+	// Emit subscription.threshold_crossed before the optional cycle reset
+	// so consumers see the crossing event ahead of any cycle-rollover side
+	// effects.
+	if e.events != nil {
+		payload := map[string]any{
+			"subscription_id":   sub.ID,
+			"customer_id":       sub.CustomerID,
+			"invoice_id":        inv.ID,
+			"running_subtotal":  eval.RunningSubtotal,
+			"crossed_amount":    eval.CrossedAmount,
+			"crossed_item_id":   eval.CrossedItemID,
+			"reset_cycle":       sub.BillingThresholds.ResetBillingCycle,
+		}
+		if err := e.events.Dispatch(ctx, sub.TenantID, domain.EventSubscriptionThresholdCrossed, payload); err != nil {
+			slog.Error("threshold scan: dispatch subscription.threshold_crossed failed",
+				"subscription_id", sub.ID, "tenant_id", sub.TenantID, "error", err)
+		}
+	}
+
+	// Cycle reset (when configured): the new cycle starts at fire time and
+	// the next bill is the natural cycle invoice. When reset_billing_cycle
+	// is false, the original cycle continues — a second invoice will fire
+	// at the natural cycle end with whatever residual usage accumulated.
+	if sub.BillingThresholds.ResetBillingCycle {
+		nextPeriodStart := now
+		nextPeriodEnd := advanceBillingPeriod(now, plans[sub.Items[0].PlanID].BillingInterval)
+		if err := e.subs.UpdateBillingCycle(ctx, sub.TenantID, sub.ID, nextPeriodStart, nextPeriodEnd, nextPeriodEnd); err != nil {
+			// Cycle advance failure is non-fatal at the count level: the
+			// invoice already exists, so we return fired=true and let the
+			// next tick reconcile. The partial unique index ensures the
+			// next tick won't double-fire.
+			slog.Error("threshold scan: cycle advance failed after fire",
+				"subscription_id", sub.ID,
+				"invoice_id", inv.ID,
+				"error", err,
+			)
+			return true, nil
+		}
+	}
+
+	slog.Info("threshold-fired invoice generated",
+		"invoice_id", inv.ID,
+		"subscription_id", sub.ID,
+		"running_subtotal", eval.RunningSubtotal,
+		"crossed_amount", eval.CrossedAmount,
+		"crossed_item_id", eval.CrossedItemID,
+		"total_cents", totalWithTax,
+		"reset_cycle", sub.BillingThresholds.ResetBillingCycle,
+	)
+
+	return true, nil
+}

--- a/internal/billing/threshold_scan_integration_test.go
+++ b/internal/billing/threshold_scan_integration_test.go
@@ -25,13 +25,13 @@ import (
 // index, ListWithThresholds candidate query, and CreateInvoiceWithLineItems
 // are all exercised end-to-end.
 type thresholdFixture struct {
-	db        *postgres.DB
-	tenantID  string
-	subStore  *subscription.PostgresStore
-	subSvc    *subscription.Service
-	usageSvc  *usage.Service
-	invStore  *invoice.PostgresStore
-	engine    *billing.Engine
+	db       *postgres.DB
+	tenantID string
+	subStore *subscription.PostgresStore
+	subSvc   *subscription.Service
+	usageSvc *usage.Service
+	invStore *invoice.PostgresStore
+	engine   *billing.Engine
 
 	// Seed-by-default test data
 	customerID string

--- a/internal/billing/threshold_scan_integration_test.go
+++ b/internal/billing/threshold_scan_integration_test.go
@@ -1,0 +1,447 @@
+package billing_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/billing"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/pricing"
+	"github.com/sagarsuperuser/velox/internal/subscription"
+	"github.com/sagarsuperuser/velox/internal/tenant"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+	"github.com/sagarsuperuser/velox/internal/usage"
+)
+
+// thresholdFixture wires a real-store engine and seeds a single subscription
+// with billing thresholds configured. Mirrors previewFixture but exposes the
+// engine's ScanThresholds path against actual Postgres so the partial unique
+// index, ListWithThresholds candidate query, and CreateInvoiceWithLineItems
+// are all exercised end-to-end.
+type thresholdFixture struct {
+	db        *postgres.DB
+	tenantID  string
+	subStore  *subscription.PostgresStore
+	subSvc    *subscription.Service
+	usageSvc  *usage.Service
+	invStore  *invoice.PostgresStore
+	engine    *billing.Engine
+
+	// Seed-by-default test data
+	customerID string
+	planID     string
+	subID      string
+	itemID     string
+	meterID    string
+	cycleStart time.Time
+	cycleEnd   time.Time
+}
+
+// newThresholdFixture sets up a tenant with a single-meter, single-rule plan
+// (1 cent / call flat rate, no base fee) and an active sub mid-cycle. Tests
+// can configure thresholds on the seeded sub via subSvc.SetBillingThresholds.
+func newThresholdFixture(t *testing.T, name string) *thresholdFixture {
+	t.Helper()
+	db := testutil.SetupTestDB(t)
+	tenantID := testutil.CreateTestTenant(t, db, name)
+
+	customerStore := customer.NewPostgresStore(db)
+	customerSvc := customer.NewService(customerStore)
+	pricingStore := pricing.NewPostgresStore(db)
+	pricingSvc := pricing.NewService(pricingStore)
+	subStore := subscription.NewPostgresStore(db)
+	subSvc := subscription.NewService(subStore, nil)
+	usageStore := usage.NewPostgresStore(db)
+	usageSvc := usage.NewService(usageStore)
+	invoiceStore := invoice.NewPostgresStore(db)
+	settingsStore := tenant.NewSettingsStore(db)
+
+	engine := billing.NewEngine(
+		&subStoreAdapter{subStore},
+		&usageStoreAdapter{usageStore},
+		&pricingStoreAdapter{pricingStore},
+		&invoiceStoreAdapter{invoiceStore},
+		nil, settingsStore, nil, nil, nil,
+	)
+
+	ctx := context.Background()
+
+	cust, err := customerSvc.Create(ctx, tenantID, customer.CreateInput{
+		ExternalID:  "cus_thresh",
+		DisplayName: "Threshold Customer",
+		Email:       "thresh@example.test",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	rrv, err := pricingSvc.CreateRatingRule(ctx, tenantID, pricing.CreateRatingRuleInput{
+		RuleKey: "calls_flat", Name: "Calls Flat",
+		Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("create rrv: %v", err)
+	}
+
+	meter, err := pricingSvc.CreateMeter(ctx, tenantID, pricing.CreateMeterInput{
+		Key: "calls", Name: "Calls", Unit: "calls",
+		Aggregation: "sum", RatingRuleVersionID: rrv.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+
+	plan, err := pricingSvc.CreatePlan(ctx, tenantID, pricing.CreatePlanInput{
+		Code: "pln_thresh", Name: "Threshold Plan",
+		Currency: "USD", BillingInterval: domain.BillingMonthly,
+		BaseAmountCents: 0, MeterIDs: []string{meter.ID},
+	})
+	if err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	subID := postgres.NewID("vlx_sub")
+	itemID := postgres.NewID("vlx_si")
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		t.Fatalf("begin sub tx: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	now := time.Now().UTC()
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO subscriptions (
+			id, tenant_id, code, display_name, customer_id, status, billing_time,
+			current_billing_period_start, current_billing_period_end, next_billing_at,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, 'active', 'anniversary', $6, $7, $7, $8, $8)
+	`, subID, tenantID, "code-thresh", "Threshold Sub", cust.ID, cycleStart, cycleEnd, now)
+	if err != nil {
+		t.Fatalf("insert sub: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO subscription_items (id, tenant_id, subscription_id, plan_id, quantity, metadata, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, 1, '{}'::jsonb, $5, $5)
+	`, itemID, tenantID, subID, plan.ID, now)
+	if err != nil {
+		t.Fatalf("insert sub item: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit sub: %v", err)
+	}
+
+	return &thresholdFixture{
+		db:         db,
+		tenantID:   tenantID,
+		subStore:   subStore,
+		subSvc:     subSvc,
+		usageSvc:   usageSvc,
+		invStore:   invoiceStore,
+		engine:     engine,
+		customerID: cust.ID,
+		planID:     plan.ID,
+		subID:      subID,
+		itemID:     itemID,
+		meterID:    meter.ID,
+		cycleStart: cycleStart,
+		cycleEnd:   cycleEnd,
+	}
+}
+
+// ingestUsage seeds N events spread evenly over the first 60 minutes of the
+// cycle. cycleStart is 72h ago so all events are in the past relative to
+// wall-clock now (which is what the threshold scan uses as the period
+// upper bound). Each event has the supplied quantity, so
+// ingestUsage(t, ctx, 100, 10) produces 100 events × qty 10 = 1000
+// total quantity, billed at 1c/call = 1000c subtotal.
+func (f *thresholdFixture) ingestUsage(t *testing.T, ctx context.Context, count int, qty int64) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		ts := f.cycleStart.Add(time.Duration(i) * time.Minute)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: f.customerID,
+			MeterID:    f.meterID,
+			Quantity:   decimal.NewFromInt(qty),
+			Timestamp:  &ts,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+}
+
+func (f *thresholdFixture) listInvoices(t *testing.T, ctx context.Context) []domain.Invoice {
+	t.Helper()
+	invoices, _, err := f.invStore.List(ctx, invoice.ListFilter{TenantID: f.tenantID})
+	if err != nil {
+		t.Fatalf("list invoices: %v", err)
+	}
+	return invoices
+}
+
+// TestThresholdScan_AmountCrossFiresEarly is the headline test: usage drives
+// the running subtotal past AmountGTE, the scan emits a threshold-billed
+// invoice, the cycle resets, and a second scan against the new (empty) cycle
+// is a no-op. End-to-end against real Postgres so the CreateWithLineItems
+// path, partial unique index, and ListWithThresholds candidate query are
+// all exercised together.
+func TestThresholdScan_AmountCrossFiresEarly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newThresholdFixture(t, "Threshold Amount Cross")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// 100 events × qty 10 × 1c = 1000c subtotal.
+	f.ingestUsage(t, ctx, 100, 10)
+
+	// Configure amount threshold at 500c — well below 1000c.
+	if _, err := f.subSvc.SetBillingThresholds(ctx, f.tenantID, f.subID, subscription.BillingThresholdsInput{
+		AmountGTE: 500,
+	}); err != nil {
+		t.Fatalf("set threshold: %v", err)
+	}
+
+	fired, errs := f.engine.ScanThresholds(ctx, 50)
+	if len(errs) > 0 {
+		t.Fatalf("scan errors: %v", errs)
+	}
+	if fired != 1 {
+		t.Fatalf("fired count: got %d, want 1", fired)
+	}
+
+	invoices := f.listInvoices(t, ctx)
+	if len(invoices) != 1 {
+		t.Fatalf("expected 1 invoice, got %d", len(invoices))
+	}
+	inv := invoices[0]
+	if inv.BillingReason != domain.BillingReasonThreshold {
+		t.Errorf("billing_reason: got %q, want %q", inv.BillingReason, domain.BillingReasonThreshold)
+	}
+	if inv.SubscriptionID != f.subID {
+		t.Errorf("subscription_id: got %q, want %q", inv.SubscriptionID, f.subID)
+	}
+	if inv.SubtotalCents != 1000 {
+		t.Errorf("subtotal_cents: got %d, want 1000", inv.SubtotalCents)
+	}
+	if !inv.BillingPeriodStart.Equal(f.cycleStart) {
+		t.Errorf("billing_period_start: got %v, want %v", inv.BillingPeriodStart, f.cycleStart)
+	}
+
+	// Cycle reset: with reset_billing_cycle=true (default), the sub's
+	// current_billing_period_start should now be the fire-time, not the
+	// original cycleStart.
+	updated, err := f.subStore.Get(ctx, f.tenantID, f.subID)
+	if err != nil {
+		t.Fatalf("reload sub: %v", err)
+	}
+	if updated.CurrentBillingPeriodStart == nil {
+		t.Fatal("current_billing_period_start should be set after reset")
+	}
+	if updated.CurrentBillingPeriodStart.Equal(f.cycleStart) {
+		t.Error("expected period_start to advance after reset_billing_cycle=true")
+	}
+}
+
+// TestThresholdScan_Idempotent guards against double-finalize on retry.
+// A second ScanThresholds tick after the first fire must observe the same
+// underlying state but emit zero new invoices — the partial unique index
+// is the seam that catches a concurrent retry without losing the invoice.
+func TestThresholdScan_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newThresholdFixture(t, "Threshold Idempotent")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	f.ingestUsage(t, ctx, 100, 10)
+
+	// reset_billing_cycle=false means the cycle stays put after fire, so
+	// the next tick observes the same partial cycle that already fired —
+	// the partial unique index is the only thing preventing a second
+	// invoice. Perfect setup for verifying the idempotency seam.
+	resetFalse := false
+	if _, err := f.subSvc.SetBillingThresholds(ctx, f.tenantID, f.subID, subscription.BillingThresholdsInput{
+		AmountGTE:         500,
+		ResetBillingCycle: &resetFalse,
+	}); err != nil {
+		t.Fatalf("set threshold: %v", err)
+	}
+
+	// First tick — fires the invoice.
+	fired1, errs1 := f.engine.ScanThresholds(ctx, 50)
+	if len(errs1) > 0 {
+		t.Fatalf("first scan errors: %v", errs1)
+	}
+	if fired1 != 1 {
+		t.Fatalf("first fired count: got %d, want 1", fired1)
+	}
+
+	// Second tick against the same cycle — must short-circuit on the
+	// partial unique index. No additional invoice, no error returned.
+	fired2, errs2 := f.engine.ScanThresholds(ctx, 50)
+	if len(errs2) > 0 {
+		t.Fatalf("second scan errors: %v", errs2)
+	}
+	if fired2 != 0 {
+		t.Fatalf("second fired count: got %d, want 0 (idempotent skip)", fired2)
+	}
+
+	invoices := f.listInvoices(t, ctx)
+	if len(invoices) != 1 {
+		t.Fatalf("expected exactly 1 invoice after re-tick, got %d", len(invoices))
+	}
+}
+
+// TestThresholdScan_ItemUsageCross verifies the per-item path against real
+// Postgres — the per-meter aggregator wraps AggregateByPricingRules, so this
+// proves the scan respects the same priority+claim resolution as the cycle.
+func TestThresholdScan_ItemUsageCross(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newThresholdFixture(t, "Threshold Item Cross")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// 100 events × qty 10 = 1000 total quantity on the meter.
+	f.ingestUsage(t, ctx, 100, 10)
+
+	if _, err := f.subSvc.SetBillingThresholds(ctx, f.tenantID, f.subID, subscription.BillingThresholdsInput{
+		ItemThresholds: []subscription.ItemThresholdInput{
+			{SubscriptionItemID: f.itemID, UsageGTE: "500"},
+		},
+	}); err != nil {
+		t.Fatalf("set threshold: %v", err)
+	}
+
+	fired, errs := f.engine.ScanThresholds(ctx, 50)
+	if len(errs) > 0 {
+		t.Fatalf("scan errors: %v", errs)
+	}
+	if fired != 1 {
+		t.Fatalf("fired count: got %d, want 1 (item quantity 1000 > cap 500)", fired)
+	}
+
+	invoices := f.listInvoices(t, ctx)
+	if len(invoices) != 1 {
+		t.Fatalf("expected 1 invoice, got %d", len(invoices))
+	}
+	if invoices[0].BillingReason != domain.BillingReasonThreshold {
+		t.Errorf("billing_reason: got %q, want %q", invoices[0].BillingReason, domain.BillingReasonThreshold)
+	}
+}
+
+// TestThresholdScan_BelowThresholdNoFire is the silent-success case: usage
+// is non-zero but doesn't cross the cap, so the scan should observe but
+// emit nothing. Catches a regression where the threshold logic accidentally
+// fires on every tick.
+func TestThresholdScan_BelowThresholdNoFire(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newThresholdFixture(t, "Threshold Below Cap")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// 100 events × qty 10 × 1c = 1000c subtotal.
+	f.ingestUsage(t, ctx, 100, 10)
+
+	// Cap at 5000c — well above 1000c.
+	if _, err := f.subSvc.SetBillingThresholds(ctx, f.tenantID, f.subID, subscription.BillingThresholdsInput{
+		AmountGTE: 5000,
+	}); err != nil {
+		t.Fatalf("set threshold: %v", err)
+	}
+
+	fired, errs := f.engine.ScanThresholds(ctx, 50)
+	if len(errs) > 0 {
+		t.Fatalf("scan errors: %v", errs)
+	}
+	if fired != 0 {
+		t.Fatalf("fired count: got %d, want 0", fired)
+	}
+	invoices := f.listInvoices(t, ctx)
+	if len(invoices) != 0 {
+		t.Fatalf("expected 0 invoices, got %d", len(invoices))
+	}
+}
+
+// TestThresholdScan_NoConfigSkipped covers the candidate-query side: a sub
+// with no billing thresholds configured must not appear in
+// ListWithThresholds and thus must not be considered by the scan.
+func TestThresholdScan_NoConfigSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newThresholdFixture(t, "Threshold No Config")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Lots of usage but no threshold configured — the candidate query
+	// must filter this out.
+	f.ingestUsage(t, ctx, 100, 100)
+
+	fired, errs := f.engine.ScanThresholds(ctx, 50)
+	if len(errs) > 0 {
+		t.Fatalf("scan errors: %v", errs)
+	}
+	if fired != 0 {
+		t.Fatalf("fired count: got %d, want 0 (no threshold configured)", fired)
+	}
+}
+
+// TestThresholdScan_ResetCycleFalse confirms the cycle stays put when the
+// caller explicitly opts out. The threshold invoice still fires, but the
+// next natural cycle invoice will pick up where the original cycle ended —
+// not where the threshold fired.
+func TestThresholdScan_ResetCycleFalse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newThresholdFixture(t, "Threshold Reset False")
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	f.ingestUsage(t, ctx, 100, 10)
+
+	resetFalse := false
+	if _, err := f.subSvc.SetBillingThresholds(ctx, f.tenantID, f.subID, subscription.BillingThresholdsInput{
+		AmountGTE:         500,
+		ResetBillingCycle: &resetFalse,
+	}); err != nil {
+		t.Fatalf("set threshold: %v", err)
+	}
+
+	fired, errs := f.engine.ScanThresholds(ctx, 50)
+	if len(errs) > 0 {
+		t.Fatalf("scan errors: %v", errs)
+	}
+	if fired != 1 {
+		t.Fatalf("fired count: got %d, want 1", fired)
+	}
+
+	updated, err := f.subStore.Get(ctx, f.tenantID, f.subID)
+	if err != nil {
+		t.Fatalf("reload sub: %v", err)
+	}
+	if updated.CurrentBillingPeriodStart == nil {
+		t.Fatal("period_start should be set")
+	}
+	// reset_billing_cycle=false means period_start should NOT have advanced.
+	if !updated.CurrentBillingPeriodStart.Equal(f.cycleStart) {
+		t.Errorf("period_start should remain %v with reset=false, got %v",
+			f.cycleStart, *updated.CurrentBillingPeriodStart)
+	}
+}

--- a/internal/billing/threshold_scan_test.go
+++ b/internal/billing/threshold_scan_test.go
@@ -1,0 +1,290 @@
+package billing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// thresholdMockSubs extends mockSubs with a candidate filter so the
+// scan-tick test can exercise the candidate-fetch path without coupling to
+// mockSubs's status-based GetDueBilling filter.
+type thresholdMockSubs struct {
+	*mockSubs
+	candidates []domain.Subscription
+}
+
+func (m *thresholdMockSubs) ListWithThresholds(_ context.Context, _ bool, _ int) ([]domain.Subscription, error) {
+	return m.candidates, nil
+}
+
+// setupThresholdEngine builds a minimal engine wired with mocks that mirror the
+// natural-cycle setupEngine but with a single-meter, single-rule plan so the
+// running subtotal under test is unambiguous. Returns the engine, the wrapping
+// mockSubs (for cycle-advance assertion), and the mock invoice store.
+func setupThresholdEngine(thresholds *domain.BillingThresholds, usageQty int64) (*Engine, *thresholdMockSubs, *mockInvoices) {
+	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	nextBilling := periodEnd
+
+	sub := domain.Subscription{
+		ID: "sub_1", TenantID: "t1", CustomerID: "cus_1",
+		Items: []domain.SubscriptionItem{
+			{ID: "subitem_1", PlanID: "pln_1", Quantity: 1},
+		},
+		Status:                    domain.SubscriptionActive,
+		BillingTime:               domain.BillingTimeCalendar,
+		CurrentBillingPeriodStart: &periodStart,
+		CurrentBillingPeriodEnd:   &periodEnd,
+		NextBillingAt:             &nextBilling,
+		BillingThresholds:         thresholds,
+	}
+
+	base := &mockSubs{
+		subs:         map[string]domain.Subscription{"sub_1": sub},
+		cycleUpdated: make(map[string]bool),
+	}
+	subs := &thresholdMockSubs{
+		mockSubs:   base,
+		candidates: []domain.Subscription{sub},
+	}
+
+	usage := &mockUsage{
+		totals: map[string]int64{
+			"mtr_api": usageQty,
+		},
+	}
+
+	pricing := &mockPricing{
+		plans: map[string]domain.Plan{
+			"pln_1": {
+				ID: "pln_1", Name: "Pro Plan", Currency: "USD",
+				BillingInterval: domain.BillingMonthly,
+				BaseAmountCents: 4900,
+				MeterIDs:        []string{"mtr_api"},
+			},
+		},
+		meters: map[string]domain.Meter{
+			"mtr_api": {ID: "mtr_api", Name: "API Calls", Unit: "calls", RatingRuleVersionID: "rrv_api"},
+		},
+		rules: map[string]domain.RatingRuleVersion{
+			"rrv_api": {
+				ID: "rrv_api", RuleKey: "api_calls", Version: 1, Mode: domain.PricingFlat,
+				FlatAmountCents: 100, // 1 cent / call (in basis-of-100 — 100 = $1)
+			},
+		},
+	}
+
+	invoices := &mockInvoices{}
+
+	engine := NewEngine(subs, usage, pricing, invoices, nil, &mockSettings{}, nil, nil, nil)
+	return engine, subs, invoices
+}
+
+// TestEvaluateThresholds_AmountCross verifies the running-subtotal check —
+// usage * unit_amount + base_fee crossing AmountGTE flips CrossedAny and
+// CrossedAmount. The minimum bar to ship; if this drifts the engine would
+// either over- or under-fire.
+func TestEvaluateThresholds_AmountCross(t *testing.T) {
+	// Plan: $49 base + 1000 calls @ $1 each = $1049 (104900 cents).
+	// Threshold: $1000 (100000 cents) → crossed.
+	thresholds := &domain.BillingThresholds{
+		AmountGTE:         100000,
+		ResetBillingCycle: true,
+	}
+	engine, _, _ := setupThresholdEngine(thresholds, 1000)
+
+	sub, _ := engine.subs.Get(context.Background(), "t1", "sub_1")
+	periodStart := *sub.CurrentBillingPeriodStart
+	now := periodStart.AddDate(0, 0, 5) // 5 days into the cycle
+
+	eval, err := engine.evaluateThresholds(context.Background(), sub, periodStart, now)
+	if err != nil {
+		t.Fatalf("evaluateThresholds: %v", err)
+	}
+
+	if !eval.CrossedAny {
+		t.Error("expected CrossedAny to be true")
+	}
+	if !eval.CrossedAmount {
+		t.Error("expected CrossedAmount to be true")
+	}
+	if eval.CrossedItem {
+		t.Error("CrossedItem should be false (no item caps configured)")
+	}
+	// $49 base (4900) + 1000 calls × 100 cents/call (100000) = 104900 cents
+	wantSubtotal := int64(4900 + 1000*100)
+	if eval.RunningSubtotal != wantSubtotal {
+		t.Errorf("running subtotal: got %d, want %d", eval.RunningSubtotal, wantSubtotal)
+	}
+	if eval.InvoiceCurrency != "USD" {
+		t.Errorf("currency: got %q, want USD", eval.InvoiceCurrency)
+	}
+	if len(eval.LineItems) == 0 {
+		t.Error("expected non-empty line items")
+	}
+}
+
+// TestEvaluateThresholds_BelowAmount asserts no fire when running subtotal
+// is below the configured cap. The natural cycle would still bill at end —
+// the threshold scan just stays out of the way.
+func TestEvaluateThresholds_BelowAmount(t *testing.T) {
+	// Plan: $49 base + 100 calls × 100 cents = 14900 cents. Threshold: 100000 → not crossed.
+	thresholds := &domain.BillingThresholds{
+		AmountGTE:         100000,
+		ResetBillingCycle: true,
+	}
+	engine, _, _ := setupThresholdEngine(thresholds, 100)
+
+	sub, _ := engine.subs.Get(context.Background(), "t1", "sub_1")
+	periodStart := *sub.CurrentBillingPeriodStart
+	now := periodStart.AddDate(0, 0, 5)
+
+	eval, err := engine.evaluateThresholds(context.Background(), sub, periodStart, now)
+	if err != nil {
+		t.Fatalf("evaluateThresholds: %v", err)
+	}
+
+	if eval.CrossedAny {
+		t.Error("expected CrossedAny to be false")
+	}
+	if eval.CrossedAmount {
+		t.Error("expected CrossedAmount to be false")
+	}
+}
+
+// TestEvaluateThresholds_ItemCross verifies the per-item quantity-cap path.
+// Sums quantities across each item's plan meters during the partial cycle —
+// any single item crossing fires.
+func TestEvaluateThresholds_ItemCross(t *testing.T) {
+	thresholds := &domain.BillingThresholds{
+		ResetBillingCycle: true,
+		ItemThresholds: []domain.SubscriptionItemThreshold{
+			{SubscriptionItemID: "subitem_1", UsageGTE: decimal.NewFromInt(1000)},
+		},
+	}
+	engine, _, _ := setupThresholdEngine(thresholds, 1500) // qty 1500 > cap 1000
+
+	sub, _ := engine.subs.Get(context.Background(), "t1", "sub_1")
+	periodStart := *sub.CurrentBillingPeriodStart
+	now := periodStart.AddDate(0, 0, 5)
+
+	eval, err := engine.evaluateThresholds(context.Background(), sub, periodStart, now)
+	if err != nil {
+		t.Fatalf("evaluateThresholds: %v", err)
+	}
+
+	if !eval.CrossedAny {
+		t.Error("expected CrossedAny to be true (item crossed)")
+	}
+	if !eval.CrossedItem {
+		t.Error("expected CrossedItem to be true")
+	}
+	if eval.CrossedItemID != "subitem_1" {
+		t.Errorf("crossed item id: got %q, want subitem_1", eval.CrossedItemID)
+	}
+	if eval.CrossedAmount {
+		t.Error("CrossedAmount should be false (no amount cap configured)")
+	}
+}
+
+// TestEvaluateThresholds_BelowItemQuantity confirms the per-item path also
+// respects the < cap case so we never spuriously fire.
+func TestEvaluateThresholds_BelowItemQuantity(t *testing.T) {
+	thresholds := &domain.BillingThresholds{
+		ResetBillingCycle: true,
+		ItemThresholds: []domain.SubscriptionItemThreshold{
+			{SubscriptionItemID: "subitem_1", UsageGTE: decimal.NewFromInt(1000)},
+		},
+	}
+	engine, _, _ := setupThresholdEngine(thresholds, 500)
+
+	sub, _ := engine.subs.Get(context.Background(), "t1", "sub_1")
+	periodStart := *sub.CurrentBillingPeriodStart
+	now := periodStart.AddDate(0, 0, 5)
+
+	eval, err := engine.evaluateThresholds(context.Background(), sub, periodStart, now)
+	if err != nil {
+		t.Fatalf("evaluateThresholds: %v", err)
+	}
+
+	if eval.CrossedAny {
+		t.Error("expected CrossedAny to be false")
+	}
+}
+
+// TestScanThresholds_SkipsTerminalSubs covers the gate that prevents
+// firing on canceled/archived subs. The candidate query in postgres
+// already restricts to active+trialing — this test guards the second-line
+// defense in scanOneThreshold so a stale candidate row can't bypass.
+func TestScanThresholds_SkipsTerminalSubs(t *testing.T) {
+	thresholds := &domain.BillingThresholds{
+		AmountGTE:         100, // very low cap so we'd cross if it fired
+		ResetBillingCycle: true,
+	}
+	engine, subs, invoices := setupThresholdEngine(thresholds, 1000)
+
+	// Force-cancel the candidate after build.
+	s := subs.subs["sub_1"]
+	s.Status = domain.SubscriptionCanceled
+	subs.subs["sub_1"] = s
+	subs.candidates[0] = s
+
+	fired, errs := engine.ScanThresholds(context.Background(), 50)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if fired != 0 {
+		t.Errorf("expected 0 fires for canceled sub, got %d", fired)
+	}
+	if len(invoices.invoices) != 0 {
+		t.Errorf("expected 0 invoices, got %d", len(invoices.invoices))
+	}
+}
+
+// TestScanThresholds_SkipsPauseCollection covers pause_collection: the
+// scan must not emit an invoice that can't be charged or dunned.
+func TestScanThresholds_SkipsPauseCollection(t *testing.T) {
+	thresholds := &domain.BillingThresholds{
+		AmountGTE:         100,
+		ResetBillingCycle: true,
+	}
+	engine, subs, invoices := setupThresholdEngine(thresholds, 1000)
+
+	s := subs.subs["sub_1"]
+	s.PauseCollection = &domain.PauseCollection{
+		Behavior: domain.PauseCollectionKeepAsDraft,
+	}
+	subs.subs["sub_1"] = s
+	subs.candidates[0] = s
+
+	fired, errs := engine.ScanThresholds(context.Background(), 50)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if fired != 0 {
+		t.Errorf("expected 0 fires for paused sub, got %d", fired)
+	}
+	if len(invoices.invoices) != 0 {
+		t.Errorf("expected 0 invoices, got %d", len(invoices.invoices))
+	}
+}
+
+// TestScanThresholds_NoCandidates handles the fast-path when no rows
+// have thresholds configured. Returns (0, nil) without entering the loop.
+func TestScanThresholds_NoCandidates(t *testing.T) {
+	engine, subs, _ := setupThresholdEngine(&domain.BillingThresholds{AmountGTE: 100}, 100)
+	subs.candidates = nil
+
+	fired, errs := engine.ScanThresholds(context.Background(), 50)
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %v", errs)
+	}
+	if fired != 0 {
+		t.Errorf("fired count: got %d, want 0", fired)
+	}
+}

--- a/internal/domain/invoice.go
+++ b/internal/domain/invoice.go
@@ -11,6 +11,24 @@ const (
 	InvoiceVoided    InvoiceStatus = "voided"
 )
 
+// InvoiceBillingReason classifies the trigger that produced an invoice.
+// Mirrors Stripe's invoice.billing_reason. Persisted as nullable on
+// the invoices table — legacy rows pre-FEAT-Week5c are NULL.
+//
+// SubscriptionCycle is the natural-cycle end invoice the cycle scan
+// emits at period boundaries. SubscriptionCreate is the prorated
+// initial invoice when a subscription starts mid-cycle. Manual is an
+// operator-initiated standalone invoice. Threshold is the hard-cap
+// early finalize fired by the threshold scan tick.
+type InvoiceBillingReason string
+
+const (
+	BillingReasonSubscriptionCycle  InvoiceBillingReason = "subscription_cycle"
+	BillingReasonSubscriptionCreate InvoiceBillingReason = "subscription_create"
+	BillingReasonManual             InvoiceBillingReason = "manual"
+	BillingReasonThreshold          InvoiceBillingReason = "threshold"
+)
+
 type InvoicePaymentStatus string
 
 const (
@@ -119,6 +137,13 @@ type Invoice struct {
 	SourcePlanChangedAt      *time.Time     `json:"source_plan_changed_at,omitempty"`
 	SourceSubscriptionItemID string         `json:"source_subscription_item_id,omitempty"`
 	SourceChangeType         ItemChangeType `json:"source_change_type,omitempty"`
+
+	// BillingReason classifies the trigger that produced this invoice.
+	// Stamped at create time and never mutated. Threshold-fired invoices
+	// (BillingReasonThreshold) participate in the partial unique index
+	// on (tenant, subscription, billing_period_start) so the threshold
+	// scan re-tick is idempotent under retry.
+	BillingReason InvoiceBillingReason `json:"billing_reason,omitempty"`
 }
 
 // ItemChangeType classifies per-item proration artifacts so the dedup index

--- a/internal/domain/subscription.go
+++ b/internal/domain/subscription.go
@@ -133,13 +133,13 @@ type Subscription struct {
 	// invoice-emitting path.
 	BillingThresholds         *BillingThresholds `json:"billing_thresholds,omitempty"`
 	CurrentBillingPeriodStart *time.Time         `json:"current_billing_period_start,omitempty"`
-	CurrentBillingPeriodEnd   *time.Time       `json:"current_billing_period_end,omitempty"`
-	NextBillingAt             *time.Time       `json:"next_billing_at,omitempty"`
-	UsageCapUnits             *int64           `json:"usage_cap_units,omitempty"` // Max usage units per billing period (nil = unlimited)
-	OverageAction             string           `json:"overage_action,omitempty"`  // "block" or "charge" (default: charge)
-	TestClockID               string           `json:"test_clock_id,omitempty"`   // Test mode only — attached simulator clock
-	CreatedAt                 time.Time        `json:"created_at"`
-	UpdatedAt                 time.Time        `json:"updated_at"`
+	CurrentBillingPeriodEnd   *time.Time         `json:"current_billing_period_end,omitempty"`
+	NextBillingAt             *time.Time         `json:"next_billing_at,omitempty"`
+	UsageCapUnits             *int64             `json:"usage_cap_units,omitempty"` // Max usage units per billing period (nil = unlimited)
+	OverageAction             string             `json:"overage_action,omitempty"`  // "block" or "charge" (default: charge)
+	TestClockID               string             `json:"test_clock_id,omitempty"`   // Test mode only — attached simulator clock
+	CreatedAt                 time.Time          `json:"created_at"`
+	UpdatedAt                 time.Time          `json:"updated_at"`
 
 	// Items is populated by store reads that hydrate the subscription with
 	// its current priced lines. Writes through Store.Create require a

--- a/internal/domain/subscription.go
+++ b/internal/domain/subscription.go
@@ -1,6 +1,10 @@
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
 
 type SubscriptionStatus string
 
@@ -36,6 +40,39 @@ const (
 type PauseCollection struct {
 	Behavior  PauseCollectionBehavior `json:"behavior"`
 	ResumesAt *time.Time              `json:"resumes_at,omitempty"`
+}
+
+// SubscriptionItemThreshold is one configured per-item usage cap on a
+// subscription. UsageGTE is decimal because meter quantities can be
+// fractional (cached-token ratios, GPU-hours) and we want round-trip
+// precision in the wire contract; Postgres column is NUMERIC(38,12).
+type SubscriptionItemThreshold struct {
+	SubscriptionItemID string          `json:"subscription_item_id"`
+	UsageGTE           decimal.Decimal `json:"usage_gte"`
+}
+
+// BillingThresholds is the Stripe-parity hard-cap configuration. Two
+// independent threshold types:
+//
+//   - AmountGTE: the running cycle subtotal (cents) at which the engine
+//     fires an early finalize. Currency is the subscription's own
+//     currency; multi-currency subs are rejected at PATCH time.
+//
+//   - ItemThresholds: per-subscription-item quantity caps. When any
+//     item's running cycle quantity crosses its UsageGTE, the engine
+//     fires the same early finalize.
+//
+// Either alone or both. First to fire wins.
+//
+// ResetBillingCycle controls whether the cycle resets after fire. When
+// true (default), the new cycle starts at fire time and the next bill
+// is the natural cycle invoice for the new cycle. When false, the
+// original cycle continues and a second invoice fires at the natural
+// cycle end with whatever residual usage accumulated.
+type BillingThresholds struct {
+	AmountGTE         int64                       `json:"amount_gte,omitempty"`
+	ResetBillingCycle bool                        `json:"reset_billing_cycle"`
+	ItemThresholds    []SubscriptionItemThreshold `json:"item_thresholds"`
 }
 
 // SubscriptionItem is a single priced line on a subscription. A subscription
@@ -88,8 +125,14 @@ type Subscription struct {
 	// invoice as draft and skips finalize/charge/dunning. Distinct from
 	// Status=paused, which is the hard freeze (sub excluded from
 	// GetDueBilling entirely). Nil means collection is running normally.
-	PauseCollection           *PauseCollection `json:"pause_collection,omitempty"`
-	CurrentBillingPeriodStart *time.Time       `json:"current_billing_period_start,omitempty"`
+	PauseCollection *PauseCollection `json:"pause_collection,omitempty"`
+	// BillingThresholds holds the Stripe-parity hard-cap config. When
+	// non-nil, the threshold scan tick computes the in-cycle running
+	// totals and fires an early finalize once any configured cap is
+	// crossed. Nil means no threshold; the cycle scan is the only
+	// invoice-emitting path.
+	BillingThresholds         *BillingThresholds `json:"billing_thresholds,omitempty"`
+	CurrentBillingPeriodStart *time.Time         `json:"current_billing_period_start,omitempty"`
 	CurrentBillingPeriodEnd   *time.Time       `json:"current_billing_period_end,omitempty"`
 	NextBillingAt             *time.Time       `json:"next_billing_at,omitempty"`
 	UsageCapUnits             *int64           `json:"usage_cap_units,omitempty"` // Max usage units per billing period (nil = unlimited)

--- a/internal/domain/webhook_outbound.go
+++ b/internal/domain/webhook_outbound.go
@@ -92,6 +92,7 @@ const (
 	EventSubscriptionCollectionResumed      = "subscription.collection_resumed"
 	EventSubscriptionTrialEnded             = "subscription.trial_ended"
 	EventSubscriptionTrialExtended          = "subscription.trial_extended"
+	EventSubscriptionThresholdCrossed       = "subscription.threshold_crossed"
 	EventCustomerCreated                    = "customer.created"
 	EventCustomerEmailBounced               = "customer.email_bounced"
 	EventDunningStarted                     = "dunning.started"

--- a/internal/invoice/postgres.go
+++ b/internal/invoice/postgres.go
@@ -33,7 +33,7 @@ const invCols = `id, tenant_id, customer_id, subscription_id, invoice_number, st
 	tax_provider, tax_calculation_id, COALESCE(tax_transaction_id,''),
 	tax_reverse_charge, tax_exempt_reason,
 	tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason,
-	COALESCE(public_token,'')`
+	COALESCE(public_token,''), COALESCE(billing_reason,'')`
 
 func (s *PostgresStore) Create(ctx context.Context, tenantID string, inv domain.Invoice) (domain.Invoice, error) {
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
@@ -62,8 +62,8 @@ func (s *PostgresStore) Create(ctx context.Context, tenantID string, inv domain.
 			net_payment_term_days, memo, footer, metadata, created_at, updated_at,
 			source_plan_changed_at, source_subscription_item_id, source_change_type,
 			tax_provider, tax_calculation_id, tax_reverse_charge, tax_exempt_reason,
-			tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38)
+			tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason, billing_reason)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39)
 		RETURNING `+invCols,
 		id, tenantID, inv.CustomerID, inv.SubscriptionID, inv.InvoiceNumber,
 		inv.Status, inv.PaymentStatus, inv.Currency,
@@ -79,6 +79,7 @@ func (s *PostgresStore) Create(ctx context.Context, tenantID string, inv domain.
 		postgres.NullableString(string(inv.SourceChangeType)),
 		inv.TaxProvider, inv.TaxCalculationID, inv.TaxReverseCharge, inv.TaxExemptReason,
 		string(taxStatus), postgres.NullableTime(inv.TaxDeferredAt), inv.TaxRetryCount, inv.TaxPendingReason,
+		postgres.NullableString(string(inv.BillingReason)),
 	).Scan(scanInvDest(&inv)...)
 
 	if err != nil {
@@ -772,8 +773,8 @@ func (s *PostgresStore) CreateWithLineItems(ctx context.Context, tenantID string
 			net_payment_term_days, memo, footer, metadata, created_at, updated_at,
 			source_plan_changed_at, source_subscription_item_id, source_change_type,
 			tax_provider, tax_calculation_id, tax_reverse_charge, tax_exempt_reason,
-			tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39)
+			tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason, billing_reason)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40)
 		RETURNING `+invCols,
 		id, tenantID, inv.CustomerID, inv.SubscriptionID, inv.InvoiceNumber,
 		inv.Status, inv.PaymentStatus, inv.Currency,
@@ -790,6 +791,7 @@ func (s *PostgresStore) CreateWithLineItems(ctx context.Context, tenantID string
 		postgres.NullableString(string(inv.SourceChangeType)),
 		inv.TaxProvider, inv.TaxCalculationID, inv.TaxReverseCharge, inv.TaxExemptReason,
 		string(taxStatus), postgres.NullableTime(inv.TaxDeferredAt), inv.TaxRetryCount, inv.TaxPendingReason,
+		postgres.NullableString(string(inv.BillingReason)),
 	).Scan(scanInvDest(&inv)...)
 
 	if err != nil {
@@ -971,7 +973,7 @@ func scanInvDest(inv *domain.Invoice) []any {
 		&inv.TaxProvider, &inv.TaxCalculationID, &inv.TaxTransactionID,
 		&inv.TaxReverseCharge, &inv.TaxExemptReason,
 		(*string)(&inv.TaxStatus), &inv.TaxDeferredAt, &inv.TaxRetryCount, &inv.TaxPendingReason,
-		&inv.PublicToken,
+		&inv.PublicToken, (*string)(&inv.BillingReason),
 	}
 }
 

--- a/internal/platform/migrate/sql/0056_subscription_billing_thresholds.down.sql
+++ b/internal/platform/migrate/sql/0056_subscription_billing_thresholds.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_subscriptions_billing_thresholds_amount;
+DROP INDEX IF EXISTS idx_invoices_threshold_unique_per_cycle;
+ALTER TABLE invoices
+    DROP CONSTRAINT IF EXISTS invoices_billing_reason_check,
+    DROP COLUMN IF EXISTS billing_reason;
+DROP TABLE IF EXISTS subscription_item_thresholds;
+ALTER TABLE subscriptions
+    DROP CONSTRAINT IF EXISTS subscriptions_billing_threshold_amount_gte_check,
+    DROP COLUMN IF EXISTS billing_threshold_reset_cycle,
+    DROP COLUMN IF EXISTS billing_threshold_amount_gte;

--- a/internal/platform/migrate/sql/0056_subscription_billing_thresholds.up.sql
+++ b/internal/platform/migrate/sql/0056_subscription_billing_thresholds.up.sql
@@ -1,0 +1,74 @@
+-- Stripe-parity billing thresholds. A subscription configures a hard cap
+-- (amount_gte cents and/or per-item usage_gte units); when the in-cycle
+-- running total crosses, the engine fires an early finalize via
+-- billing_reason='threshold' and (when reset_billing_cycle=true) rolls
+-- the cycle forward as if the period had ended naturally.
+--
+-- Distinct from billing alerts (Week 5d) which is the soft warning
+-- surface. Thresholds here = hard cap that emits an extra invoice;
+-- alerts = email/dashboard notification at percentage of cap.
+
+-- Per-subscription amount cap. NULL on either column = no
+-- amount-based threshold configured. CHECK enforces positive cents.
+ALTER TABLE subscriptions
+    ADD COLUMN billing_threshold_amount_gte BIGINT,
+    ADD COLUMN billing_threshold_reset_cycle BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD CONSTRAINT subscriptions_billing_threshold_amount_gte_check
+        CHECK (billing_threshold_amount_gte IS NULL OR billing_threshold_amount_gte > 0);
+
+-- Per-item usage thresholds. One row per (subscription, item) pair
+-- with a quantity threshold. NUMERIC(38,12) keeps decimal precision
+-- consistent with the rest of usage rating.
+CREATE TABLE subscription_item_thresholds (
+    subscription_id        TEXT NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    subscription_item_id   TEXT NOT NULL REFERENCES subscription_items(id) ON DELETE CASCADE,
+    tenant_id              TEXT NOT NULL,
+    usage_gte              NUMERIC(38, 12) NOT NULL CHECK (usage_gte > 0),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (subscription_item_id)
+);
+
+CREATE INDEX idx_subscription_item_thresholds_subscription
+    ON subscription_item_thresholds (subscription_id);
+
+CREATE INDEX idx_subscription_item_thresholds_tenant
+    ON subscription_item_thresholds (tenant_id);
+
+ALTER TABLE subscription_item_thresholds ENABLE ROW LEVEL SECURITY;
+ALTER TABLE subscription_item_thresholds FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON subscription_item_thresholds FOR ALL USING (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR tenant_id = current_setting('app.tenant_id', true)
+);
+
+GRANT ALL ON TABLE subscription_item_thresholds TO velox_app;
+
+-- New billing_reason on invoices. Existing rows get NULL (legacy /
+-- unspecified); new rows from the cycle scan stamp 'subscription_cycle'
+-- and the threshold scan stamps 'threshold'. CHECK constraint allows
+-- NULL for legacy rows + the four allowed values.
+ALTER TABLE invoices
+    ADD COLUMN billing_reason TEXT,
+    ADD CONSTRAINT invoices_billing_reason_check
+        CHECK (billing_reason IS NULL OR billing_reason IN (
+            'subscription_cycle', 'subscription_create', 'manual', 'threshold'
+        ));
+
+-- Partial unique index: at most one threshold-fired invoice per
+-- (tenant, subscription, billing_period_start) tuple. Idempotency seam
+-- for the "tick crossed threshold but advance failed before commit"
+-- failure path -- the next tick's INSERT lands on the existing row
+-- with errs.ErrAlreadyExists and the engine short-circuits before
+-- producing a duplicate invoice. The cycle-natural invoice is unrelated
+-- because it carries billing_reason != 'threshold' (or NULL on legacy).
+CREATE UNIQUE INDEX idx_invoices_threshold_unique_per_cycle
+    ON invoices (tenant_id, subscription_id, billing_period_start)
+    WHERE billing_reason = 'threshold';
+
+-- Scan candidate index: subscriptions with an amount threshold set.
+-- Per-item thresholds candidate via the aux table's foreign key.
+CREATE INDEX idx_subscriptions_billing_thresholds_amount
+    ON subscriptions (id)
+    WHERE billing_threshold_amount_gte IS NOT NULL;

--- a/internal/subscription/handler.go
+++ b/internal/subscription/handler.go
@@ -197,6 +197,11 @@ func (h *Handler) Routes() chi.Router {
 	r.Post("/{id}/end-trial", h.endTrial)
 	r.Post("/{id}/extend-trial", h.extendTrial)
 
+	// Billing thresholds — Stripe-parity hard-cap config. PUT writes the full
+	// (amount, reset, items) triple; DELETE clears it. Idempotent.
+	r.Put("/{id}/billing-thresholds", h.setBillingThresholds)
+	r.Delete("/{id}/billing-thresholds", h.clearBillingThresholds)
+
 	// Items — Stripe-style per-item mutation. Quantity and plan changes land
 	// on the same PATCH (body discriminates), pending-change clear has its own
 	// DELETE so client code can target it without a PATCH body shape.
@@ -518,6 +523,103 @@ func (h *Handler) resumeCollection(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.fireEvent(r.Context(), tenantID, domain.EventSubscriptionCollectionResumed, sub, nil)
+
+	respond.JSON(w, r, http.StatusOK, sub)
+}
+
+// setBillingThresholds writes the Stripe-parity hard-cap config onto a
+// subscription. Body shape:
+//
+//	{
+//	  "amount_gte": 50000,                    // optional, integer cents
+//	  "reset_billing_cycle": true,            // optional, defaults true
+//	  "item_thresholds": [                    // optional, always-array
+//	    {"subscription_item_id": "si_xxx", "usage_gte": "1000"}
+//	  ]
+//	}
+//
+// At least one of amount_gte or item_thresholds must be supplied. Returns
+// 422 on validation failure (terminal sub, unknown item id, negative
+// usage_gte, multi-currency item set, etc).
+//
+// Replaces the full set on every call: the per-item rows for any item not
+// in the new slice are deleted by the store.
+func (h *Handler) setBillingThresholds(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	id := chi.URLParam(r, "id")
+
+	var input BillingThresholdsInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		respond.BadRequest(w, r, "invalid JSON body")
+		return
+	}
+
+	// Multi-currency check happens here because plan currency lookups need
+	// h.plans, which the service doesn't have. We hydrate the sub's items,
+	// fetch each item's plan, and reject when the set spans more than one
+	// currency. A threshold expressed in cents only makes sense against a
+	// single-currency line set.
+	if h.plans != nil {
+		sub, gerr := h.svc.Get(r.Context(), tenantID, id)
+		if gerr == nil && len(sub.Items) > 0 {
+			seen := make(map[string]struct{}, 2)
+			for _, it := range sub.Items {
+				p, perr := h.plans.GetPlan(r.Context(), tenantID, it.PlanID)
+				if perr != nil {
+					continue
+				}
+				if p.Currency != "" {
+					seen[p.Currency] = struct{}{}
+				}
+			}
+			if len(seen) > 1 {
+				respond.Error(w, r, http.StatusUnprocessableEntity, "validation_error",
+					"billing thresholds are not supported on multi-currency subscriptions",
+					"billing_thresholds")
+				return
+			}
+		}
+	}
+
+	sub, err := h.svc.SetBillingThresholds(r.Context(), tenantID, id, input)
+	if err != nil {
+		respond.FromError(w, r, err, "subscription")
+		return
+	}
+
+	if h.auditLogger != nil {
+		meta := map[string]any{
+			"action":               "billing_thresholds_set",
+			"customer_id":          sub.CustomerID,
+			"amount_gte":           input.AmountGTE,
+			"item_threshold_count": len(input.ItemThresholds),
+		}
+		_ = h.auditLogger.Log(r.Context(), tenantID, domain.AuditActionUpdate, "subscription", sub.ID, meta)
+	}
+
+	respond.JSON(w, r, http.StatusOK, sub)
+}
+
+// clearBillingThresholds removes any threshold configuration on a
+// subscription. Idempotent — clearing on a sub that has no threshold returns
+// 200 with the unchanged subscription. Returns 404 only when the
+// subscription itself doesn't exist.
+func (h *Handler) clearBillingThresholds(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	id := chi.URLParam(r, "id")
+
+	sub, err := h.svc.ClearBillingThresholds(r.Context(), tenantID, id)
+	if err != nil {
+		respond.FromError(w, r, err, "subscription")
+		return
+	}
+
+	if h.auditLogger != nil {
+		_ = h.auditLogger.Log(r.Context(), tenantID, domain.AuditActionUpdate, "subscription", sub.ID, map[string]any{
+			"action":      "billing_thresholds_cleared",
+			"customer_id": sub.CustomerID,
+		})
+	}
 
 	respond.JSON(w, r, http.StatusOK, sub)
 }

--- a/internal/subscription/postgres.go
+++ b/internal/subscription/postgres.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
@@ -28,6 +30,7 @@ const subCols = `id, tenant_id, code, display_name, customer_id, status, billing
 	trial_start_at, trial_end_at, started_at, activated_at, canceled_at,
 	cancel_at, COALESCE(cancel_at_period_end, false),
 	pause_collection_behavior, pause_collection_resumes_at,
+	billing_threshold_amount_gte, COALESCE(billing_threshold_reset_cycle, true),
 	current_billing_period_start, current_billing_period_end, next_billing_at,
 	usage_cap_units, COALESCE(overage_action,'charge'),
 	COALESCE(test_clock_id,''),
@@ -128,11 +131,9 @@ func (s *PostgresStore) Get(ctx context.Context, tenantID, id string) (domain.Su
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 	return sub, nil
 }
 
@@ -185,11 +186,9 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.S
 	// acceptable on the list path at the default 50-row page size; if list
 	// growth becomes hot, batch this into one IN() query.
 	for i := range subs {
-		items, err := listItemsTx(ctx, tx, subs[i].ID)
-		if err != nil {
+		if err := hydrateSubChildrenTx(ctx, tx, &subs[i]); err != nil {
 			return nil, 0, err
 		}
-		subs[i].Items = items
 	}
 	return subs, total, nil
 }
@@ -222,11 +221,9 @@ func (s *PostgresStore) Update(ctx context.Context, tenantID string, sub domain.
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -300,11 +297,9 @@ func (s *PostgresStore) ScheduleCancellation(ctx context.Context, tenantID, id s
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -340,11 +335,9 @@ func (s *PostgresStore) ClearScheduledCancellation(ctx context.Context, tenantID
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -394,11 +387,9 @@ func (s *PostgresStore) FireScheduledCancellation(ctx context.Context, tenantID,
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -445,11 +436,9 @@ func (s *PostgresStore) SetPauseCollection(ctx context.Context, tenantID, id str
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -487,11 +476,9 @@ func (s *PostgresStore) ClearPauseCollection(ctx context.Context, tenantID, id s
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -539,11 +526,9 @@ func (s *PostgresStore) ActivateAfterTrial(ctx context.Context, tenantID, id str
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -588,11 +573,9 @@ func (s *PostgresStore) ExtendTrial(ctx context.Context, tenantID, id string, ne
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -663,11 +646,9 @@ func (s *PostgresStore) transitionAtomic(ctx context.Context, tenantID, id strin
 		return domain.Subscription{}, err
 	}
 
-	items, err := listItemsTx(ctx, tx, sub.ID)
-	if err != nil {
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
 		return domain.Subscription{}, err
 	}
-	sub.Items = items
 
 	if err := tx.Commit(); err != nil {
 		return domain.Subscription{}, err
@@ -724,11 +705,9 @@ func (s *PostgresStore) GetDueBilling(ctx context.Context, before time.Time, lim
 	}
 
 	for i := range subs {
-		items, err := listItemsTx(ctx, tx, subs[i].ID)
-		if err != nil {
+		if err := hydrateSubChildrenTx(ctx, tx, &subs[i]); err != nil {
 			return nil, err
 		}
-		subs[i].Items = items
 	}
 	return subs, nil
 }
@@ -1007,8 +986,234 @@ func (s *PostgresStore) RemoveItem(ctx context.Context, tenantID, itemID string)
 }
 
 // ---------------------------------------------------------------------------
+// Billing thresholds
+// ---------------------------------------------------------------------------
+
+// SetBillingThresholds writes the (amount_gte, reset_cycle, item_thresholds)
+// triple onto the row in one transaction. Replaces the per-item threshold
+// set: any item_thresholds row not in the new slice is deleted, present
+// rows are upserted by primary key (subscription_item_id).
+//
+// Rejects rows in canceled/archived since a threshold on a terminal
+// subscription has no meaning — the engine wouldn't observe it anyway,
+// but the API surface should be consistent. Service layer is responsible
+// for validating that every t.ItemThresholds[i].SubscriptionItemID
+// belongs to this subscription.
+func (s *PostgresStore) SetBillingThresholds(ctx context.Context, tenantID, id string, t domain.BillingThresholds) (domain.Subscription, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.Subscription{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	now := time.Now().UTC()
+
+	// Update the parent subscription columns in the same tx as the per-item
+	// upserts so a partial commit can't leave amount_gte set without the
+	// item rows the caller intended.
+	var amountArg sql.NullInt64
+	if t.AmountGTE > 0 {
+		amountArg = sql.NullInt64{Int64: t.AmountGTE, Valid: true}
+	}
+	var sub domain.Subscription
+	err = scanSubRow(tx.QueryRowContext(ctx, `
+		UPDATE subscriptions
+		SET billing_threshold_amount_gte = $1,
+		    billing_threshold_reset_cycle = $2,
+		    updated_at = $3
+		WHERE id = $4 AND status NOT IN ('canceled','archived')
+		RETURNING `+subCols,
+		amountArg, t.ResetBillingCycle, now, id,
+	), &sub)
+	if err == sql.ErrNoRows {
+		var currentStatus string
+		err2 := tx.QueryRowContext(ctx, `SELECT status FROM subscriptions WHERE id = $1`, id).Scan(&currentStatus)
+		if err2 == sql.ErrNoRows {
+			return domain.Subscription{}, errs.ErrNotFound
+		}
+		if err2 != nil {
+			return domain.Subscription{}, err2
+		}
+		return domain.Subscription{}, errs.InvalidState(fmt.Sprintf("cannot set billing threshold on %s subscription", currentStatus))
+	}
+	if err != nil {
+		return domain.Subscription{}, err
+	}
+
+	// Replace the per-item set in one statement: DELETE everything not in the
+	// new slice, then UPSERT each new row. This pattern preserves the
+	// (subscription_item_id) PK across calls and lets idempotent re-set
+	// converge to the same state without churn.
+	keepIDs := make([]string, 0, len(t.ItemThresholds))
+	for _, it := range t.ItemThresholds {
+		keepIDs = append(keepIDs, it.SubscriptionItemID)
+	}
+	if len(keepIDs) > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM subscription_item_thresholds
+			WHERE subscription_id = $1 AND NOT (subscription_item_id = ANY($2::text[]))
+		`, id, keepIDs); err != nil {
+			return domain.Subscription{}, fmt.Errorf("delete stale item thresholds: %w", err)
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM subscription_item_thresholds WHERE subscription_id = $1
+		`, id); err != nil {
+			return domain.Subscription{}, fmt.Errorf("clear item thresholds: %w", err)
+		}
+	}
+
+	for _, it := range t.ItemThresholds {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO subscription_item_thresholds (subscription_id, subscription_item_id, tenant_id, usage_gte, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $5)
+			ON CONFLICT (subscription_item_id) DO UPDATE
+			SET usage_gte = EXCLUDED.usage_gte,
+			    updated_at = EXCLUDED.updated_at
+		`, id, it.SubscriptionItemID, tenantID, it.UsageGTE.String(), now); err != nil {
+			return domain.Subscription{}, fmt.Errorf("upsert item threshold for %s: %w", it.SubscriptionItemID, err)
+		}
+	}
+
+	if err := hydrateSubChildrenTx(ctx, tx, &sub); err != nil {
+		return domain.Subscription{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return domain.Subscription{}, err
+	}
+	return sub, nil
+}
+
+// ClearBillingThresholds nulls the amount_gte column, resets reset_cycle
+// to its default (true), and deletes every per-item threshold row for
+// this subscription. Idempotent — clearing on a sub with no threshold
+// returns the unchanged subscription.
+func (s *PostgresStore) ClearBillingThresholds(ctx context.Context, tenantID, id string) (domain.Subscription, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.Subscription{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	now := time.Now().UTC()
+	var sub domain.Subscription
+	err = scanSubRow(tx.QueryRowContext(ctx, `
+		UPDATE subscriptions
+		SET billing_threshold_amount_gte = NULL,
+		    billing_threshold_reset_cycle = TRUE,
+		    updated_at = $1
+		WHERE id = $2
+		RETURNING `+subCols,
+		now, id,
+	), &sub)
+	if err == sql.ErrNoRows {
+		return domain.Subscription{}, errs.ErrNotFound
+	}
+	if err != nil {
+		return domain.Subscription{}, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM subscription_item_thresholds WHERE subscription_id = $1
+	`, id); err != nil {
+		return domain.Subscription{}, fmt.Errorf("clear item thresholds: %w", err)
+	}
+
+	// Reset BillingThresholds to nil since both amount and per-item are
+	// now cleared. scanSubRow already left it nil (column became NULL),
+	// but be explicit to keep hydrate from re-allocating an empty struct.
+	sub.BillingThresholds = nil
+
+	items, err := listItemsTx(ctx, tx, sub.ID)
+	if err != nil {
+		return domain.Subscription{}, err
+	}
+	sub.Items = items
+
+	if err := tx.Commit(); err != nil {
+		return domain.Subscription{}, err
+	}
+	return sub, nil
+}
+
+// ListWithThresholds returns active or trialing subscriptions in the
+// given livemode partition that have at least one threshold configured
+// (amount_gte set, OR at least one row in subscription_item_thresholds).
+// Used by the threshold scan tick. Result is hydrated with items +
+// thresholds so the caller can run the cycle math without a second
+// round-trip per row.
+//
+// Uses TxBypass + explicit livemode filter for the same reason as
+// GetDueBilling: the scheduler is cross-tenant and the per-tenant
+// downstream calls (usage aggregation, plan reads) carry their own
+// tenant context.
+func (s *PostgresStore) ListWithThresholds(ctx context.Context, livemode bool, limit int) ([]domain.Subscription, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		return nil, err
+	}
+	defer postgres.Rollback(tx)
+
+	if limit <= 0 {
+		limit = 100
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT `+qualifiedSubCols("s")+` FROM subscriptions s
+		WHERE s.status IN ('active', 'trialing')
+		  AND s.livemode = $1
+		  AND (s.billing_threshold_amount_gte IS NOT NULL
+		       OR EXISTS (SELECT 1 FROM subscription_item_thresholds sit WHERE sit.subscription_id = s.id))
+		ORDER BY s.id ASC
+		LIMIT $2
+	`, livemode, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var subs []domain.Subscription
+	for rows.Next() {
+		var sub domain.Subscription
+		if err := scanSubRow(rows, &sub); err != nil {
+			return nil, err
+		}
+		subs = append(subs, sub)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for i := range subs {
+		if err := hydrateSubChildrenTx(ctx, tx, &subs[i]); err != nil {
+			return nil, err
+		}
+	}
+	return subs, nil
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// hydrateSubChildrenTx hydrates a subscription's items + billing thresholds
+// inside a single transaction. Replaces the historic listItemsTx + manual
+// item assignment pattern at most call sites — feature additions like
+// thresholds should land here, not be duplicated at every read path.
+//
+// Threshold hydration only runs when the row has amount_gte set OR there
+// is at least one row in subscription_item_thresholds. Pure no-threshold
+// subs pay one extra LEFT JOIN'd EXISTS check, which is index-supported
+// (idx_subscription_item_thresholds_subscription) and effectively free.
+func hydrateSubChildrenTx(ctx context.Context, tx *sql.Tx, sub *domain.Subscription) error {
+	items, err := listItemsTx(ctx, tx, sub.ID)
+	if err != nil {
+		return err
+	}
+	sub.Items = items
+	return hydrateThresholds(ctx, tx, sub)
+}
 
 // listItemsTx reads a subscription's items inside an existing transaction so
 // callers on the hot load path don't pay a second BEGIN/COMMIT. Returns items
@@ -1095,16 +1300,22 @@ type rowScanner interface {
 
 // scanSubRow scans subCols into sub. Handles fields that need post-processing
 // — currently the nullable (behavior, resumes_at) pair that composes into
-// the *PauseCollection field on the domain struct.
+// the *PauseCollection field on the domain struct, plus the (amount_gte,
+// reset_cycle) pair that composes into BillingThresholds. Per-item
+// thresholds are hydrated separately by hydrateThresholds since they
+// live in an aux table.
 func scanSubRow(row rowScanner, sub *domain.Subscription) error {
 	var pauseBehavior sql.NullString
 	var pauseResumesAt sql.NullTime
+	var thresholdAmountGTE sql.NullInt64
+	var thresholdResetCycle bool
 	dest := []any{
 		&sub.ID, &sub.TenantID, &sub.Code, &sub.DisplayName, &sub.CustomerID,
 		&sub.Status, &sub.BillingTime, &sub.TrialStartAt, &sub.TrialEndAt, &sub.StartedAt,
 		&sub.ActivatedAt, &sub.CanceledAt,
 		&sub.CancelAt, &sub.CancelAtPeriodEnd,
 		&pauseBehavior, &pauseResumesAt,
+		&thresholdAmountGTE, &thresholdResetCycle,
 		&sub.CurrentBillingPeriodStart,
 		&sub.CurrentBillingPeriodEnd, &sub.NextBillingAt,
 		&sub.UsageCapUnits, &sub.OverageAction,
@@ -1124,6 +1335,78 @@ func scanSubRow(row rowScanner, sub *domain.Subscription) error {
 		}
 		sub.PauseCollection = pc
 	}
+	// BillingThresholds is partially populated here from the columns on the
+	// row. ItemThresholds is filled in by hydrateThresholds because it lives
+	// in an aux table. We always allocate the struct when amount_gte is set
+	// or the row's reset_cycle has been explicitly toggled away from default,
+	// and let hydrateThresholds add the items if any exist. When the caller
+	// skips hydrateThresholds entirely (rare — see ListWithThresholds for the
+	// only such site), the struct is nil-or-amount-only, which is the same
+	// shape pre-hydrate.
+	if thresholdAmountGTE.Valid {
+		sub.BillingThresholds = &domain.BillingThresholds{
+			AmountGTE:         thresholdAmountGTE.Int64,
+			ResetBillingCycle: thresholdResetCycle,
+			ItemThresholds:    []domain.SubscriptionItemThreshold{},
+		}
+	}
+	return nil
+}
+
+// hydrateThresholds fills sub.BillingThresholds.ItemThresholds from the
+// aux table. Called after scanSubRow on a hot read path (Get, List, the
+// scan tick) when the caller wants the full threshold view. Two cases:
+//
+//   - sub.BillingThresholds is non-nil from scanSubRow because amount_gte
+//     was set: append item rows (if any) to the existing slice.
+//
+//   - sub.BillingThresholds is nil because amount_gte was NULL: if any
+//     item rows exist, allocate a new struct with the aux rows; otherwise
+//     leave nil.
+//
+// Empty aux rows + NULL amount_gte means no thresholds — sub stays nil.
+func hydrateThresholds(ctx context.Context, tx *sql.Tx, sub *domain.Subscription) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT subscription_item_id, usage_gte
+		FROM subscription_item_thresholds
+		WHERE subscription_id = $1
+		ORDER BY subscription_item_id ASC
+	`, sub.ID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []domain.SubscriptionItemThreshold
+	for rows.Next() {
+		var t domain.SubscriptionItemThreshold
+		var usageGTE string
+		if err := rows.Scan(&t.SubscriptionItemID, &usageGTE); err != nil {
+			return err
+		}
+		dec, err := decimal.NewFromString(usageGTE)
+		if err != nil {
+			return fmt.Errorf("parse usage_gte for item %s: %w", t.SubscriptionItemID, err)
+		}
+		t.UsageGTE = dec
+		items = append(items, t)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		// No per-item thresholds. Leave existing struct as-is (which may
+		// have an amount-only threshold from scanSubRow), or nil.
+		return nil
+	}
+	if sub.BillingThresholds == nil {
+		sub.BillingThresholds = &domain.BillingThresholds{
+			ResetBillingCycle: true, // default mirrors the column default
+			ItemThresholds:    items,
+		}
+		return nil
+	}
+	sub.BillingThresholds.ItemThresholds = items
 	return nil
 }
 

--- a/internal/subscription/service.go
+++ b/internal/subscription/service.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/sagarsuperuser/velox/internal/auth"
 	"github.com/sagarsuperuser/velox/internal/domain"
 	"github.com/sagarsuperuser/velox/internal/errs"
@@ -546,6 +548,118 @@ func (s *Service) ExtendTrial(ctx context.Context, tenantID, id string, newTrial
 		return domain.Subscription{}, errs.Invalid("trial_end", "must be after the current trial_end_at — use end-trial to shorten")
 	}
 	return s.store.ExtendTrial(ctx, tenantID, id, newTrialEnd.UTC())
+}
+
+// ItemThresholdInput is one configured per-item usage cap on a subscription.
+// UsageGTE arrives as a JSON string from the wire so meter quantities that
+// can be fractional (cached-token ratios, GPU-hours) round-trip without
+// float drift. The service parses it into shopspring/decimal before handing
+// off to the store.
+type ItemThresholdInput struct {
+	SubscriptionItemID string `json:"subscription_item_id"`
+	UsageGTE           string `json:"usage_gte"`
+}
+
+// BillingThresholdsInput is the PATCH body shape for /v1/subscriptions/{id}
+// when setting thresholds. AmountGTE is integer cents; ItemThresholds is the
+// always-array of per-item caps. Either AmountGTE or ItemThresholds (or both)
+// must be set — a body with neither is rejected as no-op.
+//
+// ResetBillingCycle defaults to true at PATCH time when omitted (matches the
+// migration column default and Stripe's reset_billing_cycle behavior). The
+// pointer-on-field shape lets the handler distinguish "not supplied" (apply
+// default) from "explicitly false".
+type BillingThresholdsInput struct {
+	AmountGTE         int64                `json:"amount_gte,omitempty"`
+	ResetBillingCycle *bool                `json:"reset_billing_cycle,omitempty"`
+	ItemThresholds    []ItemThresholdInput `json:"item_thresholds,omitempty"`
+}
+
+// SetBillingThresholds writes (amount_gte, reset_cycle, item_thresholds) onto
+// a subscription. Validates: at least one of amount_gte or item_thresholds is
+// supplied (a body with neither is a no-op masquerade); amount_gte > 0 if
+// supplied; usage_gte parses as a non-negative decimal; every
+// subscription_item_id in item_thresholds belongs to this subscription;
+// duplicate item ids are rejected so the underlying PK doesn't surface as a
+// mid-tx integrity error. Multi-currency rejection happens upstream at the
+// handler (the only layer with a PlanReader).
+//
+// Replaces the full set on every call: per-item rows for any item not in the
+// new slice are deleted by the store. Idempotent — calling with the same
+// input replaces the row's columns and aux rows with the same values.
+func (s *Service) SetBillingThresholds(ctx context.Context, tenantID, id string, input BillingThresholdsInput) (domain.Subscription, error) {
+	if input.AmountGTE == 0 && len(input.ItemThresholds) == 0 {
+		return domain.Subscription{}, errs.Invalid("billing_thresholds",
+			"at least one of amount_gte or item_thresholds must be set; to clear use DELETE")
+	}
+	if input.AmountGTE < 0 {
+		return domain.Subscription{}, errs.Invalid("amount_gte", "must be > 0")
+	}
+
+	sub, err := s.store.Get(ctx, tenantID, id)
+	if err != nil {
+		return domain.Subscription{}, err
+	}
+	if sub.Status == domain.SubscriptionCanceled || sub.Status == domain.SubscriptionArchived {
+		return domain.Subscription{}, errs.InvalidState(
+			fmt.Sprintf("cannot configure billing thresholds on %s subscriptions", sub.Status))
+	}
+
+	itemIDs := make(map[string]struct{}, len(sub.Items))
+	for _, it := range sub.Items {
+		itemIDs[it.ID] = struct{}{}
+	}
+
+	parsed := make([]domain.SubscriptionItemThreshold, 0, len(input.ItemThresholds))
+	seen := make(map[string]struct{}, len(input.ItemThresholds))
+	for i, t := range input.ItemThresholds {
+		if t.SubscriptionItemID == "" {
+			return domain.Subscription{}, errs.Required(fmt.Sprintf("item_thresholds[%d].subscription_item_id", i))
+		}
+		if _, dup := seen[t.SubscriptionItemID]; dup {
+			return domain.Subscription{}, errs.Invalid("item_thresholds",
+				fmt.Sprintf("duplicate subscription_item_id %q", t.SubscriptionItemID))
+		}
+		seen[t.SubscriptionItemID] = struct{}{}
+		if _, ok := itemIDs[t.SubscriptionItemID]; !ok {
+			return domain.Subscription{}, errs.Invalid(
+				fmt.Sprintf("item_thresholds[%d].subscription_item_id", i),
+				fmt.Sprintf("item %q does not belong to this subscription", t.SubscriptionItemID))
+		}
+		usage, derr := decimal.NewFromString(strings.TrimSpace(t.UsageGTE))
+		if derr != nil {
+			return domain.Subscription{}, errs.Invalid(
+				fmt.Sprintf("item_thresholds[%d].usage_gte", i),
+				"must be a numeric string (e.g. \"1000\" or \"3.14\")")
+		}
+		if usage.IsNegative() {
+			return domain.Subscription{}, errs.Invalid(
+				fmt.Sprintf("item_thresholds[%d].usage_gte", i),
+				"must be >= 0")
+		}
+		parsed = append(parsed, domain.SubscriptionItemThreshold{
+			SubscriptionItemID: t.SubscriptionItemID,
+			UsageGTE:           usage,
+		})
+	}
+
+	resetCycle := true
+	if input.ResetBillingCycle != nil {
+		resetCycle = *input.ResetBillingCycle
+	}
+
+	return s.store.SetBillingThresholds(ctx, tenantID, id, domain.BillingThresholds{
+		AmountGTE:         input.AmountGTE,
+		ResetBillingCycle: resetCycle,
+		ItemThresholds:    parsed,
+	})
+}
+
+// ClearBillingThresholds removes any threshold configuration on a
+// subscription. Idempotent — clearing on a sub that has no threshold returns
+// the unchanged subscription.
+func (s *Service) ClearBillingThresholds(ctx context.Context, tenantID, id string) (domain.Subscription, error) {
+	return s.store.ClearBillingThresholds(ctx, tenantID, id)
 }
 
 func beginningOfMonth(t time.Time) time.Time {

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -1205,3 +1205,227 @@ func TestExtendTrial(t *testing.T) {
 		}
 	})
 }
+
+// TestSetBillingThresholds covers the validation paths the service applies on
+// PATCH. The Postgres store handles the actual write; integration tests
+// exercise that path. These unit tests are the merge gate for the hot config
+// rules — drop a check here and the API would happily accept e.g. duplicate
+// item ids, which would later surface as a mid-tx integrity error.
+func TestSetBillingThresholds(t *testing.T) {
+	ctx := context.Background()
+
+	newSubFixture := func(t *testing.T) (*Service, domain.Subscription) {
+		t.Helper()
+		svc := NewService(newMemStore(), nil)
+		sub, err := svc.Create(ctx, "t1", CreateInput{
+			Code: "sub-thresh", DisplayName: "Test", CustomerID: "c",
+			Items: []CreateItemInput{
+				{PlanID: "plan_base"},
+				{PlanID: "plan_addon"},
+			},
+			StartNow: true,
+		})
+		if err != nil {
+			t.Fatalf("create sub: %v", err)
+		}
+		return svc, sub
+	}
+
+	t.Run("rejects empty body", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{})
+		if err == nil {
+			t.Fatal("expected error: empty body must be rejected, not silently no-op")
+		}
+	})
+
+	t.Run("rejects negative amount_gte", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			AmountGTE: -1,
+		})
+		if err == nil {
+			t.Fatal("expected error for negative amount_gte")
+		}
+	})
+
+	t.Run("rejects unknown subscription", func(t *testing.T) {
+		svc, _ := newSubFixture(t)
+		_, err := svc.SetBillingThresholds(ctx, "t1", "vlx_sub_does_not_exist", BillingThresholdsInput{
+			AmountGTE: 500000,
+		})
+		if err == nil {
+			t.Fatal("expected ErrNotFound for unknown subscription")
+		}
+	})
+
+	t.Run("rejects on canceled sub", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		// Cancel the subscription so we can verify the terminal-state guard.
+		if _, err := svc.Cancel(ctx, "t1", sub.ID); err != nil {
+			t.Fatalf("setup cancel: %v", err)
+		}
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			AmountGTE: 500000,
+		})
+		if err == nil {
+			t.Fatal("expected error setting threshold on canceled sub")
+		}
+	})
+
+	t.Run("rejects item_thresholds with empty subscription_item_id", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			ItemThresholds: []ItemThresholdInput{
+				{SubscriptionItemID: "", UsageGTE: "1000"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for empty subscription_item_id")
+		}
+	})
+
+	t.Run("rejects duplicate subscription_item_id", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		fresh, _ := svc.Get(ctx, "t1", sub.ID)
+		itemID := fresh.Items[0].ID
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			ItemThresholds: []ItemThresholdInput{
+				{SubscriptionItemID: itemID, UsageGTE: "1000"},
+				{SubscriptionItemID: itemID, UsageGTE: "2000"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for duplicate subscription_item_id")
+		}
+	})
+
+	t.Run("rejects subscription_item_id not on this subscription", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			ItemThresholds: []ItemThresholdInput{
+				{SubscriptionItemID: "vlx_subitem_foreign", UsageGTE: "1000"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for foreign subscription_item_id")
+		}
+	})
+
+	t.Run("rejects non-numeric usage_gte", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		fresh, _ := svc.Get(ctx, "t1", sub.ID)
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			ItemThresholds: []ItemThresholdInput{
+				{SubscriptionItemID: fresh.Items[0].ID, UsageGTE: "not-a-number"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for non-numeric usage_gte")
+		}
+	})
+
+	t.Run("rejects negative usage_gte", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		fresh, _ := svc.Get(ctx, "t1", sub.ID)
+		_, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			ItemThresholds: []ItemThresholdInput{
+				{SubscriptionItemID: fresh.Items[0].ID, UsageGTE: "-1"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for negative usage_gte")
+		}
+	})
+
+	t.Run("accepts amount-only configuration", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		updated, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			AmountGTE: 500000,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updated.BillingThresholds == nil {
+			t.Fatal("expected BillingThresholds set on updated sub")
+		}
+		if updated.BillingThresholds.AmountGTE != 500000 {
+			t.Errorf("amount_gte: got %d, want 500000", updated.BillingThresholds.AmountGTE)
+		}
+		if !updated.BillingThresholds.ResetBillingCycle {
+			t.Error("reset_billing_cycle should default to true when omitted")
+		}
+	})
+
+	t.Run("accepts item-only configuration", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		fresh, _ := svc.Get(ctx, "t1", sub.ID)
+		updated, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			ItemThresholds: []ItemThresholdInput{
+				{SubscriptionItemID: fresh.Items[0].ID, UsageGTE: "1000.5"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updated.BillingThresholds == nil {
+			t.Fatal("expected BillingThresholds set on updated sub")
+		}
+		if len(updated.BillingThresholds.ItemThresholds) != 1 {
+			t.Fatalf("expected 1 item threshold, got %d", len(updated.BillingThresholds.ItemThresholds))
+		}
+	})
+
+	t.Run("accepts explicit reset_billing_cycle=false", func(t *testing.T) {
+		svc, sub := newSubFixture(t)
+		falseV := false
+		updated, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			AmountGTE:         500000,
+			ResetBillingCycle: &falseV,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updated.BillingThresholds.ResetBillingCycle {
+			t.Error("reset_billing_cycle: explicit false should be respected")
+		}
+	})
+}
+
+// TestClearBillingThresholds is idempotent and unconditional — the service
+// delegates straight to the store. We just verify the round-trip wires
+// through correctly and removing a never-set threshold is not an error.
+func TestClearBillingThresholds(t *testing.T) {
+	ctx := context.Background()
+	svc := NewService(newMemStore(), nil)
+
+	sub, err := svc.Create(ctx, "t1", CreateInput{
+		Code: "sub-clear", DisplayName: "Test", CustomerID: "c",
+		Items:    []CreateItemInput{{PlanID: "plan_base"}},
+		StartNow: true,
+	})
+	if err != nil {
+		t.Fatalf("create sub: %v", err)
+	}
+
+	t.Run("idempotent on never-set", func(t *testing.T) {
+		if _, err := svc.ClearBillingThresholds(ctx, "t1", sub.ID); err != nil {
+			t.Errorf("clearing never-set threshold should be a no-op, got %v", err)
+		}
+	})
+
+	t.Run("clears after set", func(t *testing.T) {
+		if _, err := svc.SetBillingThresholds(ctx, "t1", sub.ID, BillingThresholdsInput{
+			AmountGTE: 500000,
+		}); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		updated, err := svc.ClearBillingThresholds(ctx, "t1", sub.ID)
+		if err != nil {
+			t.Fatalf("clear: %v", err)
+		}
+		if updated.BillingThresholds != nil {
+			t.Errorf("BillingThresholds should be nil after clear, got %+v", updated.BillingThresholds)
+		}
+	})
+}

--- a/internal/subscription/service_test.go
+++ b/internal/subscription/service_test.go
@@ -364,6 +364,51 @@ func (m *memStore) RemoveItem(_ context.Context, tenantID, itemID string) error 
 	return nil
 }
 
+// SetBillingThresholds is a minimal in-memory implementation matching the
+// store contract: stores the BillingThresholds struct on the row and rejects
+// terminal subs. The handler tests don't exercise this path; integration
+// tests against real Postgres cover the full behaviour.
+func (m *memStore) SetBillingThresholds(_ context.Context, tenantID, id string, t domain.BillingThresholds) (domain.Subscription, error) {
+	s, ok := m.subs[id]
+	if !ok || s.TenantID != tenantID {
+		return domain.Subscription{}, errs.ErrNotFound
+	}
+	if s.Status == domain.SubscriptionCanceled || s.Status == domain.SubscriptionArchived {
+		return domain.Subscription{}, errs.InvalidState("cannot configure billing thresholds on terminated subscription")
+	}
+	bt := t
+	s.BillingThresholds = &bt
+	m.subs[id] = s
+	s.Items = m.hydrateItems(id)
+	return s, nil
+}
+
+func (m *memStore) ClearBillingThresholds(_ context.Context, tenantID, id string) (domain.Subscription, error) {
+	s, ok := m.subs[id]
+	if !ok || s.TenantID != tenantID {
+		return domain.Subscription{}, errs.ErrNotFound
+	}
+	s.BillingThresholds = nil
+	m.subs[id] = s
+	s.Items = m.hydrateItems(id)
+	return s, nil
+}
+
+func (m *memStore) ListWithThresholds(_ context.Context, _ bool, _ int) ([]domain.Subscription, error) {
+	var out []domain.Subscription
+	for _, s := range m.subs {
+		if s.BillingThresholds == nil {
+			continue
+		}
+		if s.Status != domain.SubscriptionActive && s.Status != domain.SubscriptionTrialing {
+			continue
+		}
+		s.Items = m.hydrateItems(s.ID)
+		out = append(out, s)
+	}
+	return out, nil
+}
+
 func (m *memStore) hydrateItems(subID string) []domain.SubscriptionItem {
 	var out []domain.SubscriptionItem
 	for _, it := range m.items {

--- a/internal/subscription/store.go
+++ b/internal/subscription/store.go
@@ -69,6 +69,27 @@ type Store interface {
 	// — clearing an already-cleared row returns the unchanged subscription.
 	ClearPauseCollection(ctx context.Context, tenantID, id string) (domain.Subscription, error)
 
+	// SetBillingThresholds writes the (amount_gte, reset_cycle, item_thresholds)
+	// triple onto the row in one transaction. Replaces the full item_thresholds
+	// set — the per-item rows for any item not in the new slice are deleted.
+	// Rejects rows in canceled/archived since a threshold on a terminated sub
+	// has no meaning. The service layer is responsible for validating that
+	// every subscription_item_id in t.ItemThresholds belongs to this
+	// subscription.
+	SetBillingThresholds(ctx context.Context, tenantID, id string, t domain.BillingThresholds) (domain.Subscription, error)
+
+	// ClearBillingThresholds nulls the amount_gte column and deletes every
+	// row in subscription_item_thresholds for this subscription. Idempotent
+	// — clearing on a sub that has no threshold returns the unchanged
+	// subscription.
+	ClearBillingThresholds(ctx context.Context, tenantID, id string) (domain.Subscription, error)
+
+	// ListWithThresholds returns subscriptions in the given livemode partition
+	// that have at least one threshold configured (amount or per-item) and are
+	// in active or trialing status. Used by the threshold scan tick. Result is
+	// hydrated with items + thresholds.
+	ListWithThresholds(ctx context.Context, livemode bool, limit int) ([]domain.Subscription, error)
+
 	// ActivateAfterTrial atomically transitions a subscription from
 	// 'trialing' to 'active'. Sets activated_at = `at` if the column is
 	// still NULL (preserves the original activation timestamp on

--- a/internal/subscription/wire_shape_test.go
+++ b/internal/subscription/wire_shape_test.go
@@ -1,0 +1,183 @@
+package subscription
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// TestWireShape_SnakeCase pins the JSON contract for billing-thresholds
+// PATCH/GET surfaces. The cost dashboard's "Billing Thresholds" panel
+// reads these keys directly; drift here (drop a json:"…" tag, or an
+// empty slice marshalling as null) breaks the frontend at runtime, so
+// we marshal the input + domain shapes and assert:
+//
+//   - Every documented snake_case key is present at the right level.
+//   - No PascalCase keys leak through (json tag dropped off a field).
+//   - usage_gte round-trips as a JSON string per ADR-005 — meter
+//     quantities can be fractional NUMERIC(38,12) and JSON numbers
+//     would lose precision on large values.
+//   - item_thresholds[] marshals as a JSON array even when empty,
+//     so the UI can iterate without a null guard.
+//
+// This is the merge gate for /v1/subscriptions/{id}/billing-thresholds.
+// See docs/design-billing-thresholds.md.
+func TestWireShape_SnakeCase(t *testing.T) {
+	t.Run("BillingThresholdsInputFullyPopulated", func(t *testing.T) {
+		reset := true
+		body := BillingThresholdsInput{
+			AmountGTE:         500000,
+			ResetBillingCycle: &reset,
+			ItemThresholds: []ItemThresholdInput{
+				{
+					SubscriptionItemID: "vlx_subitem_abc",
+					UsageGTE:           "1000000.123456",
+				},
+			},
+		}
+
+		blob, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		topLevel := []string{"amount_gte", "reset_billing_cycle", "item_thresholds"}
+		for _, k := range topLevel {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("input missing %q (raw keys=%v)", k, mapKeys(raw))
+			}
+		}
+		// PascalCase leak guard
+		for _, k := range []string{"AmountGTE", "ResetBillingCycle", "ItemThresholds"} {
+			if _, ok := raw[k]; ok {
+				t.Errorf("input leaked PascalCase key %q", k)
+			}
+		}
+
+		items, ok := raw["item_thresholds"].([]any)
+		if !ok {
+			t.Fatalf("item_thresholds must marshal as array, got %T", raw["item_thresholds"])
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 item threshold, got %d", len(items))
+		}
+		it0, ok := items[0].(map[string]any)
+		if !ok {
+			t.Fatalf("item_thresholds[0] not an object: %T", items[0])
+		}
+		for _, k := range []string{"subscription_item_id", "usage_gte"} {
+			if _, ok := it0[k]; !ok {
+				t.Errorf("item_thresholds[0] missing %q (keys=%v)", k, mapKeys(it0))
+			}
+		}
+		// usage_gte on input is the JSON string form (decimal NUMERIC).
+		if uStr, isString := it0["usage_gte"].(string); !isString {
+			t.Errorf("usage_gte must marshal as JSON string on input, got %T", it0["usage_gte"])
+		} else if uStr != "1000000.123456" {
+			t.Errorf("usage_gte precision lost: got %q want %q", uStr, "1000000.123456")
+		}
+	})
+
+	t.Run("DomainBillingThresholdsRoundTrip", func(t *testing.T) {
+		// What gets returned from GET /subscriptions/{id} after a PATCH
+		// — domain.BillingThresholds is what hydrates onto the row and
+		// is rendered to the dashboard. Same snake_case, same always-array
+		// idiom for item_thresholds, same string-precision usage_gte.
+		bt := domain.BillingThresholds{
+			AmountGTE:         500000,
+			ResetBillingCycle: true,
+			ItemThresholds: []domain.SubscriptionItemThreshold{
+				{
+					SubscriptionItemID: "vlx_subitem_abc",
+					UsageGTE:           decimal.RequireFromString("1000000.123456"),
+				},
+			},
+		}
+
+		blob, err := json.Marshal(bt)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		for _, k := range []string{"amount_gte", "reset_billing_cycle", "item_thresholds"} {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("billing_thresholds missing %q (keys=%v)", k, mapKeys(raw))
+			}
+		}
+		for _, k := range []string{"AmountGTE", "ResetBillingCycle", "ItemThresholds"} {
+			if _, ok := raw[k]; ok {
+				t.Errorf("billing_thresholds leaked PascalCase key %q", k)
+			}
+		}
+
+		items, ok := raw["item_thresholds"].([]any)
+		if !ok {
+			t.Fatalf("item_thresholds must marshal as JSON array, got %T", raw["item_thresholds"])
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 item threshold, got %d", len(items))
+		}
+		it0 := items[0].(map[string]any)
+		for _, k := range []string{"subscription_item_id", "usage_gte"} {
+			if _, ok := it0[k]; !ok {
+				t.Errorf("item_thresholds[0] missing %q (keys=%v)", k, mapKeys(it0))
+			}
+		}
+		// usage_gte on the domain type is decimal.Decimal which marshals
+		// as a string per shopspring/decimal MarshalJSON — same precision
+		// guarantee as the input shape.
+		uStr, isString := it0["usage_gte"].(string)
+		if !isString {
+			t.Errorf("domain usage_gte must marshal as JSON string, got %T", it0["usage_gte"])
+		} else if uStr != "1000000.123456" {
+			t.Errorf("usage_gte precision lost: got %q want %q", uStr, "1000000.123456")
+		}
+	})
+
+	t.Run("EmptyItemThresholdsArrayNotNull", func(t *testing.T) {
+		// When a tenant configures only an amount cap (no per-item caps),
+		// item_thresholds must still serialize as []. Empty-state UI
+		// iterates over the slice; null would crash.
+		bt := domain.BillingThresholds{
+			AmountGTE:         500000,
+			ResetBillingCycle: true,
+			ItemThresholds:    []domain.SubscriptionItemThreshold{},
+		}
+		blob, err := json.Marshal(bt)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(blob, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		arr, ok := raw["item_thresholds"].([]any)
+		if !ok {
+			t.Fatalf("item_thresholds must marshal as JSON array even when empty, got %T", raw["item_thresholds"])
+		}
+		if len(arr) != 0 {
+			t.Errorf("item_thresholds should be empty in this fixture, got %d", len(arr))
+		}
+	})
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -32,6 +32,20 @@ const entries: {
   },
   {
     date: '2026-04-26',
+    title: 'Billing thresholds — Stripe Tier 1 hard-cap mid-cycle finalize',
+    tag: 'feature',
+    body: 'PATCH /v1/subscriptions/{id}/billing-thresholds configures a per-subscription hard cap on the running cycle subtotal (amount_gte, integer cents) and/or per-item quantity caps (item_thresholds[] with usage_gte as a NUMERIC(38,12) decimal string). When usage pushes the running total past any configured cap, the engine emits an early-finalize invoice with billing_reason=threshold mid-cycle — same charge-and-dunning chain a natural-cycle invoice goes through, just before the period boundary. reset_billing_cycle (default true, matching Stripe) controls whether the cycle resets after fire so the next bill starts from fire-time, or whether the original cycle continues with residual usage.',
+    bullets: [
+      'Engine path reuses the create_preview previewWithWindow over the partial cycle — running subtotal is the same figure the cycle scan would bill (preview math == invoice math, by construction).',
+      'Per-item caps sum quantities across each item\'s plan meters via usage.AggregateByPricingRules — the same priority+claim LATERAL JOIN the cycle scan and customer-usage already use, so multi-dim tenants get the canonical aggregation.',
+      'Idempotency seam: a partial unique index on invoices(tenant, sub, billing_period_start) WHERE billing_reason=threshold makes a re-tick after a transient failure a no-op — the second insert lands on errs.ErrAlreadyExists and short-circuits without losing the row.',
+      'Skips terminal/trialing subs and pause_collection rows so the scan doesn\'t emit a draft that can\'t be charged. Webhook event subscription.threshold_crossed fires before the optional cycle reset.',
+      'Service rejects multi-currency subs at the handler layer (only layer with a PlanReader), terminal subs at the service layer, and foreign / duplicate / blank subscription_item_id and non-numeric / negative usage_gte across both — the store sees only validated input.',
+      '12 service-validation unit cases + 7 evaluateThresholds/ScanThresholds unit cases + 6 integration cases against real Postgres (amount-cross fires early, item-cross fires, re-tick idempotent, below-threshold no-fire, no-config-skipped, reset_billing_cycle=false) + 3 wire-shape cases on JSON contracts.',
+    ],
+  },
+  {
+    date: '2026-04-26',
     title: 'Create-preview endpoint — Stripe Tier 1 invoice.upcoming parity',
     tag: 'feature',
     body: 'POST /v1/invoices/create_preview returns the same totals the cycle scan would bill — without writing a row. Multi-dim aware by construction: the preview path runs through usage.AggregateByPricingRules (LATERAL JOIN with priority + claim across the five aggregation modes), so a meter with cached-input vs uncached vs output rules previews into the same buckets the invoice will land in. Mounted under PermInvoiceRead. Both the in-app debug surface (/v1/billing/preview/{id}) and the new Tier 1 surface return one shape so TypeScript clients and dashboards share one type.',


### PR DESCRIPTION
## Summary
- Stripe Tier 1 parity feature: `subscription.billing_thresholds` configures a per-subscription hard cap on running cycle subtotal (`amount_gte`, integer cents) and/or per-item quantity caps (`item_thresholds[]` with `usage_gte` as a NUMERIC(38,12) decimal string).
- When usage pushes the running total past any configured cap, the engine emits an early-finalize invoice with `billing_reason='threshold'` mid-cycle — same charge-and-dunning chain a natural-cycle invoice goes through, just before the period boundary.
- `reset_billing_cycle` (default true, matching Stripe) controls cycle reset after fire.
- Reuses `previewWithWindow` for running subtotal so preview math == invoice math by construction (same guarantee as create_preview). Per-item caps sum quantities across each item's plan meters via `usage.AggregateByPricingRules`.
- Idempotency seam: partial unique index on `invoices(tenant, sub, billing_period_start) WHERE billing_reason='threshold'` makes a re-tick after a transient failure a no-op.

## Wire shape (new endpoints)
- `PUT /v1/subscriptions/{id}/billing-thresholds` body `{amount_gte, reset_billing_cycle?, item_thresholds[]}` (snake_case, always-array, decimal-string `usage_gte`).
- `DELETE /v1/subscriptions/{id}/billing-thresholds` clears the configuration.
- Webhook event `subscription.threshold_crossed` dispatched on every fire, before optional cycle reset.

## Migration
- `0056_subscription_billing_thresholds`: two columns on `subscriptions`, new `subscription_item_thresholds` table with RLS, `billing_reason` column on `invoices` with CHECK constraint covering `'subscription_cycle' | 'subscription_create' | 'manual' | 'threshold' | NULL`, partial unique index for idempotency. Cycle-scan invoices now stamp `billing_reason='subscription_cycle'` so threshold isn't an outlier.

## Test plan
- [x] 12 unit cases on `Service.SetBillingThresholds` validation (empty body, negative amount, terminal sub, foreign / duplicate / blank `subscription_item_id`, non-numeric / negative `usage_gte`, default + explicit `reset_billing_cycle`).
- [x] 7 unit cases on `evaluateThresholds` + `ScanThresholds` (amount-cross, item-cross, below-amount, below-item, terminal-sub gate, paused-collection gate, no-candidates fast path).
- [x] 6 integration cases against real Postgres (amount-cross fires early with cycle reset, item-usage-cross fires, re-tick idempotent, below-threshold no-fire, no-config-skipped, reset_billing_cycle=false keeps cycle).
- [x] 3 wire-shape cases in `TestWireShape_SnakeCase` (input shape, domain shape, empty `item_thresholds[]` always-array).
- [x] All pre-existing tests pass (`go test ./... -short` and `go test -p 1 ./... -short=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)