### PR TITLE
feat(billing): billing alerts — Stripe Tier 1 threshold + webhook (Week 5d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,54 @@ Two surfaces mirror this file:
 
 ### Added
 
+- **Billing alerts — Stripe Tier 1 parity for "Billing Alerts"** (2026-04-26) —
+  the operator-configurable threshold surface that fires a webhook +
+  dashboard notification when a customer's cycle spend (or per-meter
+  usage) crosses a limit. Four endpoints: `POST /v1/billing/alerts` with
+  `{ title, customer_id, filter: { meter_id?, dimensions? }, threshold:
+  { amount_gte? | usage_gte? }, recurrence: "one_time" | "per_period" }`,
+  `GET /v1/billing/alerts/{id}`, `GET /v1/billing/alerts?customer_id=…
+  &status=…&limit=…&offset=…`, and `POST /v1/billing/alerts/{id}/archive`
+  for soft-disable. Mounted under `PermInvoiceRead` / `PermInvoiceWrite`
+  at `/v1/billing/alerts`; the path is registered before `/billing` so
+  chi picks the more-specific pattern. A background evaluator (interval
+  configurable via `VELOX_BILLING_ALERTS_INTERVAL`) leader-elects via
+  Postgres advisory lock `LockKeyBillingAlertEvaluator`, scans armed
+  alerts via the partial index `idx_billing_alerts_evaluator` (predicate
+  `status IN ('active','triggered_for_period')`), aggregates the
+  customer's current cycle through the same `AggregateByPricingRules`
+  LATERAL JOIN the cycle scan and customer-usage already use (so
+  alert-firing math == invoice math by construction), and on threshold
+  cross fires a `billing.alert.triggered` webhook through the outbox in
+  the same tx as the trigger insert + alert state mutation — the
+  `UNIQUE (alert_id, period_from)` index gives per-period idempotency
+  across replica races and evaluator retries. `recurrence: one_time`
+  transitions to a terminal `triggered` status; `recurrence:
+  per_period` transitions to `triggered_for_period` and re-arms when
+  the next cycle begins. Wire shape is snake_case throughout
+  (regression-gated by `TestWireShape_SnakeCase`), `dimensions` is
+  always-object `{}` (no null guard needed in dashboard rendering),
+  `threshold` always emits both `amount_gte` and `usage_gte` keys with
+  one as `null`, and `usage_gte` is decimal-as-string per ADR-005
+  (NUMERIC(38,12) round-trip preserved). Service-layer validation
+  enforces title required + ≤200 chars, recurrence in
+  `{one_time, per_period}`, exactly one threshold field set with
+  amount > 0 / quantity > 0, dimensions only valid when meter_id is set,
+  ≤ 16 dimension keys, scalar values only (string / number / bool).
+  Two new mode-aware tables (`billing_alerts`, `billing_alert_triggers`)
+  ship with the standard tenant + livemode RLS policy from migration
+  0020 and the BEFORE INSERT livemode-from-session trigger from
+  migration 0021 (added to the regression list in
+  `TestRLSIsolation_AllModeAwareTablesHaveLivemodePredicate`). Tests:
+  24 unit cases (handler validation table, service validation table,
+  evaluator dimension-match / should-fire / primary-sub-pick tables,
+  payload-build, meter-aggregation map) plus 9 integration cases
+  against real Postgres (one-time-fire, per-period-fire-and-rearm,
+  double-fire-idempotent, archived-skipped, below-threshold-no-fire,
+  no-subscription-warning, multi-tenant-isolation,
+  atomicity-on-rollback verifying the alert-state-update is rolled
+  back when outbox enqueue fails, RLS isolation). Migration 0057.
+
 - **Create-preview endpoint — Stripe Tier 1 parity for `Invoice.upcoming`** (2026-04-26) —
   the third flagship developer-experience surface alongside customer-usage
   and recipes (per `docs/design-create-preview.md`, `docs/positioning.md`

--- a/cmd/velox/main.go
+++ b/cmd/velox/main.go
@@ -191,6 +191,19 @@ func serve() {
 		}()
 	}
 
+	// Billing alerts evaluator: scans armed alerts on a tick, fires
+	// `billing.alert.triggered` via the webhook outbox atomically with
+	// the alert state mutation. Leader-gated by
+	// LockKeyBillingAlertEvaluator so multi-replica deploys don't
+	// double-emit. See docs/design-billing-alerts.md.
+	if server.BillingAlertEvaluator != nil {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			server.BillingAlertEvaluator.Start(ctx)
+		}()
+	}
+
 	go func() {
 		slog.Info("listening", "addr", srv.Addr)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/docs/design-billing-alerts.md
+++ b/docs/design-billing-alerts.md
@@ -1,0 +1,432 @@
+# Billing Alerts — Technical Design
+
+> **Status:** Draft v1
+> **Owner:** Track A
+> **Last revised:** 2026-04-26
+> **Implementation window:** Week 5d of `docs/90-day-plan.md`
+> **Related:** `docs/design-create-preview.md` (sibling — same composition + always-array conventions), `docs/design-customer-usage.md` (the read surface alerts evaluate against), `docs/design-multi-dim-meters.md` (Week 2 dependency — `usage.AggregateByPricingRules` is the trigger evaluator's engine), `docs/positioning.md` pillar 1.4 (cost transparency)
+
+## Motivation
+
+Stripe ships [Billing Alerts](https://stripe.com/docs/billing/alerts) as a Tier 1 surface — operators set "alert me when this customer's bill exceeds $X this cycle" and the system fires a webhook + dashboard notification when usage crosses the threshold. AI tenants in particular ask for this constantly because per-token spend can scale unexpectedly and a slow Slack alert prevents an unbounded bill before the cycle closes. Velox already has the read surfaces (`/v1/customers/{id}/usage`, `/v1/invoices/create_preview`) and the durable webhook outbox; alerts are the orchestration layer that turns them into proactive notifications.
+
+This slice ships:
+
+1. **Alerts CRUD** — `POST /v1/billing/alerts` to create, `GET /v1/billing/alerts/{id}` to read one, `GET /v1/billing/alerts` to list with filters, `POST /v1/billing/alerts/{id}/archive` to soft-disable.
+2. **Trigger evaluator** — a background goroutine that scans active alerts, evaluates each against `usage.AggregateByPricingRules` for the customer's current cycle, and emits `billing.alert.triggered` via the webhook outbox once the threshold crosses.
+3. **Recurrence semantics** — `one_time` alerts fire once per alert lifetime; `per_period` alerts fire once per billing cycle and reset on the cycle boundary so the operator gets a fresh signal each month.
+4. **Atomic emission** — the alert's state mutation (status flip + trigger row insert) and the outbox enqueue happen in the same Postgres tx so a partial commit can't leave a webhook with no audit trail or vice versa.
+
+The dashboard consumer is the existing CostDashboard's notifications panel; it polls `GET /v1/billing/alerts?customer_id=…&status=triggered` to surface unread alerts inline. Track B will follow up with a "Set alert" button on the cost dashboard that mints the alert via this endpoint.
+
+## Goals
+
+- **Stripe Tier 1 parity** for the simple "alert me at $X" use case. Threshold is either dollar-cents (`amount_gte`) or raw quantity (`usage_gte`) — both are common ("alert at $50 spent" vs "alert at 1M tokens consumed").
+- **Customer-scoped first**. v1 alerts are always tied to a `customer_id`; tenant-wide ("alert me when ANY customer crosses $1000 this cycle") is a separate, more-complex surface — defer.
+- **Optional meter scope**. An alert can target one specific meter (`filter.meter_id`) or aggregate across all meters on the customer's plan (omit `filter.meter_id`). Single-meter alerts evaluate against that meter's rule resolution; cross-meter alerts evaluate against the customer's total amount across the cycle (same number `customer-usage` reports).
+- **Optional dimension filter**. Multi-dim meters (Week 2) let pricing rules carry `dimension_match` — alerts can narrow further: "alert me when GPT-4 input token spend on customer X exceeds $50". Implemented as a strict-superset match on rule `dimension_match`.
+- **Reliable emission via outbox**. Trigger evaluation reads, decides to fire, mutates state and enqueues the webhook all inside one tx. If the tx rolls back, no webhook fires; if it commits, the dispatcher will eventually deliver. Same atomicity contract every other event-emitting domain uses.
+- **Idempotent recurrence**. `per_period` alerts emit at most one event per (alert, cycle) — even across crashes / replica failovers / replays of the evaluator. The trigger row's UNIQUE constraint on `(alert_id, period_from)` is the source of truth.
+- **Always-array / always-object wire shape**. Same conventions as customer-usage and create_preview — `alerts[]` is a JSON array even when empty; `dimension_match` is a JSON object even when empty (the rule's "match anything" identity); decimals serialize as JSON strings.
+
+## Non-goals (deferred)
+
+- **Tenant-wide alerts.** Stripe has them; we don't (yet). The use case is real but the evaluator topology is different (one alert vs N customers; needs cross-customer LATERAL JOINs); ship customer-scoped first to validate the contract.
+- **Multi-recipient alerts / Slack / SMS.** v1 emits a webhook + a dashboard notification. The tenant wires their own Slack via the outbound webhook (their server consumes `billing.alert.triggered` and posts to whatever notification channel they want). v2 may add direct-Slack as a sugar layer.
+- **Threshold ramps / multi-tier alerts.** "Alert me at $50, then again at $100, then again at $200" is one alert with multiple thresholds in Stripe's surface. v1 is one alert = one threshold; an operator who wants three thresholds creates three alerts. Cleaner shape, fewer footguns.
+- **Forecasting alerts.** "Alert me when projected end-of-cycle bill > $X" requires the full `create_preview` path; v1 only fires on observed usage. Deferred to v2 once create_preview is dashboard-stable. Same data, different trigger condition — a one-line evaluator change when we get there.
+- **Backfill triggers.** When an alert is created mid-cycle and the customer is already past the threshold, v1 fires immediately on the next evaluator tick (≤ 5 min). It does NOT replay historical "would have fired N hours ago" events — operators creating an alert mid-cycle accept the as-of-now interpretation.
+- **Per-alert rate limiting.** A `per_period` alert only fires once per cycle by construction, so spam isn't possible. We don't need a separate rate-limit knob.
+
+## API surface
+
+> **Wire-contract conventions** (consistent with `/v1/*`, see `docs/design-customer-usage.md`):
+>
+> - **Snake-case JSON keys**, struct-tag enforced.
+> - **Customer/meter/alert identity = ID** (`vlx_cus_…`, `vlx_mtr_…`, `vlx_alrt_…`).
+> - **Empty arrays are `[]`**, never `null`.
+> - **Empty objects are `{}`**, never `null` (e.g. `dimensions`).
+> - **Decimals are JSON strings** per ADR-005 (`"1234567.000000000000"`).
+> - **Cents are integers**.
+> - **Recurrence enum:** `one_time` | `per_period`.
+> - **Status enum:** `active` (armed, awaiting threshold) | `triggered` (one_time, fired and done) | `triggered_for_period` (per_period, fired this cycle, will rearm next cycle) | `archived` (soft-disabled by operator).
+> - **Threshold mode:** exactly one of `amount_gte` (integer cents) or `usage_gte` (decimal-string quantity). Both null → 422; both non-null → 422.
+
+### `POST /v1/billing/alerts`
+
+Creates an alert.
+
+```http
+POST /v1/billing/alerts
+Authorization: Bearer <secret_key>
+Content-Type: application/json
+
+{
+  "title": "GPT-4 cost cap for ACME",
+  "customer_id": "vlx_cus_abc123",
+  "filter": {
+    "meter_id": "vlx_mtr_tokens",
+    "dimensions": { "model": "gpt-4", "operation": "input" }
+  },
+  "threshold": {
+    "amount_gte": 50000
+  },
+  "recurrence": "per_period"
+}
+```
+
+Request body:
+- `title` (string, required, ≤ 200 chars) — display name for the dashboard.
+- `customer_id` (string, required) — RLS-scoped; cross-tenant IDs surface as 404.
+- `filter` (object, optional):
+  - `filter.meter_id` (string, optional) — when set, the alert evaluates only that meter's resolved spend. When omitted, the alert evaluates against the customer's total cycle spend (sum across all meters).
+  - `filter.dimensions` (object, optional) — strict-superset match against rule `dimension_match`. Only meaningful when `filter.meter_id` is set (cross-meter dimension filtering doesn't have a well-defined evaluator). Empty object `{}` is equivalent to omitted.
+- `threshold` (object, required) — exactly one of:
+  - `threshold.amount_gte` (integer cents) — fires when observed amount-cents ≥ this. Currency is implicit from the customer's billing profile (or first rated rule's currency for cross-meter alerts).
+  - `threshold.usage_gte` (decimal-string quantity) — fires when observed quantity ≥ this. Only meaningful with a `filter.meter_id`; rejected with 422 otherwise (cross-meter quantity sums are not well-defined when meters have different units).
+- `recurrence` (string, required) — `one_time` or `per_period`.
+
+Response `201`:
+
+```json
+{
+  "id": "vlx_alrt_xyz789",
+  "title": "GPT-4 cost cap for ACME",
+  "customer_id": "vlx_cus_abc123",
+  "filter": {
+    "meter_id": "vlx_mtr_tokens",
+    "dimensions": { "model": "gpt-4", "operation": "input" }
+  },
+  "threshold": {
+    "amount_gte": 50000,
+    "usage_gte": null
+  },
+  "recurrence": "per_period",
+  "status": "active",
+  "last_triggered_at": null,
+  "last_period_start": null,
+  "created_at": "2026-04-26T12:00:00Z",
+  "updated_at": "2026-04-26T12:00:00Z"
+}
+```
+
+Notes on the response:
+- `threshold.amount_gte` and `threshold.usage_gte` are both always present (one is null) — the always-object idiom lets clients read both without conditional indexing.
+- `filter.dimensions` is always an object (`{}` when no filter) per always-object idiom.
+- `last_triggered_at` and `last_period_start` are null until the alert fires for the first time.
+
+### `GET /v1/billing/alerts/{id}`
+
+Reads a single alert. Same response shape as create. 404 if not found (RLS hides cross-tenant IDs by construction).
+
+### `GET /v1/billing/alerts`
+
+Lists alerts. Optional query params:
+
+- `customer_id` (string) — filter to one customer.
+- `status` (string) — filter to one status (`active`, `triggered`, `triggered_for_period`, `archived`).
+- `limit` (int, default 50, max 200) — pagination cap.
+- `offset` (int, default 0).
+
+Response `200`:
+
+```json
+{
+  "data": [
+    { ...alert object... },
+    { ...alert object... }
+  ],
+  "total": 7
+}
+```
+
+Standard list-envelope shape (`data` + `total`) used by every paginated `/v1/*` surface. Empty result is `data: []` not null.
+
+### `POST /v1/billing/alerts/{id}/archive`
+
+Soft-disables an alert. The alert's `status` flips to `archived`; the evaluator skips archived alerts on every subsequent tick. Idempotent — archiving an already-archived alert returns the same shape with no error.
+
+Response `200` is the updated alert object.
+
+### Error shapes
+
+- `400 invalid_request` — body unparseable, malformed JSON.
+- `422 validation_error` (with `param`) — required field missing (`title`, `customer_id`, `recurrence`, `threshold`), threshold has both / neither of (`amount_gte`, `usage_gte`), `usage_gte` set without `filter.meter_id`, unknown `recurrence` value, `dimensions` value not a scalar.
+- `404 not_found` — `customer_id` doesn't exist for this tenant; `meter_id` doesn't exist; alert ID on read/archive doesn't exist.
+- `409 already_exists` — not used in v1; alerts have no unique business key.
+
+## Webhook payload
+
+When the evaluator fires, it enqueues a `billing.alert.triggered` event into `webhook_outbox` inside the same tx that flips the alert's status:
+
+```json
+{
+  "id": "evt_…",
+  "type": "billing.alert.triggered",
+  "data": {
+    "alert_id": "vlx_alrt_xyz789",
+    "customer_id": "vlx_cus_abc123",
+    "title": "GPT-4 cost cap for ACME",
+    "threshold": {
+      "amount_gte": 50000,
+      "usage_gte": null
+    },
+    "observed": {
+      "amount_cents": 51234,
+      "quantity": "1234567.000000000000"
+    },
+    "currency": "usd",
+    "triggered_at": "2026-04-26T14:23:01Z",
+    "period": {
+      "from": "2026-04-01T00:00:00Z",
+      "to":   "2026-05-01T00:00:00Z",
+      "source": "current_billing_cycle"
+    },
+    "filter": {
+      "meter_id": "vlx_mtr_tokens",
+      "dimensions": { "model": "gpt-4", "operation": "input" }
+    },
+    "recurrence": "per_period"
+  }
+}
+```
+
+Snake-case throughout. `observed.amount_cents` and `observed.quantity` are both populated — the receiver doesn't need to know which threshold the alert was set on. `currency` is lower-case (matches Stripe convention and the rest of Velox's emitted events).
+
+`period.source` mirrors the customer-usage convention: `current_billing_cycle` when derived from the customer's primary active subscription. `filter.dimensions` is always an object (`{}` when no dimension filter) per always-object idiom.
+
+## Schema
+
+```sql
+CREATE TABLE billing_alerts (
+    id                   TEXT PRIMARY KEY DEFAULT 'vlx_alrt_' || encode(gen_random_bytes(12), 'hex'),
+    tenant_id            TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    customer_id          TEXT NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+    title                TEXT NOT NULL,
+    meter_id             TEXT REFERENCES meters(id) ON DELETE SET NULL,
+    dimensions           JSONB NOT NULL DEFAULT '{}'::jsonb,
+    threshold_amount_cents BIGINT,
+    threshold_quantity   NUMERIC(38,12),
+    recurrence           TEXT NOT NULL CHECK (recurrence IN ('one_time','per_period')),
+    status               TEXT NOT NULL DEFAULT 'active'
+                              CHECK (status IN ('active','triggered','triggered_for_period','archived')),
+    last_triggered_at    TIMESTAMPTZ,
+    last_period_start    TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- exactly one threshold field set
+    CHECK ( (threshold_amount_cents IS NOT NULL)::int + (threshold_quantity IS NOT NULL)::int = 1 )
+);
+
+CREATE INDEX idx_billing_alerts_tenant_customer
+    ON billing_alerts (tenant_id, customer_id, status);
+CREATE INDEX idx_billing_alerts_evaluator
+    ON billing_alerts (status)
+    WHERE status IN ('active','triggered_for_period');
+
+CREATE TABLE billing_alert_triggers (
+    id                  TEXT PRIMARY KEY DEFAULT 'vlx_atrg_' || encode(gen_random_bytes(12), 'hex'),
+    tenant_id           TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    alert_id            TEXT NOT NULL REFERENCES billing_alerts(id) ON DELETE CASCADE,
+    period_from         TIMESTAMPTZ NOT NULL,
+    period_to           TIMESTAMPTZ NOT NULL,
+    observed_amount_cents BIGINT NOT NULL,
+    observed_quantity   NUMERIC(38,12) NOT NULL DEFAULT 0,
+    currency            TEXT NOT NULL,
+    triggered_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (alert_id, period_from)
+);
+```
+
+Both tables enable RLS via the standard pattern (`current_setting('app.bypass_rls', …) = 'on' OR tenant_id = current_setting('app.tenant_id', …)`).
+
+The `UNIQUE (alert_id, period_from)` constraint on `billing_alert_triggers` is the per-period idempotency contract — two replicas racing the evaluator can both attempt to insert; one wins, the other gets a unique-violation that the evaluator catches and treats as "already fired this period, skip".
+
+The partial index `idx_billing_alerts_evaluator` keeps the evaluator's hot scan tight: archived alerts and one_time alerts that already fired are excluded by predicate, so the evaluator only walks rows that could plausibly fire.
+
+## Trigger evaluation
+
+The evaluator runs on a 5-minute tick (configurable via `VELOX_BILLING_ALERTS_INTERVAL`, default `5m` in local / `1m` in production for fast operator feedback). Each tick:
+
+1. **Acquire advisory lock** (`LockKeyBillingAlertEvaluator`). One leader runs the evaluator across the cluster; followers skip silently.
+2. **Per livemode** (live, then test): fan out so the evaluator sees both partitions correctly under RLS.
+3. **List candidate alerts**: `SELECT … FROM billing_alerts WHERE status IN ('active','triggered_for_period')`. For `triggered_for_period` rows, the evaluator additionally checks if the customer's current cycle has rolled past `last_period_start` — if so, transition back to `active` (rearm) and re-evaluate this tick.
+4. **Per alert**: open a tenant-scoped tx, evaluate the threshold, decide whether to fire.
+5. **Evaluate**: resolve the customer's current cycle (primary active subscription), call `usage.AggregateByPricingRules` for the meter (or all meters in the plan if no `meter_id`), filter by `dimensions` (strict-superset on rule `dimension_match`), sum `amount_cents` and `quantity`. Compare against threshold.
+6. **Fire (in tx)**: insert the trigger row (UNIQUE (alert_id, period_from) handles idempotency), flip the alert status (`triggered` for one_time / `triggered_for_period` for per_period), set `last_triggered_at` + `last_period_start`, enqueue `billing.alert.triggered` in `webhook_outbox`. Commit.
+7. **No-fire**: continue to next alert; nothing persists. The evaluator is read-only on the no-fire path.
+8. **Errors per alert**: log + continue. One bad alert (e.g. customer was deleted concurrently, sub has no cycle) doesn't block the rest.
+
+### Recurrence semantics
+
+- **`one_time`**: status `active` → `triggered` on first fire. Stays `triggered` forever (until archived). The evaluator's hot scan excludes `triggered` rows via the partial index, so a one_time alert that fired is invisible to the evaluator on subsequent ticks.
+- **`per_period`**: status `active` → `triggered_for_period` on first fire of the cycle. On the next evaluator tick where the customer's `current_billing_period_start > alerts.last_period_start`, the evaluator transitions the alert back to `active` and immediately re-evaluates against the new cycle (so the operator gets a fresh signal as soon as the threshold is crossed in the new cycle). The cycle-rollover detection is part of the evaluator, not a scheduled cron, so it works correctly even when ticks are sparse or skipped.
+
+### Atomicity contract
+
+Within the per-alert tx (step 6 above), three operations happen:
+1. INSERT `billing_alert_triggers` row.
+2. UPDATE `billing_alerts` (status, last_triggered_at, last_period_start, updated_at).
+3. INSERT `webhook_outbox` row via `OutboxStore.Enqueue(ctx, tx, …)`.
+
+Either all three commit together or none commit. A crash mid-tx rolls back everything; the next tick re-evaluates and re-fires (the UNIQUE constraint guarantees we don't double-emit on retry). A crash AFTER commit but before the outbox dispatcher delivers leaves the row pending in `webhook_outbox` — the dispatcher retries until delivery succeeds (or DLQs after 15 attempts).
+
+### Multi-replica safety
+
+Two safeguards prevent double-fire:
+- **Advisory lock at the evaluator level** (`LockKeyBillingAlertEvaluator`). One leader wins the tick; followers skip. Same pattern as the billing scheduler.
+- **UNIQUE constraint at the trigger-row level**. If two replicas somehow race past the lock (e.g. lock contention edge case during failover), the second INSERT into `billing_alert_triggers` violates UNIQUE (alert_id, period_from), the tx rolls back, and no double-emission occurs.
+
+### Edge cases
+
+- **Customer deleted**: the FK is `ON DELETE CASCADE`, so customer deletion drops the alert and its trigger rows. No orphan emission.
+- **Subscription canceled**: the customer has no current cycle. The evaluator logs a warning and skips. Alert stays `active` indefinitely until either the customer re-subscribes (alert wakes up) or the operator archives it.
+- **Multi-currency customer**: rare today but real for cross-region tenants. The evaluator computes per-currency totals and compares the threshold against the FIRST currency seen (typically the customer's billing profile currency). v1 doesn't try to convert; "alert me at $50" on a customer with a EUR sub will compare 50 cents to the EUR amount as if they're the same unit. Documented limitation; refine in v2 once a real consumer asks.
+- **Alert created mid-cycle, customer already past threshold**: fires on next tick (≤ 5 min after creation). No replay; the as-of-now observed amount is what gets emitted.
+- **Pricing rules change mid-cycle**: the alert evaluates against current rule resolution. Historical events get retroactively re-rated under the new rules (this is how `AggregateByPricingRules` works); the alert reflects whatever the dashboard reflects.
+- **Test-mode alerts**: live and test alerts are independent (RLS-partitioned via `tenant_id` plus livemode tagged on the outbox row). Test-mode subscriptions can fire alerts that emit to test-mode webhook endpoints.
+
+## Internals
+
+### Composition
+
+```go
+// internal/billingalert/service.go (sketch)
+type Service struct {
+    store Store
+}
+
+func (s *Service) Create(ctx context.Context, tenantID string, req CreateRequest) (domain.BillingAlert, error) {
+    // validate, RLS-write, emit billing.alert.created? (not v1; create is a quiet op)
+}
+
+func (s *Service) Archive(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+    // tenant-scoped tx, flip status to archived
+}
+```
+
+```go
+// internal/billingalert/evaluator.go (sketch)
+type Evaluator struct {
+    store         Store
+    customers     CustomerLookup       // narrow interface
+    subscriptions SubscriptionLister   // narrow interface
+    pricing       PricingReader        // narrow interface
+    usage         *usage.Service       // for AggregateByPricingRules
+    outbox        OutboxEnqueuer       // narrow interface — Enqueue(ctx, tx, ...)
+    locker        Locker
+    interval      time.Duration
+    clock         clock.Clock
+}
+
+func (e *Evaluator) RunOnce(ctx context.Context) {
+    // acquire advisory lock; per livemode fan-out; list candidate alerts;
+    // per alert, open tx, evaluate, fire-or-skip, commit.
+}
+```
+
+The narrow-interface pattern mirrors customer-usage and create-preview. No direct cross-domain imports — `billingalert` depends only on:
+- `internal/domain` for shared types
+- `internal/errs` for error envelope
+- `internal/usage.Service` for `AggregateByPricingRules` (peer-package okay; usage is the canonical aggregation engine)
+- narrow interfaces (`CustomerLookup`, `SubscriptionLister`, `PricingReader`, `OutboxEnqueuer`) satisfied by other packages without cross-importing them.
+
+### RLS
+
+Every store method opens a tenant-scoped tx via `db.BeginTx(ctx, postgres.TxTenant, tenantID)`. The evaluator's per-alert tx is also tenant-scoped — it reads the alert under the alert's tenant context, so cross-tenant ID confusion (an evaluator pulling alert A's customer for alert B's tenant) is impossible by construction.
+
+Cross-tenant 404s surface naturally: the customer lookup inside `Service.Create` opens a TxTenant scoped to the calling tenant, so a request body specifying a customer ID that belongs to a different tenant returns ErrNotFound. The handler maps that to 404.
+
+### Wire shape
+
+The handler decoupling is identical to create-preview: a wire-shape struct with snake-case JSON tags, a service-shape struct that exposes Go-typed fields, and a `decode*Request` helper that translates one to the other. This keeps the JSON contract pinned by struct tags and the service signature ergonomic.
+
+The wire-shape regression test (`TestWireShape_SnakeCase`) marshals a fully-populated `domain.BillingAlert` plus a fully-populated webhook payload and asserts:
+- All snake_case keys present.
+- No PascalCase leaks.
+- `dimensions` marshals as JSON object even when empty.
+- `threshold.amount_gte` and `threshold.usage_gte` are both present (one null).
+- `data` arrays in list responses are `[]` not null when empty.
+
+## Tests
+
+### Unit tests
+
+- `Service.Create` — table-driven: missing title / customer_id / recurrence → 422 with field; both thresholds set → 422; usage_gte without meter_id → 422; happy path returns alert with `status='active'`.
+- `Service.Archive` — already-archived returns same shape (idempotent); not-found returns 404; cross-tenant returns 404.
+- `Service.List` — filter by customer_id; filter by status; pagination clamps.
+- `Evaluator.evaluateAmount` — table-driven against fake usage data: below threshold no fire; at threshold fire; above threshold fire; multi-currency mismatch logs warning.
+- `Evaluator.dimensionsMatch` — strict-superset semantics: rule's match must contain all alert filter keys with equal values; missing key fails; extra key on rule passes.
+- `Evaluator.shouldRearm` — per_period alerts whose `last_period_start` is older than the customer's current `current_billing_period_start` flip back to `active`.
+- **`TestWireShape_SnakeCase` (the merge gate)**: marshal a fully-populated `domain.BillingAlert` and webhook payload; assert all snake_case keys present; no PascalCase leaks; `dimensions` is `{}` not null when empty.
+
+### Integration tests (real Postgres)
+
+- `TestCreateAlert_Persist` — create via service; read via store; assert all fields round-trip including `dimensions` JSONB.
+- `TestCreateAlert_RLS` — tenant B can't read tenant A's alert (404).
+- `TestEvaluator_FiresOnceForOneTime` — seed customer + sub + plan + meter + events past threshold; run evaluator; assert one trigger row, status=triggered, one outbox row with `billing.alert.triggered`. Run evaluator again; assert no new rows.
+- `TestEvaluator_FiresPerPeriodAndRearms` — seed; fire once; advance test clock past cycle boundary; assert evaluator transitions alert back to active and re-fires; assert two trigger rows with different `period_from`; two outbox rows.
+- `TestEvaluator_DoubleFireIdempotent` — manually insert a trigger row for the current period; run evaluator; assert no new outbox row (UNIQUE constraint catches the duplicate).
+- `TestEvaluator_ArchivedSkipped` — archive a triggered alert; advance clock; assert evaluator never re-fires it.
+- `TestEvaluator_DimensionFilter` — multi-dim meter; alert filters to `{model:"gpt-4"}`; events tagged gpt-3.5 don't count toward threshold; events tagged gpt-4 do.
+- `TestEvaluator_AtomicityOnRollback` — inject a webhook outbox failure (e.g. extreme payload size); assert both the trigger row insert AND the alert status update roll back together (no half-commit).
+- `TestEvaluator_NoSubscription` — customer has no active sub; assert evaluator logs warning and skips; alert stays active.
+- `TestEvaluator_MultiTenantIsolation` — two tenants, one alert each; assert each alert evaluates against its own tenant's events.
+
+### Wire-shape merge gate
+
+`TestWireShape_SnakeCase` lives in `internal/billingalert/wire_shape_test.go`. Same pattern as the create_preview merge gate — must pass before merge, blocks PR otherwise.
+
+## Migrations
+
+`0057_billing_alerts.up.sql` / `0057_billing_alerts.down.sql`. Number is sibling-aware: 0056 is reserved for the parallel billing-thresholds slice; 0057 is the next free slot for this work. **Do not** renumber locally — pick from `origin/main`'s latest, never the local branch.
+
+## Performance
+
+- Evaluator hot scan: indexed by partial index `idx_billing_alerts_evaluator` on `status IN ('active','triggered_for_period')`. Tenant with 1000 alerts (heavy) → 1000-row scan, tens of ms.
+- Per-alert evaluation: 1 customer lookup + 1 sub lookup + 1 `AggregateByPricingRules` call. Same cost envelope as customer-usage / create_preview. For typical sub (10K events / cycle): ~50ms. Tenant with 100 active alerts: ~5s end-to-end. 5-min tick is comfortable.
+- The advisory lock prevents two replicas duplicating the work. Lock contention is graceful: followers log Debug and return.
+- The outbox enqueue is one extra INSERT per fire; the dispatcher amortizes delivery cost across many events on its own tick. No extra round-trips on the evaluator's hot path.
+
+## Open questions
+
+1. **Should we ship a `GET /v1/billing/alerts/{id}/triggers` endpoint to list past trigger events?** Useful for an audit pane on the alert detail page. **Proposal: defer.** v1 emits via webhook + dashboard notification; the trigger history can be reconstructed from the customer's webhook delivery log if needed. Add when a real consumer asks (post-launch).
+2. **Should `filter.dimensions` be allowed without `filter.meter_id`?** Cross-meter dimension filtering ("alert when ANY meter spend with `region=us-east` exceeds $X") has a real use case but the evaluator topology is more complex (per-meter rule resolution, then per-meter dimension filter, then aggregate). **Proposal: reject in v1** with a clear error; ship if a real consumer asks.
+3. **Should we surface a "muted" status separate from "archived"?** Mute = pause for one cycle, then auto-rearm. Archive = soft-disable forever. Stripe has both. **Proposal: defer.** Operators can archive + recreate to mute; the audit trail (the trigger rows) is preserved across recreates. Add muted as a v2 nicety.
+4. **Should `recurrence: per_period` reset on the customer's cycle or on a calendar boundary (e.g. monthly UTC)?** **Proposal: customer's cycle.** A subscription anchored to the 15th of each month should fire alerts that follow that cycle, not the calendar month. This matches Stripe's semantics and the rest of the billing engine.
+5. **Should the evaluator interval be per-tenant configurable?** A high-spend tenant might want 1-min ticks; a low-volume one is fine with 30-min. **Proposal: defer.** Single global interval (5m local / 1m production) covers v1; per-tenant tuning is a v2 lever once we have data on usage patterns.
+6. **Should we persist the trigger row's outbox `event_id` for cross-reference?** Useful for debugging "did this alert's webhook get delivered". **Proposal: defer.** The webhook outbox is queryable on its own; cross-referencing via `event_type='billing.alert.triggered'` and matching `data.alert_id` is sufficient. Add a column if a real ops use case emerges.
+7. **Should we expose a way to test-fire an alert without waiting for real usage?** Useful for the operator to verify their webhook receiver is wired correctly. **Proposal: defer to v2** behind a separate `POST /v1/billing/alerts/{id}/test_fire` route gated to test-mode keys only. v1 operators can verify via Stripe's standard webhook-event replay UI on the dashboard.
+
+## Implementation checklist (Week 5d)
+
+- [ ] `docs/design-billing-alerts.md` — this RFC.
+- [ ] `internal/domain/billing_alert.go` — domain types (`BillingAlert`, `BillingAlertStatus`, `BillingAlertRecurrence`, `BillingAlertTrigger`, threshold helpers).
+- [ ] `internal/platform/migrate/sql/0057_billing_alerts.up.sql` + `.down.sql` — schema.
+- [ ] `internal/billingalert/store.go` — `Store` interface + `ListFilter`.
+- [ ] `internal/billingalert/postgres.go` — Postgres implementation.
+- [ ] `internal/billingalert/service.go` — Create / Get / List / Archive.
+- [ ] `internal/billingalert/handler.go` — chi router for the four endpoints.
+- [ ] `internal/billingalert/evaluator.go` — background evaluator with advisory lock.
+- [ ] `internal/billingalert/wire_shape_test.go` — `TestWireShape_SnakeCase` merge gate.
+- [ ] `internal/billingalert/service_test.go` — unit tests with fakes.
+- [ ] `internal/billingalert/evaluator_test.go` — unit tests for evaluator helpers.
+- [ ] `internal/billingalert/integration_test.go` — full-stack integration with real Postgres + outbox.
+- [ ] Add `EventBillingAlertTriggered = "billing.alert.triggered"` to `internal/domain/webhook_outbound.go`.
+- [ ] Add `LockKeyBillingAlertEvaluator int64 = 76540005` to `internal/platform/postgres/advisory_lock.go`.
+- [ ] Wire routes + evaluator goroutine in `internal/api/router.go` and `cmd/velox/main.go`.
+- [ ] Update `web-v2/src/lib/api.ts` — `BillingAlert` types + endpoint methods.
+- [ ] Update `CHANGELOG.md` (Track A) + `web-v2/src/pages/Changelog.tsx` (Track B).
+- [ ] Append entry to `docs/parallel-handoff.md`.
+
+## Track B unblock
+
+Track B can scaffold a "Set alert" CTA on the cost dashboard against the contract in this RFC, mocking the API client until the backend lands. The CTA opens a modal with title / threshold / recurrence inputs; on submit calls `POST /v1/billing/alerts`. The notifications panel polls `GET /v1/billing/alerts?customer_id=…&status=triggered_for_period,triggered` to surface any unread alerts inline.
+
+Same parallel-work pattern as recipes / customer-usage / create-preview: Track B mocks against this RFC, swaps to the real API at integration time.
+
+## Review status
+
+- **Track A author:** drafted 2026-04-26 alongside the implementation.
+- **Track B review:** pending — Track B can scaffold the alert-creation CTA against this design without waiting for further iteration.
+- **Human review:** pending — flag any open question to revisit.

--- a/docs/parallel-handoff.md
+++ b/docs/parallel-handoff.md
@@ -350,3 +350,53 @@ Track A merged PR #20 (multi-dim backend, 12 commits) into `main` at 18:25:30Z. 
 - **Open for human review:**
   - PR to be opened on `feat/backend-week5b-create-preview` once final commit lands.
 - **Next session (Track A):** drive PR to green, self-merge per authorization (CI green AND `TestWireShape_SnakeCase` in suite — both conditions met), then start Week 5/6 next blocker per 90-day plan.
+
+---
+
+## 2026-04-26 (Sun) — Track A: billing alerts (Week 5d)
+
+### Track A
+- **Branch:** `feat/backend-week5d-billing-alerts` in worktree `agent-a52ca468` (parallel slice; sibling worktree `agent-a42df1cd` shipping Week 5c billing thresholds, owns migration 0056).
+- **Goal:** ship Stripe Tier 1 "Billing Alerts" — operator-configurable thresholds that fire `billing.alert.triggered` over the existing webhook outbox + dashboard notification when a customer's cycle spend (or per-meter usage) crosses a limit. Atomic by construction: trigger insert + alert state mutation + outbox enqueue all commit in one tx; UNIQUE (alert_id, period_from) gives per-period idempotency across replica races.
+- **Shipped:**
+  - **Migration `0057_billing_alerts`** — two new mode-aware tables (`billing_alerts`, `billing_alert_triggers`), partial index `idx_billing_alerts_evaluator` on `status IN ('active','triggered_for_period')` to bound the per-tick scan, hot-read indexes for dashboard list (`tenant_id, customer_id, status`) and trigger-history (`alert_id, triggered_at DESC`). Standard tenant + livemode RLS policy, plus the BEFORE INSERT livemode-from-session trigger from migration 0021 wired to both new tables (regression entry added to `TestRLSIsolation_AllModeAwareTablesHaveLivemodePredicate`). Migration number coordinated with the parallel Week 5c agent that owns 0056 — both branches cleanly stack on `main` without conflict.
+  - **`internal/billingalert/`** — full new domain package: `domain.go` (BillingAlert, BillingAlertTrigger, BillingAlertStatus, BillingAlertRecurrence types), `service.go` (validation + Create/Get/List/Archive), `postgres.go` (Store impl with FireInTx for tx-passing across the evaluator commit boundary, ListCandidates under TxBypass for cross-tenant scan), `evaluator.go` (background goroutine with leader-election advisory lock `LockKeyBillingAlertEvaluator`, dimension-match logic, primary-subscription pick, threshold-cross detection, atomic fire path), `handler.go` (four /v1/billing/alerts endpoints with chi pattern precedence — `/{id}/archive` registered before `/{id}` so chi picks the more-specific route).
+  - **`internal/api/router.go` wiring** — new `BillingAlertEvaluator *billingalert.Evaluator` field on `Server`, full DI: store → service → handler → evaluator. Mount `/billing/alerts` BEFORE `/billing` so chi picks the more-specific pattern (otherwise `/billing/{id}` would catch `alerts` as an ID). Two new adapter types in `internal/api/adapters.go`: `billingAlertSubscriptionListerAdapter` (bridges `subscription.PostgresStore` → `billingalert.SubscriptionLister`) and `billingAlertLockerAdapter` (bridges `*postgres.DB` → `billingalert.Locker`). Evaluator interval configurable via `VELOX_BILLING_ALERTS_INTERVAL` env var.
+  - **`cmd/velox/main.go`** — evaluator goroutine spawn after the email dispatcher block, gated by `if server.BillingAlertEvaluator != nil` so test code that constructs partial servers still boots cleanly.
+  - **`internal/testutil/db.go`** — added `billing_alert_triggers, billing_alerts` to the TRUNCATE list in FK-safe order (between `webhook_endpoints` and `tenants`).
+  - **24 unit tests:**
+    - **`wire_shape_test.go` (the merge gate):** 5 sub-tests covering snake_case throughout, dimensions as always-object `{}`, threshold always emits both keys (one as null), `usage_gte` as decimal-as-string per ADR-005, no PascalCase leaks.
+    - **`service_test.go`:** table-driven validation (12 cases: title required + ≤200 chars, customer required, recurrence in `{one_time, per_period}`, threshold required, threshold-both-set rejection, amount > 0, quantity > 0, `usage_without_meter`, `dimensions_without_meter`, `dimensions_too_many_keys` (>16), `dimensions_non_scalar_value`); plus happy-path Create, customer-not-found, meter-not-found, list-status-validation, get-requires-id, archive-idempotent.
+    - **`evaluator_test.go`:** `TestDimensionsMatch` (12 cases — empty filter matches anything, exact match, subset match, JSON int-vs-float64 normalisation, bool match, etc.), `TestShouldFire` (7 cases — amount/quantity above/at/below thresholds, no-threshold-set), `TestPickPrimarySubscription` (4 cases — picks active + latest cycle, treats trialing as active, excludes canceled), `TestBuildEventPayload` (+ nil dimensions case), `TestEqualAny` (11 cases), `TestMapMeterAggregation` (6 cases).
+  - **9 integration tests against real Postgres (`integration_test.go`):**
+    - `TestEvaluator_FiresOnceForOneTime` — happy path: 100 events × qty=10 × 1¢ = 1000c crosses 500c threshold, fires once, transitions to terminal `triggered`, emits exactly 1 outbox row, second tick is a no-op.
+    - `TestEvaluator_FiresPerPeriodAndRearms` — fires in cycle 1, transitions to `triggered_for_period`, evaluator sees the next cycle's roll, re-arms to `active` and fires again on cross.
+    - `TestEvaluator_DoubleFireIdempotent` — UNIQUE (alert_id, period_from) catches the duplicate insert from a simulated replica race; the loser's tx rolls back cleanly with `ErrAlreadyFired`.
+    - `TestEvaluator_ArchivedSkipped` — partial index excludes archived; archived alert with crossed threshold doesn't fire.
+    - `TestEvaluator_BelowThresholdNoFire` — non-zero usage below cap is a no-op.
+    - `TestEvaluator_NoSubscription` — customer with no active sub surfaces a structured warning, doesn't fire.
+    - `TestEvaluator_MultiTenantIsolation` — two tenants with identical alerts don't cross-fire; each only sees its own customer's events.
+    - `TestEvaluator_AtomicityOnRollback` — `fakeOutbox` simulates an enqueue failure; assertion: trigger row NOT inserted (count unchanged), alert state NOT mutated. Proves the all-or-nothing tx contract.
+    - `TestCreateAlert_RLS` — tenant B's secret key against tenant A's customer ID 404s at the customer existence check.
+- **Decisions made inline (per `feedback_feat8_autonomy`):**
+  - **Bundle alert state + trigger insert + outbox enqueue in one tx** (over a saga). Single tx is the simplest correct semantics for "fire exactly once, with the webhook"; UNIQUE constraint plus tx-rollback gives both halves of the contract.
+  - **Bypass RLS for the evaluator's candidate scan** (`ListCandidates` under `TxBypass`). The evaluator is cross-tenant by design (one leader per cluster); the partial index keeps it bounded.
+  - **`Routes(read, write)` per-method middleware** (over a single `RequireAny([read, write])` middleware). `auth.RequireAny` doesn't exist; refactoring the auth package was out of scope. Per-method `r.With(read).Get(...)` matches the chi idiom and keeps per-route gating explicit.
+  - **`billingAlertLockerAdapter`** rather than reusing `billing.Locker` directly. The two `Locker` interfaces in different packages have different shapes (`Lock(ctx, key int64) (release func(), error)` vs `Lock(ctx, key int64, fn func(ctx) error) error`); the adapter is two lines of glue and avoids leaking domain dependencies between billing and billingalert.
+  - **Migration 0057 (skipping 0056)** because the parallel Week 5c agent (worktree `agent-a42df1cd`) owns 0056. Coordinated via `feedback_migration_numbering` discipline (pick next number from `origin/main`, not local branch — but in parallel-slice mode, picking the *next-next* number ensures both branches stack cleanly on main without conflict).
+- **Test status:**
+  - `go test -short ./...`: all packages pass (40+ packages green).
+  - `go test -p 1 ./internal/billingalert/... -short=false -count=1`: all 24 unit + 9 integration tests pass against real Postgres.
+  - `TestRLSIsolation_AllModeAwareTablesHaveLivemodePredicate` updated with `billing_alerts` + `billing_alert_triggers` and passes.
+  - `TestWireShape_SnakeCase` (the merge gate) passes.
+  - Note: shared `velox_test` DB across worktrees can race during concurrent test runs (the parallel Week 5c agent doing the same `go test -p 1`); failures of the form `relation "tenants" does not exist` are transient infrastructure when both agents run simultaneously, not code regressions. CI uses an isolated DB per job so won't hit this.
+- **`web-v2/src/lib/api.ts`** — new types (`BillingAlert`, `BillingAlertFilter`, `BillingAlertThreshold`, `CreateBillingAlertRequest`, `BillingAlertStatus`, `BillingAlertRecurrence`) plus four methods (`listBillingAlerts`, `getBillingAlert`, `createBillingAlert`, `archiveBillingAlert`). Snake_case throughout, dimensions typed as `Record<string, unknown>` to mirror the always-object shape, `usage_gte` typed as `string` to honor decimal-as-string.
+- **CHANGELOG.md** comprehensive entry at top of `[Unreleased]/Added`.
+- **`web-v2/src/pages/Changelog.tsx`** — Linear-style feature entry dated 2026-04-26 with 6 bullets (recurrence semantics, threshold contract, filter contract, atomicity guarantee, mode-aware regression coverage, test summary).
+- **Blocking Track B on:** nothing.
+- **Track B can pick up:**
+  - **Billing alerts CRUD UI** — call `api.listBillingAlerts({customer_id})` on the customer detail page, render a "Spend alerts" section with a create-alert dialog. The four endpoints + types are wired and ready.
+  - **`billing.alert.triggered` event surface in the webhook events viewer** — already routes through the existing webhook outbox so the events log will pick it up automatically; just needs a friendly icon + summary line for the new event type.
+- **Open for human review:**
+  - PR to be opened on `feat/backend-week5d-billing-alerts` once final commit lands.
+- **Next session (Track A):** drive PR to green, self-merge per authorization (CI green AND `TestWireShape_SnakeCase` + integration suite — both conditions met), then queue the next blocker per 90-day plan.

--- a/internal/api/adapters.go
+++ b/internal/api/adapters.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stripe/stripe-go/v82"
 
 	"github.com/sagarsuperuser/velox/internal/billing"
+	"github.com/sagarsuperuser/velox/internal/billingalert"
 	"github.com/sagarsuperuser/velox/internal/credit"
 	"github.com/sagarsuperuser/velox/internal/creditnote"
 	"github.com/sagarsuperuser/velox/internal/customer"
@@ -411,4 +412,37 @@ func (a *hostedInvoiceStripeAdapter) CreateInvoicePaymentSession(
 		return "", fmt.Errorf("checkout session: %w", err)
 	}
 	return sess.URL, nil
+}
+
+// billingAlertSubscriptionListerAdapter bridges *subscription.PostgresStore →
+// billingalert.SubscriptionLister. The billingalert package keeps its
+// own ListFilter shape so it doesn't import the subscription package
+// directly — same pattern create_preview's preview package uses for
+// CustomerLookup, etc.
+type billingAlertSubscriptionListerAdapter struct {
+	store *subscription.PostgresStore
+}
+
+func (a *billingAlertSubscriptionListerAdapter) List(ctx context.Context, filter billingalert.SubscriptionListFilter) ([]domain.Subscription, int, error) {
+	return a.store.List(ctx, subscription.ListFilter{
+		TenantID:   filter.TenantID,
+		CustomerID: filter.CustomerID,
+	})
+}
+
+// billingAlertLockerAdapter bridges *postgres.DB → billingalert.Locker.
+// The billingalert package defines its own Locker / Lock interfaces so
+// the evaluator can be unit-tested without a real Postgres — same
+// rationale billing has its own. We can't reuse billing.NewPostgresLocker
+// because the Lock interface types differ across packages.
+type billingAlertLockerAdapter struct {
+	db *postgres.DB
+}
+
+func (a *billingAlertLockerAdapter) TryAdvisoryLock(ctx context.Context, key int64) (billingalert.Lock, bool, error) {
+	lock, ok, err := a.db.TryAdvisoryLock(ctx, key)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return lock, true, nil
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sagarsuperuser/velox/internal/audit"
 	"github.com/sagarsuperuser/velox/internal/auth"
 	"github.com/sagarsuperuser/velox/internal/billing"
+	"github.com/sagarsuperuser/velox/internal/billingalert"
 	"github.com/sagarsuperuser/velox/internal/coupon"
 	"github.com/sagarsuperuser/velox/internal/credit"
 	"github.com/sagarsuperuser/velox/internal/creditnote"
@@ -96,6 +97,11 @@ type Server struct {
 	InvoiceSvc         *invoice.Service
 	TokenSvc           *payment.TokenService
 	PaymentReconciler  *payment.Reconciler
+	// BillingAlertEvaluator scans active billing alerts on a tick and
+	// fires `billing.alert.triggered` events via the webhook outbox.
+	// Started by main.go alongside the billing scheduler so leader
+	// gating is consistent across all background workers.
+	BillingAlertEvaluator *billingalert.Evaluator
 }
 
 func NewServer(db *postgres.DB, clk clock.Clock) *Server {
@@ -440,6 +446,35 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	createPreviewH := billing.NewCreatePreviewHandler(
 		billing.NewPreviewService(engine, customerStore, subStore),
 	)
+
+	// Billing alerts: operator-defined spend/usage thresholds with a
+	// background evaluator that fires `billing.alert.triggered` via the
+	// webhook outbox atomically with the alert state mutation. Mounted
+	// at /v1/billing/alerts BELOW so the route is sibling to /billing
+	// (the more-specific /billing/alerts pattern is registered before
+	// /billing/{id} to avoid the param capture). See
+	// docs/design-billing-alerts.md.
+	billingAlertStore := billingalert.NewPostgresStore(db)
+	billingAlertSvc := billingalert.NewService(billingAlertStore, customerStore, pricingSvc)
+	billingAlertH := billingalert.NewHandler(billingAlertSvc)
+	billingAlertEvaluator := billingalert.NewEvaluator(
+		billingAlertStore,
+		customerStore,
+		&billingAlertSubscriptionListerAdapter{store: subStore},
+		pricingSvc,
+		usageSvc,
+		outboxStore,
+		clk,
+	)
+	billingAlertEvaluator.SetLocker(&billingAlertLockerAdapter{db: db}, postgres.LockKeyBillingAlertEvaluator)
+	if intervalStr := strings.TrimSpace(os.Getenv("VELOX_BILLING_ALERTS_INTERVAL")); intervalStr != "" {
+		if d, err := time.ParseDuration(intervalStr); err == nil && d > 0 {
+			billingAlertEvaluator.SetInterval(d)
+		} else {
+			slog.Warn("VELOX_BILLING_ALERTS_INTERVAL invalid — using default", "value", intervalStr, "error", err)
+		}
+	}
+
 	analyticsH := analytics.NewHandler(db)
 
 	// Customer portal sessions — operators mint a session for a customer
@@ -540,19 +575,20 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	customerH.SetGDPR(customer.NewGDPRHandler(gdprSvc))
 
 	s := &Server{
-		BillingEngine:      engine,
-		DunningSvc:         dunningSvc,
-		SettingsStore:      settingsStore,
-		WebhookOutSvc:      webhookOutSvc,
-		OutboxStore:        outboxStore,
-		OutboxEnabled:      outboxEnabled,
-		EmailOutboxStore:   emailOutboxStore,
-		EmailOutboxEnabled: emailOutboxEnabled,
-		EmailSender:        emailSender,
-		CreditSvc:          creditSvc,
-		InvoiceSvc:         invoiceSvc,
-		TokenSvc:           tokenSvc,
-		PaymentReconciler:  paymentReconciler,
+		BillingEngine:         engine,
+		DunningSvc:            dunningSvc,
+		SettingsStore:         settingsStore,
+		WebhookOutSvc:         webhookOutSvc,
+		OutboxStore:           outboxStore,
+		OutboxEnabled:         outboxEnabled,
+		EmailOutboxStore:      emailOutboxStore,
+		EmailOutboxEnabled:    emailOutboxEnabled,
+		EmailSender:           emailSender,
+		CreditSvc:             creditSvc,
+		InvoiceSvc:            invoiceSvc,
+		TokenSvc:              tokenSvc,
+		PaymentReconciler:     paymentReconciler,
+		BillingAlertEvaluator: billingAlertEvaluator,
 	}
 
 	// Redis for distributed rate limiting (fail-open if not configured)
@@ -741,6 +777,18 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 		r.With(auth.Require(auth.PermPricingWrite)).Mount("/coupons", couponH.Routes())
 		r.With(auth.Require(auth.PermCustomerWrite)).Mount("/credits", creditH.Routes())
 		r.With(auth.Require(auth.PermDunningRead)).Mount("/dunning", dunningH.Routes())
+		// /billing/alerts must mount BEFORE /billing because chi tries
+		// patterns in registration order — once /billing is mounted with
+		// /{id}/... children, "alerts" would be claimed as a billing-job
+		// ID. See docs/design-billing-alerts.md.
+		// Per-route auth: read (list, get) → PermInvoiceRead; write
+		// (create, archive) → PermInvoiceWrite — same level as invoice-
+		// related surfaces since alerts are an invoice-adjacent operator
+		// capability.
+		r.Mount("/billing/alerts", billingAlertH.Routes(
+			auth.Require(auth.PermInvoiceRead),
+			auth.Require(auth.PermInvoiceWrite),
+		))
 		r.With(auth.Require(auth.PermInvoiceWrite)).Mount("/billing", billingH.Routes())
 		r.With(auth.Require(auth.PermAPIKeyWrite)).Mount("/webhook-endpoints", webhookOutH.Routes())
 		r.With(auth.Require(auth.PermAPIKeyRead)).Mount("/audit-log", auditH.Routes())

--- a/internal/billingalert/evaluator.go
+++ b/internal/billingalert/evaluator.go
@@ -1,0 +1,626 @@
+package billingalert
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/clock"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+)
+
+// Evaluator scans active billing alerts on a periodic tick, evaluates
+// each against the customer's current billing cycle, and fires a
+// `billing.alert.triggered` webhook + state mutation atomically.
+//
+// One leader per cluster runs the tick — gated by the
+// LockKeyBillingAlertEvaluator advisory lock. Followers skip silently
+// (the lock auto-releases on the leader's TCP session drop, so crashes
+// don't strand the lock).
+//
+// Per-alert work runs inside a tenant-scoped tx: the trigger row
+// insert, the alert status update, and the outbox enqueue all commit
+// together — see docs/design-billing-alerts.md "Atomicity contract".
+type Evaluator struct {
+	store         Store
+	customers     CustomerLookup
+	subscriptions SubscriptionLister
+	pricing       PricingReader
+	usage         UsageAggregator
+	outbox        OutboxEnqueuer
+	locker        Locker
+	lockKey       int64
+	interval      time.Duration
+	batch         int
+	clock         clock.Clock
+	onTick        func()
+}
+
+// NewEvaluator wires the composition. interval defaults to 1 minute
+// if zero; batch defaults to 500 alerts per tick (the partial index
+// keeps this scan cheap, but cap to bound an outlier tenant). All
+// collaborators are required.
+func NewEvaluator(
+	store Store,
+	customers CustomerLookup,
+	subscriptions SubscriptionLister,
+	pricing PricingReader,
+	usage UsageAggregator,
+	outbox OutboxEnqueuer,
+	clk clock.Clock,
+) *Evaluator {
+	if clk == nil {
+		clk = clock.Real()
+	}
+	return &Evaluator{
+		store:         store,
+		customers:     customers,
+		subscriptions: subscriptions,
+		pricing:       pricing,
+		usage:         usage,
+		outbox:        outbox,
+		clock:         clk,
+		interval:      1 * time.Minute,
+		batch:         500,
+	}
+}
+
+// SetInterval overrides the default tick interval. Operators can tune
+// via VELOX_BILLING_ALERTS_INTERVAL on the wire side.
+func (e *Evaluator) SetInterval(d time.Duration) {
+	if d > 0 {
+		e.interval = d
+	}
+}
+
+// SetBatch overrides the default per-tick batch size.
+func (e *Evaluator) SetBatch(n int) {
+	if n > 0 {
+		e.batch = n
+	}
+}
+
+// SetLocker enables leader gating. When set, the evaluator only runs
+// the tick if it wins the advisory lock — preventing two replicas
+// from double-firing alerts.
+func (e *Evaluator) SetLocker(locker Locker, lockKey int64) {
+	e.locker = locker
+	e.lockKey = lockKey
+}
+
+// SetOnTick registers a callback invoked after each completed tick.
+// Used by the API health check to track liveness.
+func (e *Evaluator) SetOnTick(fn func()) {
+	e.onTick = fn
+}
+
+// Start runs the evaluator in a background goroutine. Blocks until
+// ctx is cancelled (graceful shutdown).
+func (e *Evaluator) Start(ctx context.Context) {
+	slog.Info("billing alerts evaluator started", "interval", e.interval.String(), "batch_size", e.batch)
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("billing alerts evaluator stopped")
+			return
+		case <-ticker.C:
+			e.RunOnce(ctx)
+		}
+	}
+}
+
+// RunOnce performs one evaluator tick. Exposed for tests + manual
+// trigger. Under leader gating, returns immediately when another
+// replica holds the lock.
+func (e *Evaluator) RunOnce(ctx context.Context) {
+	if e.locker != nil && e.lockKey != 0 {
+		lock, ok, err := e.locker.TryAdvisoryLock(ctx, e.lockKey)
+		if err != nil {
+			slog.Error("billing alerts evaluator: lock acquire failed", "error", err)
+			return
+		}
+		if !ok {
+			slog.Debug("billing alerts evaluator: another leader holds the lock; skipping tick")
+			return
+		}
+		defer lock.Release()
+	}
+
+	// Mode fan-out: live then test. RLS partitions on (tenant_id,
+	// livemode) downstream — without WithLivemode the per-alert tx
+	// would silently default to live mode and miss test-mode rows.
+	for _, live := range []bool{true, false} {
+		modeCtx := postgres.WithLivemode(ctx, live)
+		e.runForMode(modeCtx, live)
+	}
+
+	if e.onTick != nil {
+		e.onTick()
+	}
+}
+
+func (e *Evaluator) runForMode(ctx context.Context, live bool) {
+	mode := "live"
+	if !live {
+		mode = "test"
+	}
+
+	alerts, err := e.store.ListCandidates(ctx, e.batch)
+	if err != nil {
+		slog.Error("billing alerts evaluator: list candidates", "mode", mode, "error", err)
+		return
+	}
+
+	for _, alert := range alerts {
+		if err := e.evaluateAlert(ctx, alert); err != nil {
+			slog.Error("billing alerts evaluator: per-alert error",
+				"mode", mode,
+				"alert_id", alert.ID,
+				"tenant_id", alert.TenantID,
+				"error", err,
+			)
+		}
+	}
+}
+
+// evaluateAlert resolves the customer's current cycle, evaluates the
+// threshold, and fires (with full atomicity) when crossed.
+func (e *Evaluator) evaluateAlert(ctx context.Context, alert domain.BillingAlert) error {
+	// Resolve customer + primary active subscription. A customer
+	// without an active sub can't have a current cycle; skip with a
+	// debug log (the alert stays armed in case the customer
+	// resubscribes later).
+	if _, err := e.customers.Get(ctx, alert.TenantID, alert.CustomerID); err != nil {
+		// Customer deletion cascades to alerts via FK, so reaching
+		// this branch means the customer became unreadable mid-tick
+		// (e.g. race with archive). Log and move on.
+		return fmt.Errorf("customer %s: %w", alert.CustomerID, err)
+	}
+	subs, _, err := e.subscriptions.List(ctx, SubscriptionListFilter{
+		TenantID:   alert.TenantID,
+		CustomerID: alert.CustomerID,
+	})
+	if err != nil {
+		return fmt.Errorf("list subscriptions: %w", err)
+	}
+	primary, ok := pickPrimarySubscription(subs)
+	if !ok {
+		slog.Debug("billing alerts: customer has no active subscription with current cycle; skipping",
+			"alert_id", alert.ID, "customer_id", alert.CustomerID)
+		return nil
+	}
+
+	from := *primary.CurrentBillingPeriodStart
+	to := *primary.CurrentBillingPeriodEnd
+
+	// Per-period rearm: alert fired in a previous cycle and the
+	// customer's cycle has rolled forward. Flip back to active and
+	// re-evaluate against the new cycle in this same tick (so the
+	// operator gets a fresh signal as soon as the threshold crosses
+	// in the new cycle, not on the next tick).
+	if alert.Status == domain.BillingAlertStatusTriggeredForPeriod {
+		if alert.LastPeriodStart == nil || from.After(*alert.LastPeriodStart) {
+			if err := e.store.Rearm(ctx, alert.TenantID, alert.ID); err != nil {
+				return fmt.Errorf("rearm: %w", err)
+			}
+			alert.Status = domain.BillingAlertStatusActive
+			alert.LastPeriodStart = nil
+		} else {
+			// Still within the cycle the alert already fired for;
+			// nothing to do until rollover.
+			return nil
+		}
+	}
+
+	// Rate the alert's scope. Two paths:
+	//   - meter_id set → evaluate that one meter's per-rule resolution
+	//     (filtered by dimensions if present).
+	//   - meter_id empty → walk the customer's plan(s) and sum across
+	//     every meter (no dimension filter applies in this path).
+	observedAmount, observedQty, currency, err := e.observeUsage(ctx, alert, primary, from, to)
+	if err != nil {
+		return fmt.Errorf("observe usage: %w", err)
+	}
+
+	if !shouldFire(alert.Threshold, observedAmount, observedQty) {
+		return nil
+	}
+
+	// Fire. Open the tenant-scoped tx, insert the trigger row + flip
+	// the alert status (FireInTx), enqueue the outbox row, commit. A
+	// crash mid-tx rolls back everything; the next tick re-evaluates
+	// and the UNIQUE constraint guarantees no double-emit on retry.
+	tx, err := e.store.BeginTenantTx(ctx, alert.TenantID)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer postgres.Rollback(tx)
+
+	newStatus := domain.BillingAlertStatusTriggered
+	if alert.Recurrence == domain.BillingAlertRecurrencePerPeriod {
+		newStatus = domain.BillingAlertStatusTriggeredForPeriod
+	}
+
+	trigger := domain.BillingAlertTrigger{
+		TenantID:            alert.TenantID,
+		AlertID:             alert.ID,
+		PeriodFrom:          from,
+		PeriodTo:            to,
+		ObservedAmountCents: observedAmount,
+		ObservedQuantity:    observedQty,
+		Currency:            currency,
+	}
+
+	inserted, err := e.store.FireInTx(ctx, tx, alert, trigger, newStatus)
+	if err != nil {
+		if errors.Is(err, ErrAlreadyFired) {
+			// Another evaluator already fired this period (shouldn't
+			// happen under leader gating, but the UNIQUE constraint
+			// is the safety net). No-op.
+			return nil
+		}
+		return fmt.Errorf("fire: %w", err)
+	}
+
+	payload := buildEventPayload(alert, inserted)
+	if _, err := e.outbox.Enqueue(ctx, tx, alert.TenantID, domain.EventBillingAlertTriggered, payload); err != nil {
+		return fmt.Errorf("enqueue outbox: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	slog.Info("billing alert fired",
+		"alert_id", alert.ID,
+		"tenant_id", alert.TenantID,
+		"customer_id", alert.CustomerID,
+		"observed_amount_cents", observedAmount,
+		"recurrence", string(alert.Recurrence),
+	)
+	return nil
+}
+
+// observeUsage rates the alert's scope and returns
+// (amount_cents, quantity, currency). The two paths diverge based on
+// whether filter.meter_id is set:
+//
+//   - meter scoped: walk the rules for that meter, filter the rule
+//     aggregations by the alert's dimension filter (strict-superset
+//     match against rule dimension_match), rate each rule, sum.
+//   - cross-meter: walk every meter on the customer's plan(s), rate
+//     each meter's resolved usage, sum amounts across all meters.
+//     dimension_match doesn't apply on this path (cross-meter
+//     dimension filtering rejected at create time).
+func (e *Evaluator) observeUsage(
+	ctx context.Context,
+	alert domain.BillingAlert,
+	sub domain.Subscription,
+	from, to time.Time,
+) (int64, decimal.Decimal, string, error) {
+	if alert.Filter.MeterID != "" {
+		return e.observeMeterScoped(ctx, alert, from, to)
+	}
+	return e.observeCrossMeter(ctx, alert, sub, from, to)
+}
+
+// observeMeterScoped rates a single meter through the priority+claim
+// path, filters per-rule aggregations by the alert's dimension filter,
+// and sums amount_cents + quantity across the matching rule buckets.
+func (e *Evaluator) observeMeterScoped(
+	ctx context.Context,
+	alert domain.BillingAlert,
+	from, to time.Time,
+) (int64, decimal.Decimal, string, error) {
+	meter, err := e.pricing.GetMeter(ctx, alert.TenantID, alert.Filter.MeterID)
+	if err != nil {
+		return 0, decimal.Zero, "", fmt.Errorf("get meter: %w", err)
+	}
+
+	defaultMode := mapMeterAggregation(meter.Aggregation)
+	aggs, err := e.usage.AggregateByPricingRules(ctx, alert.TenantID, alert.CustomerID, alert.Filter.MeterID, defaultMode, from, to)
+	if err != nil {
+		return 0, decimal.Zero, "", fmt.Errorf("aggregate by rules: %w", err)
+	}
+
+	rules, err := e.pricing.ListMeterPricingRulesByMeter(ctx, alert.TenantID, alert.Filter.MeterID)
+	if err != nil {
+		return 0, decimal.Zero, "", fmt.Errorf("list pricing rules: %w", err)
+	}
+	rulesByID := make(map[string]domain.MeterPricingRule, len(rules))
+	for _, rule := range rules {
+		rulesByID[rule.ID] = rule
+	}
+
+	var (
+		totalCents int64
+		totalQty   = decimal.Zero
+		currency   string
+	)
+
+	for _, agg := range aggs {
+		// Dimension filter: strict-superset match against rule's
+		// dimension_match. Empty filter matches every rule.
+		if len(alert.Filter.Dimensions) > 0 {
+			rule, ok := rulesByID[agg.RuleID]
+			if !ok || !dimensionsMatch(alert.Filter.Dimensions, rule.DimensionMatch) {
+				continue
+			}
+		}
+
+		ratingRuleID := agg.RatingRuleVersionID
+		if ratingRuleID == "" {
+			ratingRuleID = meter.RatingRuleVersionID
+		}
+		if ratingRuleID == "" {
+			// No rule binding — skip but don't fail; the alert
+			// stays armed.
+			continue
+		}
+		ratingRule, err := e.pricing.GetRatingRule(ctx, alert.TenantID, ratingRuleID)
+		if err != nil {
+			return 0, decimal.Zero, "", fmt.Errorf("get rating rule: %w", err)
+		}
+
+		cents, err := domain.ComputeAmountCents(ratingRule, agg.Quantity)
+		if err != nil {
+			return 0, decimal.Zero, "", fmt.Errorf("compute amount: %w", err)
+		}
+
+		if currency == "" {
+			currency = ratingRule.Currency
+		}
+		totalCents += cents
+		totalQty = totalQty.Add(agg.Quantity)
+	}
+
+	return totalCents, totalQty, currency, nil
+}
+
+// observeCrossMeter walks the customer's plan(s) and aggregates amount
+// across every meter. Quantity is unmeaningful in this path (different
+// meters can have different units), so we return zero — the threshold
+// validation already rejected `usage_gte` for cross-meter alerts.
+func (e *Evaluator) observeCrossMeter(
+	ctx context.Context,
+	alert domain.BillingAlert,
+	sub domain.Subscription,
+	from, to time.Time,
+) (int64, decimal.Decimal, string, error) {
+	plans := map[string]domain.Plan{}
+	seen := map[string]struct{}{}
+	var meterIDs []string
+	for _, item := range sub.Items {
+		plan, ok := plans[item.PlanID]
+		if !ok {
+			p, err := e.pricing.GetPlan(ctx, alert.TenantID, item.PlanID)
+			if err != nil {
+				return 0, decimal.Zero, "", fmt.Errorf("get plan: %w", err)
+			}
+			plan = p
+			plans[item.PlanID] = plan
+		}
+		for _, mid := range plan.MeterIDs {
+			if _, dup := seen[mid]; dup {
+				continue
+			}
+			seen[mid] = struct{}{}
+			meterIDs = append(meterIDs, mid)
+		}
+	}
+
+	var (
+		totalCents int64
+		currency   string
+	)
+	for _, meterID := range meterIDs {
+		meter, err := e.pricing.GetMeter(ctx, alert.TenantID, meterID)
+		if err != nil {
+			return 0, decimal.Zero, "", fmt.Errorf("get meter %s: %w", meterID, err)
+		}
+		defaultMode := mapMeterAggregation(meter.Aggregation)
+		aggs, err := e.usage.AggregateByPricingRules(ctx, alert.TenantID, alert.CustomerID, meterID, defaultMode, from, to)
+		if err != nil {
+			return 0, decimal.Zero, "", fmt.Errorf("aggregate %s: %w", meterID, err)
+		}
+		for _, agg := range aggs {
+			ratingRuleID := agg.RatingRuleVersionID
+			if ratingRuleID == "" {
+				ratingRuleID = meter.RatingRuleVersionID
+			}
+			if ratingRuleID == "" {
+				continue
+			}
+			ratingRule, err := e.pricing.GetRatingRule(ctx, alert.TenantID, ratingRuleID)
+			if err != nil {
+				return 0, decimal.Zero, "", fmt.Errorf("get rating rule: %w", err)
+			}
+			cents, err := domain.ComputeAmountCents(ratingRule, agg.Quantity)
+			if err != nil {
+				return 0, decimal.Zero, "", fmt.Errorf("compute amount: %w", err)
+			}
+			if currency == "" {
+				currency = ratingRule.Currency
+			}
+			totalCents += cents
+		}
+	}
+
+	return totalCents, decimal.Zero, currency, nil
+}
+
+// shouldFire compares the observed values against the alert's
+// threshold. Exactly one of AmountCentsGTE / QuantityGTE is set
+// (DB CHECK + service validation); compare against the populated one.
+func shouldFire(threshold domain.BillingAlertThreshold, observedAmount int64, observedQty decimal.Decimal) bool {
+	if threshold.AmountCentsGTE != nil {
+		return observedAmount >= *threshold.AmountCentsGTE
+	}
+	if threshold.QuantityGTE != nil {
+		return observedQty.GreaterThanOrEqual(*threshold.QuantityGTE)
+	}
+	return false
+}
+
+// dimensionsMatch returns true when every key/value pair in `filter`
+// is present and equal in `actual` (strict-superset semantics —
+// `actual` is a superset of `filter`). An empty filter matches every
+// actual map.
+func dimensionsMatch(filter, actual map[string]any) bool {
+	if len(filter) == 0 {
+		return true
+	}
+	for k, v := range filter {
+		got, ok := actual[k]
+		if !ok {
+			return false
+		}
+		if !equalAny(v, got) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalAny compares two scalar values for equality. JSON unmarshaling
+// produces float64 for all numbers, so we normalise int → float64
+// before comparing — otherwise an alert filter `{count:5}` would
+// never match an event with `{count:5.0}` (same value, different
+// concrete type).
+func equalAny(a, b any) bool {
+	switch av := a.(type) {
+	case nil:
+		return b == nil
+	case bool:
+		bv, ok := b.(bool)
+		return ok && bv == av
+	case string:
+		bv, ok := b.(string)
+		return ok && bv == av
+	case float64:
+		return numericEqual(av, b)
+	case float32:
+		return numericEqual(float64(av), b)
+	case int:
+		return numericEqual(float64(av), b)
+	case int32:
+		return numericEqual(float64(av), b)
+	case int64:
+		return numericEqual(float64(av), b)
+	}
+	return false
+}
+
+func numericEqual(a float64, b any) bool {
+	switch bv := b.(type) {
+	case float64:
+		return a == bv
+	case float32:
+		return a == float64(bv)
+	case int:
+		return a == float64(bv)
+	case int32:
+		return a == float64(bv)
+	case int64:
+		return a == float64(bv)
+	}
+	return false
+}
+
+// pickPrimarySubscription mirrors the customer-usage / create_preview
+// heuristic: filter to active or trialing, pick the most recent
+// current_period_start. Subs without a current cycle (paused,
+// canceled, draft) are excluded — they have no cycle to evaluate.
+func pickPrimarySubscription(subs []domain.Subscription) (domain.Subscription, bool) {
+	var primary *domain.Subscription
+	for i := range subs {
+		sub := &subs[i]
+		if sub.Status != domain.SubscriptionActive && sub.Status != domain.SubscriptionTrialing {
+			continue
+		}
+		if sub.CurrentBillingPeriodStart == nil || sub.CurrentBillingPeriodEnd == nil {
+			continue
+		}
+		if primary == nil || sub.CurrentBillingPeriodStart.After(*primary.CurrentBillingPeriodStart) {
+			primary = sub
+		}
+	}
+	if primary == nil {
+		return domain.Subscription{}, false
+	}
+	return *primary, true
+}
+
+// mapMeterAggregation translates the meter's stored aggregation
+// string to the AggregationMode the priority+claim resolver accepts.
+// Duplicated from billing.previewMeter / usage.customer_usage rather
+// than imported — same rationale: keep cross-domain imports flat.
+func mapMeterAggregation(agg string) domain.AggregationMode {
+	switch agg {
+	case "sum":
+		return domain.AggSum
+	case "count":
+		return domain.AggCount
+	case "max":
+		return domain.AggMax
+	case "last":
+		return domain.AggLastDuringPeriod
+	default:
+		return domain.AggSum
+	}
+}
+
+// buildEventPayload is the single source of truth for the
+// `billing.alert.triggered` webhook payload shape. Snake-case
+// throughout; always-object idiom on `filter.dimensions`; both
+// threshold fields present (one as null); decimal as JSON string.
+//
+// See docs/design-billing-alerts.md "Webhook payload" for the spec.
+func buildEventPayload(alert domain.BillingAlert, trigger domain.BillingAlertTrigger) map[string]any {
+	dims := alert.Filter.Dimensions
+	if dims == nil {
+		dims = map[string]any{}
+	}
+
+	threshold := map[string]any{
+		"amount_gte": nil,
+		"usage_gte":  nil,
+	}
+	if alert.Threshold.AmountCentsGTE != nil {
+		threshold["amount_gte"] = *alert.Threshold.AmountCentsGTE
+	}
+	if alert.Threshold.QuantityGTE != nil {
+		threshold["usage_gte"] = alert.Threshold.QuantityGTE.String()
+	}
+
+	return map[string]any{
+		"alert_id":    alert.ID,
+		"customer_id": alert.CustomerID,
+		"title":       alert.Title,
+		"threshold":   threshold,
+		"observed": map[string]any{
+			"amount_cents": trigger.ObservedAmountCents,
+			"quantity":     trigger.ObservedQuantity.String(),
+		},
+		"currency":     trigger.Currency,
+		"triggered_at": trigger.TriggeredAt.UTC().Format(time.RFC3339Nano),
+		"period": map[string]any{
+			"from":   trigger.PeriodFrom.UTC().Format(time.RFC3339Nano),
+			"to":     trigger.PeriodTo.UTC().Format(time.RFC3339Nano),
+			"source": "current_billing_cycle",
+		},
+		"filter": map[string]any{
+			"meter_id":   alert.Filter.MeterID,
+			"dimensions": dims,
+		},
+		"recurrence": string(alert.Recurrence),
+	}
+}

--- a/internal/billingalert/evaluator_test.go
+++ b/internal/billingalert/evaluator_test.go
@@ -1,0 +1,405 @@
+package billingalert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// TestDimensionsMatch covers the strict-superset semantics: an alert's
+// dimension filter is a subset selector — every (k,v) in the filter must
+// be present and equal in the rule's dimension_match. Empty filter
+// matches every actual map.
+func TestDimensionsMatch(t *testing.T) {
+	cases := []struct {
+		name   string
+		filter map[string]any
+		actual map[string]any
+		want   bool
+	}{
+		{
+			name:   "empty_filter_matches_anything",
+			filter: nil,
+			actual: map[string]any{"model": "gpt-4"},
+			want:   true,
+		},
+		{
+			name:   "empty_filter_matches_empty_actual",
+			filter: map[string]any{},
+			actual: map[string]any{},
+			want:   true,
+		},
+		{
+			name:   "exact_match",
+			filter: map[string]any{"model": "gpt-4"},
+			actual: map[string]any{"model": "gpt-4"},
+			want:   true,
+		},
+		{
+			name:   "subset_match_filter_in_actual_with_more_keys",
+			filter: map[string]any{"model": "gpt-4"},
+			actual: map[string]any{"model": "gpt-4", "operation": "input"},
+			want:   true,
+		},
+		{
+			name:   "filter_not_in_actual_missing_key",
+			filter: map[string]any{"model": "gpt-4"},
+			actual: map[string]any{"operation": "input"},
+			want:   false,
+		},
+		{
+			name:   "filter_value_differs",
+			filter: map[string]any{"model": "gpt-4"},
+			actual: map[string]any{"model": "gpt-3.5"},
+			want:   false,
+		},
+		{
+			name:   "multi_key_match",
+			filter: map[string]any{"model": "gpt-4", "operation": "input"},
+			actual: map[string]any{"model": "gpt-4", "operation": "input", "cached": false},
+			want:   true,
+		},
+		{
+			name:   "multi_key_one_differs",
+			filter: map[string]any{"model": "gpt-4", "operation": "input"},
+			actual: map[string]any{"model": "gpt-4", "operation": "output"},
+			want:   false,
+		},
+		{
+			name:   "int_vs_float64_normalised",
+			filter: map[string]any{"count": 5},
+			actual: map[string]any{"count": float64(5)},
+			want:   true,
+		},
+		{
+			name:   "int64_vs_float64_normalised",
+			filter: map[string]any{"count": int64(42)},
+			actual: map[string]any{"count": float64(42)},
+			want:   true,
+		},
+		{
+			name:   "bool_match",
+			filter: map[string]any{"cached": true},
+			actual: map[string]any{"cached": true},
+			want:   true,
+		},
+		{
+			name:   "bool_mismatch",
+			filter: map[string]any{"cached": true},
+			actual: map[string]any{"cached": false},
+			want:   false,
+		},
+		{
+			name:   "string_vs_number_no_coerce",
+			filter: map[string]any{"id": "5"},
+			actual: map[string]any{"id": 5},
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dimensionsMatch(tc.filter, tc.actual)
+			if got != tc.want {
+				t.Errorf("dimensionsMatch(%v, %v) = %v, want %v", tc.filter, tc.actual, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldFire pins the threshold-comparison semantics: exactly one of
+// AmountCentsGTE / QuantityGTE is set; the comparison is strict ≥ on the
+// populated side; the unset side must not influence the verdict.
+func TestShouldFire(t *testing.T) {
+	amount := int64(50000)
+	qty := decimal.RequireFromString("100.5")
+
+	cases := []struct {
+		name      string
+		threshold domain.BillingAlertThreshold
+		obsAmount int64
+		obsQty    decimal.Decimal
+		want      bool
+	}{
+		{
+			name:      "amount_above",
+			threshold: domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+			obsAmount: 60000,
+			want:      true,
+		},
+		{
+			name:      "amount_exactly_at",
+			threshold: domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+			obsAmount: 50000,
+			want:      true,
+		},
+		{
+			name:      "amount_below",
+			threshold: domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+			obsAmount: 49999,
+			want:      false,
+		},
+		{
+			name:      "quantity_above",
+			threshold: domain.BillingAlertThreshold{QuantityGTE: &qty},
+			obsQty:    decimal.RequireFromString("101"),
+			want:      true,
+		},
+		{
+			name:      "quantity_exactly_at",
+			threshold: domain.BillingAlertThreshold{QuantityGTE: &qty},
+			obsQty:    decimal.RequireFromString("100.5"),
+			want:      true,
+		},
+		{
+			name:      "quantity_below",
+			threshold: domain.BillingAlertThreshold{QuantityGTE: &qty},
+			obsQty:    decimal.RequireFromString("100.49999999"),
+			want:      false,
+		},
+		{
+			name:      "no_threshold_set_never_fires",
+			threshold: domain.BillingAlertThreshold{},
+			obsAmount: 1000000,
+			obsQty:    decimal.RequireFromString("999999"),
+			want:      false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldFire(tc.threshold, tc.obsAmount, tc.obsQty)
+			if got != tc.want {
+				t.Errorf("shouldFire(%v, %d, %s) = %v, want %v",
+					tc.threshold, tc.obsAmount, tc.obsQty.String(), got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPickPrimarySubscription mirrors the create_preview / customer-usage
+// heuristic: filter to active|trialing with a current cycle, pick most
+// recent CurrentBillingPeriodStart. Subs without a current cycle (paused,
+// canceled, draft) are excluded — they have no cycle to evaluate against.
+func TestPickPrimarySubscription(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	t1End := t1.AddDate(0, 1, 0)
+	t2End := t2.AddDate(0, 1, 0)
+
+	t.Run("no_subs_returns_false", func(t *testing.T) {
+		_, ok := pickPrimarySubscription(nil)
+		if ok {
+			t.Error("expected ok=false for nil input")
+		}
+	})
+
+	t.Run("only_canceled_returns_false", func(t *testing.T) {
+		subs := []domain.Subscription{
+			{ID: "vlx_sub_1", Status: domain.SubscriptionCanceled, CurrentBillingPeriodStart: &t1, CurrentBillingPeriodEnd: &t1End},
+		}
+		_, ok := pickPrimarySubscription(subs)
+		if ok {
+			t.Error("expected ok=false when only canceled subs")
+		}
+	})
+
+	t.Run("active_without_cycle_excluded", func(t *testing.T) {
+		subs := []domain.Subscription{
+			{ID: "vlx_sub_1", Status: domain.SubscriptionActive}, // no current period
+		}
+		_, ok := pickPrimarySubscription(subs)
+		if ok {
+			t.Error("expected ok=false when active sub lacks a cycle")
+		}
+	})
+
+	t.Run("picks_latest_active", func(t *testing.T) {
+		subs := []domain.Subscription{
+			{ID: "vlx_sub_old", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: &t1, CurrentBillingPeriodEnd: &t1End},
+			{ID: "vlx_sub_new", Status: domain.SubscriptionActive, CurrentBillingPeriodStart: &t2, CurrentBillingPeriodEnd: &t2End},
+		}
+		got, ok := pickPrimarySubscription(subs)
+		if !ok || got.ID != "vlx_sub_new" {
+			t.Errorf("expected vlx_sub_new, got %q (ok=%v)", got.ID, ok)
+		}
+	})
+
+	t.Run("trialing_treated_as_active", func(t *testing.T) {
+		subs := []domain.Subscription{
+			{ID: "vlx_sub_canceled", Status: domain.SubscriptionCanceled, CurrentBillingPeriodStart: &t2, CurrentBillingPeriodEnd: &t2End},
+			{ID: "vlx_sub_trial", Status: domain.SubscriptionTrialing, CurrentBillingPeriodStart: &t1, CurrentBillingPeriodEnd: &t1End},
+		}
+		got, ok := pickPrimarySubscription(subs)
+		if !ok || got.ID != "vlx_sub_trial" {
+			t.Errorf("expected vlx_sub_trial, got %q (ok=%v)", got.ID, ok)
+		}
+	})
+}
+
+// TestBuildEventPayload pins the snake_case + always-object + decimal-as-
+// string contract for the outbound webhook. The wire-shape test covers
+// these invariants too; this test additionally pins the exact values the
+// dashboard CLI snapshot relies on.
+func TestBuildEventPayload(t *testing.T) {
+	amount := int64(50000)
+	alert := domain.BillingAlert{
+		ID:         "vlx_alrt_abc",
+		TenantID:   "vlx_tenant",
+		CustomerID: "vlx_cus_abc",
+		Title:      "Spend > $500",
+		Filter: domain.BillingAlertFilter{
+			MeterID:    "vlx_mtr_tokens",
+			Dimensions: map[string]any{"model": "gpt-4"},
+		},
+		Threshold:  domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+		Recurrence: domain.BillingAlertRecurrencePerPeriod,
+	}
+	trigger := domain.BillingAlertTrigger{
+		AlertID:             alert.ID,
+		PeriodFrom:          time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PeriodTo:            time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		ObservedAmountCents: 60000,
+		ObservedQuantity:    decimal.RequireFromString("987.654"),
+		Currency:            "USD",
+		TriggeredAt:         time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC),
+	}
+
+	payload := buildEventPayload(alert, trigger)
+	if payload["alert_id"] != "vlx_alrt_abc" {
+		t.Errorf("alert_id mismatch: %v", payload["alert_id"])
+	}
+	if payload["recurrence"] != "per_period" {
+		t.Errorf("recurrence mismatch: %v", payload["recurrence"])
+	}
+	if payload["currency"] != "USD" {
+		t.Errorf("currency mismatch: %v", payload["currency"])
+	}
+
+	// observed.quantity is a JSON string (decimal precision per ADR-005).
+	observed, ok := payload["observed"].(map[string]any)
+	if !ok {
+		t.Fatalf("observed must be a map, got %T", payload["observed"])
+	}
+	if qs, isString := observed["quantity"].(string); !isString {
+		t.Errorf("observed.quantity must be string, got %T", observed["quantity"])
+	} else if qs != "987.654" {
+		t.Errorf("observed.quantity = %q, want %q", qs, "987.654")
+	}
+	if observed["amount_cents"].(int64) != 60000 {
+		t.Errorf("observed.amount_cents = %v, want 60000", observed["amount_cents"])
+	}
+
+	// threshold always emits both keys.
+	threshold, ok := payload["threshold"].(map[string]any)
+	if !ok {
+		t.Fatalf("threshold must be a map")
+	}
+	if threshold["usage_gte"] != nil {
+		t.Errorf("threshold.usage_gte must be nil when only amount_gte is set")
+	}
+	if threshold["amount_gte"].(int64) != 50000 {
+		t.Errorf("threshold.amount_gte mismatch: %v", threshold["amount_gte"])
+	}
+
+	// period.source is the audit string the dashboard renders to explain
+	// "where did this window come from".
+	period, ok := payload["period"].(map[string]any)
+	if !ok {
+		t.Fatalf("period must be a map")
+	}
+	if period["source"] != "current_billing_cycle" {
+		t.Errorf("period.source = %v, want current_billing_cycle", period["source"])
+	}
+}
+
+// TestBuildEventPayload_NilDimensions enforces the always-object idiom
+// for filter.dimensions when the alert's filter is nil. Subscriber code
+// indexes payload.filter.dimensions without a null guard; the helper
+// must normalise to {}.
+func TestBuildEventPayload_NilDimensions(t *testing.T) {
+	amount := int64(10000)
+	alert := domain.BillingAlert{
+		ID:         "vlx_alrt_nil_dims",
+		TenantID:   "vlx_tenant",
+		CustomerID: "vlx_cus",
+		Title:      "spend alert",
+		Filter:     domain.BillingAlertFilter{Dimensions: nil},
+		Threshold:  domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+		Recurrence: domain.BillingAlertRecurrenceOneTime,
+	}
+	trigger := domain.BillingAlertTrigger{
+		AlertID:             alert.ID,
+		ObservedAmountCents: 12000,
+		ObservedQuantity:    decimal.Zero,
+		Currency:            "USD",
+		TriggeredAt:         time.Now().UTC(),
+	}
+	payload := buildEventPayload(alert, trigger)
+	filter, ok := payload["filter"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter must be a map")
+	}
+	dims, ok := filter["dimensions"].(map[string]any)
+	if !ok {
+		t.Fatalf("filter.dimensions must be a map even when nil, got %T", filter["dimensions"])
+	}
+	if len(dims) != 0 {
+		t.Errorf("filter.dimensions should be empty, got %d keys", len(dims))
+	}
+}
+
+// TestEqualAny exercises the JSON-int/float normalisation directly so a
+// regression in the helper surfaces a focused failure.
+func TestEqualAny(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b any
+		want bool
+	}{
+		{"nil_nil", nil, nil, true},
+		{"nil_string", nil, "x", false},
+		{"int_float64", 5, float64(5), true},
+		{"int64_float64", int64(5), float64(5), true},
+		{"float64_int", float64(5), 5, true},
+		{"float64_int_diff", float64(5), 6, false},
+		{"string_eq", "abc", "abc", true},
+		{"string_neq", "abc", "abd", false},
+		{"bool_eq", true, true, true},
+		{"bool_neq", true, false, false},
+		{"map_unsupported", map[string]any{"x": 1}, map[string]any{"x": 1}, false}, // helper rejects non-scalars
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := equalAny(tc.a, tc.b); got != tc.want {
+				t.Errorf("equalAny(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMapMeterAggregation confirms the meter.Aggregation string → AggregationMode
+// map. A drift here would silently route every meter through AggSum and
+// quietly break alerts on count/max/last meters.
+func TestMapMeterAggregation(t *testing.T) {
+	cases := []struct {
+		in   string
+		want domain.AggregationMode
+	}{
+		{"sum", domain.AggSum},
+		{"count", domain.AggCount},
+		{"max", domain.AggMax},
+		{"last", domain.AggLastDuringPeriod},
+		{"unknown", domain.AggSum}, // sensible default
+		{"", domain.AggSum},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := mapMeterAggregation(tc.in); got != tc.want {
+				t.Errorf("mapMeterAggregation(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/billingalert/handler.go
+++ b/internal/billingalert/handler.go
@@ -1,0 +1,287 @@
+package billingalert
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/api/respond"
+	"github.com/sagarsuperuser/velox/internal/auth"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+)
+
+// Handler exposes the four /v1/billing/alerts endpoints. Permissions
+// are wired at the router mount site (PermInvoiceRead for read,
+// PermInvoiceWrite for write) — same level as invoice-related surfaces
+// since billing alerts are an invoice-adjacent operator capability.
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// Routes returns the sub-router. Mounted at /v1/billing/alerts. The
+// archive route is a sibling of the {id} read route — chi tries
+// patterns in registration order, so the more-specific pattern
+// (/{id}/archive) comes first to avoid {id} capturing "archive".
+//
+// Permission gating is applied inline via per-method `with` middleware
+// passed by the caller. The read methods (GET /, GET /{id}) gate on
+// `read`; the write methods (POST /, POST /{id}/archive) gate on
+// `write`. Splitting the gates here (rather than mounting two
+// sub-routers) keeps the chi pattern-precedence concentrated in one
+// place — moving them to the api router would risk the
+// /{id}/archive vs /{id} ordering drifting.
+func (h *Handler) Routes(read, write func(http.Handler) http.Handler) chi.Router {
+	r := chi.NewRouter()
+	r.With(write).Post("/{id}/archive", h.archive)
+	r.With(read).Get("/{id}", h.get)
+	r.With(read).Get("/", h.list)
+	r.With(write).Post("/", h.create)
+	return r
+}
+
+// wireAlert is the JSON shape the wire emits / accepts. Decoupled
+// from domain.BillingAlert so the wire contract is pinned by struct
+// tags here and the domain type stays free to evolve.
+type wireAlert struct {
+	ID              string             `json:"id"`
+	Title           string             `json:"title"`
+	CustomerID      string             `json:"customer_id"`
+	Filter          wireAlertFilter    `json:"filter"`
+	Threshold       wireAlertThreshold `json:"threshold"`
+	Recurrence      string             `json:"recurrence"`
+	Status          string             `json:"status"`
+	LastTriggeredAt *string            `json:"last_triggered_at"`
+	LastPeriodStart *string            `json:"last_period_start"`
+	CreatedAt       string             `json:"created_at"`
+	UpdatedAt       string             `json:"updated_at"`
+}
+
+// wireAlertFilter mirrors domain.BillingAlertFilter but uses the
+// always-object idiom: dimensions is a JSON object (`{}`) even when
+// the alert has no filter, so dashboard rendering doesn't need a null
+// guard. meter_id is omitempty because a missing meter and an empty
+// meter mean the same thing on the wire.
+type wireAlertFilter struct {
+	MeterID    string         `json:"meter_id,omitempty"`
+	Dimensions map[string]any `json:"dimensions"`
+}
+
+// wireAlertThreshold always emits both keys (one as null) — same
+// rationale as filter.dimensions: clients can read both fields
+// without conditional indexing.
+type wireAlertThreshold struct {
+	AmountGTE *int64  `json:"amount_gte"`
+	UsageGTE  *string `json:"usage_gte"`
+}
+
+// wireCreateRequest is the input shape for POST /v1/billing/alerts.
+// `threshold` is parsed loosely — both fields are optional in the
+// wire shape and the service-layer validation enforces the
+// "exactly one" rule. `filter` is optional; missing → no meter, no
+// dimensions.
+type wireCreateRequest struct {
+	Title      string              `json:"title"`
+	CustomerID string              `json:"customer_id"`
+	Filter     *wireCreateFilter   `json:"filter"`
+	Threshold  wireCreateThreshold `json:"threshold"`
+	Recurrence string              `json:"recurrence"`
+}
+
+type wireCreateFilter struct {
+	MeterID    string         `json:"meter_id"`
+	Dimensions map[string]any `json:"dimensions"`
+}
+
+// wireCreateThreshold accepts the decimal as a string (per ADR-005)
+// or a JSON number (loose) — DecodeDecimal handles both.
+type wireCreateThreshold struct {
+	AmountGTE *int64           `json:"amount_gte"`
+	UsageGTE  *json.RawMessage `json:"usage_gte"`
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "billing_alerts: read body", "error", err)
+		respond.BadRequest(w, r, "could not read request body")
+		return
+	}
+
+	req, err := decodeCreateRequest(body)
+	if err != nil {
+		respond.FromError(w, r, err, "billing_alert")
+		return
+	}
+
+	alert, err := h.svc.Create(r.Context(), tenantID, req)
+	if err != nil {
+		// The customer / meter lookups inside Create return
+		// errs.ErrNotFound for cross-tenant IDs. Surface as 404
+		// with the message indicating which resource was missing.
+		if errors.Is(err, errs.ErrNotFound) {
+			respond.NotFound(w, r, "customer or meter")
+			return
+		}
+		respond.FromError(w, r, err, "billing_alert")
+		return
+	}
+
+	respond.JSON(w, r, http.StatusCreated, toWireAlert(alert))
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	id := chi.URLParam(r, "id")
+
+	alert, err := h.svc.Get(r.Context(), tenantID, id)
+	if err != nil {
+		respond.FromError(w, r, err, "billing_alert")
+		return
+	}
+	respond.JSON(w, r, http.StatusOK, toWireAlert(alert))
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+
+	filter := ListFilter{TenantID: tenantID}
+	q := r.URL.Query()
+	filter.CustomerID = strings.TrimSpace(q.Get("customer_id"))
+	filter.Status = domain.BillingAlertStatus(strings.TrimSpace(q.Get("status")))
+
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			respond.ValidationField(w, r, "limit", "must be a non-negative integer")
+			return
+		}
+		filter.Limit = n
+	}
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			respond.ValidationField(w, r, "offset", "must be a non-negative integer")
+			return
+		}
+		filter.Offset = n
+	}
+
+	alerts, total, err := h.svc.List(r.Context(), filter)
+	if err != nil {
+		respond.FromError(w, r, err, "billing_alert")
+		return
+	}
+
+	wire := make([]wireAlert, 0, len(alerts))
+	for _, a := range alerts {
+		wire = append(wire, toWireAlert(a))
+	}
+	respond.List(w, r, wire, total)
+}
+
+func (h *Handler) archive(w http.ResponseWriter, r *http.Request) {
+	tenantID := auth.TenantID(r.Context())
+	id := chi.URLParam(r, "id")
+
+	alert, err := h.svc.Archive(r.Context(), tenantID, id)
+	if err != nil {
+		respond.FromError(w, r, err, "billing_alert")
+		return
+	}
+	respond.JSON(w, r, http.StatusOK, toWireAlert(alert))
+}
+
+// decodeCreateRequest parses the JSON body and translates wire-typed
+// fields (decimal-as-string, etc.) to the service-layer types.
+// Empty body is acceptable as a degenerate {} — the service-layer
+// validation surfaces the missing required fields with field tags.
+func decodeCreateRequest(body []byte) (CreateRequest, error) {
+	wire := wireCreateRequest{}
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &wire); err != nil {
+			return CreateRequest{}, errs.Invalid("body", "request body is not valid JSON")
+		}
+	}
+
+	out := CreateRequest{
+		Title:          wire.Title,
+		CustomerID:     wire.CustomerID,
+		Recurrence:     domain.BillingAlertRecurrence(strings.TrimSpace(wire.Recurrence)),
+		AmountCentsGTE: wire.Threshold.AmountGTE,
+	}
+
+	if wire.Filter != nil {
+		out.MeterID = wire.Filter.MeterID
+		out.Dimensions = wire.Filter.Dimensions
+	}
+
+	if wire.Threshold.UsageGTE != nil {
+		// Accept both JSON number (12345.67) and JSON string ("12345.67").
+		// shopspring/decimal's UnmarshalJSON handles both.
+		var qty decimal.Decimal
+		if err := json.Unmarshal(*wire.Threshold.UsageGTE, &qty); err != nil {
+			return CreateRequest{}, errs.Invalid("threshold.usage_gte", "must be a decimal number or string")
+		}
+		out.QuantityGTE = &qty
+	}
+
+	return out, nil
+}
+
+// toWireAlert converts a domain alert to the JSON shape. Always-object
+// idioms (`dimensions` as `{}`, both `threshold` keys present) are
+// applied here so every read endpoint emits the same shape regardless
+// of whether the underlying domain.BillingAlert was scanned from the
+// DB or constructed in memory.
+func toWireAlert(a domain.BillingAlert) wireAlert {
+	dims := a.Filter.Dimensions
+	if dims == nil {
+		dims = map[string]any{}
+	}
+
+	thresh := wireAlertThreshold{
+		AmountGTE: a.Threshold.AmountCentsGTE,
+	}
+	if a.Threshold.QuantityGTE != nil {
+		s := a.Threshold.QuantityGTE.String()
+		thresh.UsageGTE = &s
+	}
+
+	out := wireAlert{
+		ID:         a.ID,
+		Title:      a.Title,
+		CustomerID: a.CustomerID,
+		Filter: wireAlertFilter{
+			MeterID:    a.Filter.MeterID,
+			Dimensions: dims,
+		},
+		Threshold:  thresh,
+		Recurrence: string(a.Recurrence),
+		Status:     string(a.Status),
+		CreatedAt:  a.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:  a.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+	if a.LastTriggeredAt != nil {
+		s := a.LastTriggeredAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+		out.LastTriggeredAt = &s
+	}
+	if a.LastPeriodStart != nil {
+		s := a.LastPeriodStart.UTC().Format("2006-01-02T15:04:05Z07:00")
+		out.LastPeriodStart = &s
+	}
+	return out
+}

--- a/internal/billingalert/integration_test.go
+++ b/internal/billingalert/integration_test.go
@@ -1,0 +1,910 @@
+package billingalert_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/billingalert"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/pricing"
+	"github.com/sagarsuperuser/velox/internal/subscription"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+	"github.com/sagarsuperuser/velox/internal/usage"
+)
+
+// alertFixture wires real per-domain stores against a clean test DB so
+// the evaluator path exercises the full SQL → tx → outbox chain. The
+// outbox enqueuer is a fake (we count + capture rows) — the real
+// *webhook.OutboxStore is exercised separately, and using it here would
+// pull in the entire webhook signing config without adding coverage.
+//
+// Mirrors previewFixture but stops short of building a billing.Engine —
+// the billingalert evaluator never calls into engine paths; it composes
+// directly on top of usage.AggregateByPricingRules.
+type alertFixture struct {
+	db          *postgres.DB
+	tenantID    string
+	customerSvc *customer.Service
+	pricingSvc  *pricing.Service
+	subStore    *subscription.PostgresStore
+	usageSvc    *usage.Service
+	store       *billingalert.PostgresStore
+	svc         *billingalert.Service
+	outbox      *fakeOutbox
+	evaluator   *billingalert.Evaluator
+}
+
+func newAlertFixture(t *testing.T, name string) *alertFixture {
+	t.Helper()
+	db := testutil.SetupTestDB(t)
+	tenantID := testutil.CreateTestTenant(t, db, name)
+
+	customerStore := customer.NewPostgresStore(db)
+	customerSvc := customer.NewService(customerStore)
+	pricingStore := pricing.NewPostgresStore(db)
+	pricingSvc := pricing.NewService(pricingStore)
+	subStore := subscription.NewPostgresStore(db)
+	usageStore := usage.NewPostgresStore(db)
+	usageSvc := usage.NewService(usageStore)
+
+	store := billingalert.NewPostgresStore(db)
+	svc := billingalert.NewService(store, customerStore, pricingSvc)
+	outbox := &fakeOutbox{}
+	evaluator := billingalert.NewEvaluator(
+		store,
+		customerStore,
+		&fixtureSubLister{store: subStore},
+		pricingSvc,
+		usageSvc,
+		outbox,
+		nil,
+	)
+	// No locker → the test runs every tick without leader gating, so
+	// RunOnce is deterministic. Production wires the real *postgres.DB
+	// locker via NewBillingAlertLockerAdapter.
+
+	return &alertFixture{
+		db:          db,
+		tenantID:    tenantID,
+		customerSvc: customerSvc,
+		pricingSvc:  pricingSvc,
+		subStore:    subStore,
+		usageSvc:    usageSvc,
+		store:       store,
+		svc:         svc,
+		outbox:      outbox,
+		evaluator:   evaluator,
+	}
+}
+
+// seedSubscription mirrors previewFixture.seedSubscription. Creates a
+// customer, a plan with the given meter, and an active subscription with
+// a current cycle of [from, to). Returns customer + sub IDs.
+func (f *alertFixture) seedSubscription(
+	t *testing.T,
+	ctx context.Context,
+	externalID, planCode, meterID string,
+	cycleStart, cycleEnd time.Time,
+) (custID, subID string) {
+	t.Helper()
+
+	cust, err := f.customerSvc.Create(ctx, f.tenantID, customer.CreateInput{
+		ExternalID:  externalID,
+		DisplayName: externalID,
+		Email:       externalID + "@example.test",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	plan, err := f.pricingSvc.CreatePlan(ctx, f.tenantID, pricing.CreatePlanInput{
+		Code:            planCode,
+		Name:            planCode,
+		Currency:        "USD",
+		BillingInterval: domain.BillingMonthly,
+		BaseAmountCents: 0,
+		MeterIDs:        []string{meterID},
+	})
+	if err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+
+	subID = postgres.NewID("vlx_sub")
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, f.tenantID)
+	if err != nil {
+		t.Fatalf("begin sub tx: %v", err)
+	}
+	defer postgres.Rollback(tx)
+
+	now := time.Now().UTC()
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO subscriptions (
+			id, tenant_id, code, display_name, customer_id, status, billing_time,
+			current_billing_period_start, current_billing_period_end, next_billing_at,
+			created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, 'active', 'anniversary', $6, $7, $7, $8, $8)
+	`, subID, f.tenantID, "code-"+externalID, planCode+"-sub", cust.ID,
+		cycleStart, cycleEnd, now)
+	if err != nil {
+		t.Fatalf("insert sub: %v", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO subscription_items (id, tenant_id, subscription_id, plan_id, quantity, metadata, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, 1, '{}'::jsonb, $5, $5)
+	`, postgres.NewID("vlx_si"), f.tenantID, subID, plan.ID, now)
+	if err != nil {
+		t.Fatalf("insert sub item: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit sub: %v", err)
+	}
+	return cust.ID, subID
+}
+
+// rollSubCycle advances the subscription's current_billing_period to the
+// supplied window. The evaluator's per_period rearm path keys on the
+// new from > alert.last_period_start condition; bumping the cycle in the
+// fixture is the cleanest way to simulate cycle rollover without running
+// the real billing scheduler.
+func (f *alertFixture) rollSubCycle(t *testing.T, ctx context.Context, subID string, from, to time.Time) {
+	t.Helper()
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, f.tenantID)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer postgres.Rollback(tx)
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE subscriptions
+		SET current_billing_period_start = $2,
+		    current_billing_period_end = $3,
+		    next_billing_at = $3,
+		    updated_at = now()
+		WHERE id = $1
+	`, subID, from, to); err != nil {
+		t.Fatalf("roll cycle: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit roll: %v", err)
+	}
+}
+
+// seedSimpleMeter creates a meter with a single flat rating rule at the
+// given amount-cents. Most tests want one alert against one meter; this
+// keeps the boilerplate down.
+func (f *alertFixture) seedSimpleMeter(
+	t *testing.T,
+	ctx context.Context,
+	key, ruleKey string,
+	flatCents int64,
+) string {
+	t.Helper()
+	rrv, err := f.pricingSvc.CreateRatingRule(ctx, f.tenantID, pricing.CreateRatingRuleInput{
+		RuleKey:         ruleKey,
+		Name:            ruleKey,
+		Mode:            domain.PricingFlat,
+		Currency:        "USD",
+		FlatAmountCents: flatCents,
+	})
+	if err != nil {
+		t.Fatalf("create rating rule: %v", err)
+	}
+	meter, err := f.pricingSvc.CreateMeter(ctx, f.tenantID, pricing.CreateMeterInput{
+		Key:                 key,
+		Name:                key,
+		Unit:                "tokens",
+		Aggregation:         "sum",
+		RatingRuleVersionID: rrv.ID,
+	})
+	if err != nil {
+		t.Fatalf("create meter: %v", err)
+	}
+	return meter.ID
+}
+
+// TestEvaluator_FiresOnceForOneTime is the happy path: a one_time alert
+// crosses its threshold, the evaluator inserts a trigger row, flips the
+// alert's status to triggered, and enqueues exactly one outbox row. A
+// subsequent tick (no new usage) MUST NOT fire again — one_time alerts
+// transition to a terminal status.
+func TestEvaluator_FiresOnceForOneTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts FiresOnceForOneTime")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-1t", "tokens-1t-rule", 1)
+	custID, _ := f.seedSubscription(t, ctx, "cus_alrt_1t", "pln_alrt_1t", meterID, cycleStart, cycleEnd)
+
+	// 100 events × qty=10 × 1¢ = 1000c. Threshold = 500c → fires.
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "spend > 500c",
+		CustomerID:     custID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	f.evaluator.RunOnce(ctx)
+
+	// Reload alert + assert state transition.
+	got, err := f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get alert: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusTriggered {
+		t.Errorf("status = %q, want triggered", got.Status)
+	}
+	if got.LastTriggeredAt == nil {
+		t.Error("last_triggered_at should be set")
+	}
+
+	if len(f.outbox.captured) != 1 {
+		t.Fatalf("expected 1 outbox row, got %d", len(f.outbox.captured))
+	}
+	if f.outbox.captured[0].eventType != domain.EventBillingAlertTriggered {
+		t.Errorf("event_type = %q, want %q", f.outbox.captured[0].eventType, domain.EventBillingAlertTriggered)
+	}
+	if f.outbox.captured[0].tenantID != f.tenantID {
+		t.Errorf("outbox tenant_id = %q, want %q", f.outbox.captured[0].tenantID, f.tenantID)
+	}
+
+	// Tick again — should NOT fire (terminal).
+	f.evaluator.RunOnce(ctx)
+	if len(f.outbox.captured) != 1 {
+		t.Errorf("one_time fired again on second tick; outbox count = %d, want 1", len(f.outbox.captured))
+	}
+}
+
+// TestEvaluator_FiresPerPeriodAndRearms simulates the per_period
+// recurrence: alert fires in cycle N, status flips to
+// triggered_for_period; cycle rolls forward; evaluator rearms the alert
+// to active and fires again on the new cycle's threshold crossing.
+func TestEvaluator_FiresPerPeriodAndRearms(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts FiresPerPeriodAndRearms")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-pp", "tokens-pp-rule", 1)
+	custID, subID := f.seedSubscription(t, ctx, "cus_alrt_pp", "pln_alrt_pp", meterID, cycleStart, cycleEnd)
+
+	// 100 × 10 × 1¢ = 1000c, threshold 500c.
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "spend > 500c per period",
+		CustomerID:     custID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrencePerPeriod,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	// First tick fires.
+	f.evaluator.RunOnce(ctx)
+	got, err := f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get alert: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusTriggeredForPeriod {
+		t.Errorf("status after fire = %q, want triggered_for_period", got.Status)
+	}
+	if len(f.outbox.captured) != 1 {
+		t.Fatalf("expected 1 outbox row after first fire, got %d", len(f.outbox.captured))
+	}
+
+	// Second tick within same cycle — must not fire again.
+	f.evaluator.RunOnce(ctx)
+	if len(f.outbox.captured) != 1 {
+		t.Errorf("per_period fired again within same cycle; outbox count = %d, want 1", len(f.outbox.captured))
+	}
+
+	// Roll the cycle forward + ingest more usage in the new cycle to push
+	// it across the threshold.
+	newStart := cycleEnd
+	newEnd := newStart.Add(30 * 24 * time.Hour)
+	f.rollSubCycle(t, ctx, subID, newStart, newEnd)
+
+	for i := 0; i < 100; i++ {
+		ts := newStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest cycle 2 #%d: %v", i, err)
+		}
+	}
+
+	// Tick — rearm + fire.
+	f.evaluator.RunOnce(ctx)
+
+	got, err = f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get after rearm: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusTriggeredForPeriod {
+		t.Errorf("status after rearm fire = %q, want triggered_for_period", got.Status)
+	}
+	if len(f.outbox.captured) != 2 {
+		t.Errorf("expected 2 outbox rows after cycle rollover, got %d", len(f.outbox.captured))
+	}
+
+	// Verify two distinct trigger rows exist for this alert (one per cycle).
+	count := f.countTriggers(t, ctx, alert.ID)
+	if count != 2 {
+		t.Errorf("billing_alert_triggers row count = %d, want 2", count)
+	}
+}
+
+// TestEvaluator_DoubleFireIdempotent simulates a replica race: two
+// fires for the same (alert_id, period_from). The UNIQUE constraint
+// catches the duplicate; the evaluator surfaces ErrAlreadyFired and
+// swallows it as a no-op. No second outbox row, no second trigger row.
+func TestEvaluator_DoubleFireIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts DoubleFireIdempotent")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-idem", "tokens-idem-rule", 1)
+	custID, _ := f.seedSubscription(t, ctx, "cus_alrt_idem", "pln_alrt_idem", meterID, cycleStart, cycleEnd)
+
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "spend > 500c idem",
+		CustomerID:     custID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrencePerPeriod,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	// First tick fires.
+	f.evaluator.RunOnce(ctx)
+	if len(f.outbox.captured) != 1 {
+		t.Fatalf("first tick: expected 1 outbox row, got %d", len(f.outbox.captured))
+	}
+
+	// Manually flip the alert back to 'active' to bypass the
+	// triggered-for-period guard and force a second fire attempt
+	// against the same (alert_id, period_from). The UNIQUE catches it.
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, f.tenantID)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE billing_alerts SET status='active' WHERE id=$1`, alert.ID); err != nil {
+		t.Fatalf("force active: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit force: %v", err)
+	}
+
+	f.evaluator.RunOnce(ctx)
+
+	// Outbox count must remain 1; trigger row count must remain 1.
+	if len(f.outbox.captured) != 1 {
+		t.Errorf("double-fire emitted second outbox row; count = %d", len(f.outbox.captured))
+	}
+	if got := f.countTriggers(t, ctx, alert.ID); got != 1 {
+		t.Errorf("trigger row count = %d, want 1 (UNIQUE collapsed the duplicate)", got)
+	}
+}
+
+// TestEvaluator_ArchivedSkipped: archived alerts must NOT be evaluated,
+// even when usage crosses the threshold. The partial index includes only
+// active + triggered_for_period; archived rows are excluded by predicate.
+func TestEvaluator_ArchivedSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts ArchivedSkipped")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-arc", "tokens-arc-rule", 1)
+	custID, _ := f.seedSubscription(t, ctx, "cus_alrt_arc", "pln_alrt_arc", meterID, cycleStart, cycleEnd)
+
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest: %v", err)
+		}
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "spend > 500c (will archive)",
+		CustomerID:     custID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	if _, err := f.svc.Archive(ctx, f.tenantID, alert.ID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	f.evaluator.RunOnce(ctx)
+
+	if len(f.outbox.captured) != 0 {
+		t.Errorf("archived alert fired; outbox count = %d, want 0", len(f.outbox.captured))
+	}
+	got, err := f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusArchived {
+		t.Errorf("status = %q, want archived", got.Status)
+	}
+}
+
+// TestEvaluator_BelowThresholdNoFire: alerts whose observed amount is
+// below the threshold MUST NOT fire — basic correctness.
+func TestEvaluator_BelowThresholdNoFire(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts BelowThresholdNoFire")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-low", "tokens-low-rule", 1)
+	custID, _ := f.seedSubscription(t, ctx, "cus_alrt_low", "pln_alrt_low", meterID, cycleStart, cycleEnd)
+
+	// 10 events × 10 × 1¢ = 100c. Threshold 500c → must not fire.
+	for i := 0; i < 10; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest: %v", err)
+		}
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "spend > 500c (low usage)",
+		CustomerID:     custID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	f.evaluator.RunOnce(ctx)
+
+	got, err := f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusActive {
+		t.Errorf("status = %q, want active (below threshold)", got.Status)
+	}
+	if len(f.outbox.captured) != 0 {
+		t.Errorf("below-threshold alert fired; outbox count = %d, want 0", len(f.outbox.captured))
+	}
+}
+
+// TestEvaluator_NoSubscription: a customer without an active sub has no
+// current cycle; the evaluator skips the alert (debug log) and leaves
+// status=active so it can fire when the customer resubscribes.
+func TestEvaluator_NoSubscription(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts NoSubscription")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create a customer (no sub) — required because the alert references
+	// it. The seedSimpleMeter is also required because filter.meter_id is
+	// validated by the service via meter existence check.
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-nosub", "tokens-nosub-rule", 1)
+	cust, err := f.customerSvc.Create(ctx, f.tenantID, customer.CreateInput{
+		ExternalID:  "cus_no_sub",
+		DisplayName: "no_sub",
+		Email:       "no_sub@example.test",
+	})
+	if err != nil {
+		t.Fatalf("create cust: %v", err)
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "no sub alert",
+		CustomerID:     cust.ID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	f.evaluator.RunOnce(ctx)
+
+	got, err := f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusActive {
+		t.Errorf("status = %q, want active (no sub → no cycle → skip)", got.Status)
+	}
+	if len(f.outbox.captured) != 0 {
+		t.Errorf("no-sub alert fired; outbox count = %d, want 0", len(f.outbox.captured))
+	}
+}
+
+// TestEvaluator_MultiTenantIsolation: ListCandidates runs under TxBypass
+// (cross-tenant scan) but the per-alert evaluation tx is tenant-scoped.
+// Two tenants each with an alert past threshold must each fire exactly
+// one outbox row tagged with the right tenant_id.
+func TestEvaluator_MultiTenantIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts MultiTenantIsolation")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tenantB := testutil.CreateTestTenant(t, f.db, "Alerts MultiTenantIsolation B")
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+
+	// Tenant A.
+	meterA := f.seedSimpleMeter(t, ctx, "tokens-a", "tokens-a-rule", 1)
+	custA, _ := f.seedSubscription(t, ctx, "cus_alrt_a", "pln_alrt_a", meterA, cycleStart, cycleEnd)
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custA, MeterID: meterA,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest A: %v", err)
+		}
+	}
+
+	// Tenant B — independent fixture-like setup (different tenantID).
+	customerStoreB := customer.NewPostgresStore(f.db)
+	customerSvcB := customer.NewService(customerStoreB)
+	pricingStoreB := pricing.NewPostgresStore(f.db)
+	pricingSvcB := pricing.NewService(pricingStoreB)
+	usageSvcB := usage.NewService(usage.NewPostgresStore(f.db))
+	storeB := billingalert.NewPostgresStore(f.db)
+	svcB := billingalert.NewService(storeB, customerStoreB, pricingSvcB)
+
+	rrvB, err := pricingSvcB.CreateRatingRule(ctx, tenantB, pricing.CreateRatingRuleInput{
+		RuleKey: "tokens-b-rule", Name: "B", Mode: domain.PricingFlat, Currency: "USD", FlatAmountCents: 1,
+	})
+	if err != nil {
+		t.Fatalf("rrv B: %v", err)
+	}
+	meterB, err := pricingSvcB.CreateMeter(ctx, tenantB, pricing.CreateMeterInput{
+		Key: "tokens-b", Name: "tokens-b", Unit: "tokens",
+		Aggregation: "sum", RatingRuleVersionID: rrvB.ID,
+	})
+	if err != nil {
+		t.Fatalf("meter B: %v", err)
+	}
+	planB, err := pricingSvcB.CreatePlan(ctx, tenantB, pricing.CreatePlanInput{
+		Code: "pln_b", Name: "pln_b", Currency: "USD",
+		BillingInterval: domain.BillingMonthly, MeterIDs: []string{meterB.ID},
+	})
+	if err != nil {
+		t.Fatalf("plan B: %v", err)
+	}
+	custB, err := customerSvcB.Create(ctx, tenantB, customer.CreateInput{
+		ExternalID: "cus_alrt_b", DisplayName: "B", Email: "b@example.test",
+	})
+	if err != nil {
+		t.Fatalf("cust B: %v", err)
+	}
+	subB := postgres.NewID("vlx_sub")
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, tenantB)
+	if err != nil {
+		t.Fatalf("begin sub B tx: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO subscriptions (id, tenant_id, code, display_name, customer_id, status, billing_time,
+			current_billing_period_start, current_billing_period_end, next_billing_at, created_at, updated_at)
+		VALUES ($1, $2, 'code-B', 'sub-B', $3, 'active', 'anniversary', $4, $5, $5, now(), now())
+	`, subB, tenantB, custB.ID, cycleStart, cycleEnd); err != nil {
+		t.Fatalf("insert sub B: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO subscription_items (id, tenant_id, subscription_id, plan_id, quantity, metadata, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, 1, '{}'::jsonb, now(), now())
+	`, postgres.NewID("vlx_si"), tenantB, subB, planB.ID); err != nil {
+		t.Fatalf("insert sub item B: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit sub B: %v", err)
+	}
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := usageSvcB.Ingest(ctx, tenantB, usage.IngestInput{
+			CustomerID: custB.ID, MeterID: meterB.ID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest B: %v", err)
+		}
+	}
+
+	thresholdA := int64(500)
+	if _, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title: "A alert", CustomerID: custA, MeterID: meterA,
+		AmountCentsGTE: &thresholdA, Recurrence: domain.BillingAlertRecurrenceOneTime,
+	}); err != nil {
+		t.Fatalf("create alert A: %v", err)
+	}
+	thresholdB := int64(500)
+	if _, err := svcB.Create(ctx, tenantB, billingalert.CreateRequest{
+		Title: "B alert", CustomerID: custB.ID, MeterID: meterB.ID,
+		AmountCentsGTE: &thresholdB, Recurrence: domain.BillingAlertRecurrenceOneTime,
+	}); err != nil {
+		t.Fatalf("create alert B: %v", err)
+	}
+
+	f.evaluator.RunOnce(ctx)
+
+	if len(f.outbox.captured) != 2 {
+		t.Fatalf("expected 2 outbox rows (one per tenant), got %d", len(f.outbox.captured))
+	}
+	tenants := map[string]int{}
+	for _, e := range f.outbox.captured {
+		tenants[e.tenantID]++
+	}
+	if tenants[f.tenantID] != 1 {
+		t.Errorf("tenant A outbox count = %d, want 1", tenants[f.tenantID])
+	}
+	if tenants[tenantB] != 1 {
+		t.Errorf("tenant B outbox count = %d, want 1", tenants[tenantB])
+	}
+}
+
+// TestEvaluator_AtomicityOnRollback: an outbox.Enqueue that fails MUST
+// roll back the trigger row insert + alert status update. After the
+// failed tick, the alert is still 'active' and the trigger row count is
+// zero — the invariant the whole atomicity contract rests on.
+func TestEvaluator_AtomicityOnRollback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts AtomicityOnRollback")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cycleStart := time.Now().UTC().Truncate(time.Hour).Add(-72 * time.Hour)
+	cycleEnd := cycleStart.Add(30 * 24 * time.Hour)
+	meterID := f.seedSimpleMeter(t, ctx, "tokens-atomic", "tokens-atomic-rule", 1)
+	custID, _ := f.seedSubscription(t, ctx, "cus_alrt_atomic", "pln_alrt_atomic", meterID, cycleStart, cycleEnd)
+
+	for i := 0; i < 100; i++ {
+		ts := cycleStart.Add(time.Duration(i) * time.Hour)
+		if _, err := f.usageSvc.Ingest(ctx, f.tenantID, usage.IngestInput{
+			CustomerID: custID, MeterID: meterID,
+			Quantity: decimal.NewFromInt(10), Timestamp: &ts,
+		}); err != nil {
+			t.Fatalf("ingest: %v", err)
+		}
+	}
+
+	threshold := int64(500)
+	alert, err := f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "atomic test",
+		CustomerID:     custID,
+		MeterID:        meterID,
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+	})
+	if err != nil {
+		t.Fatalf("create alert: %v", err)
+	}
+
+	// Force the outbox enqueue to fail; the evaluator should roll back
+	// the trigger+status update inside the same tx.
+	f.outbox.failNext = errors.New("simulated outbox failure")
+	f.evaluator.RunOnce(ctx)
+
+	got, err := f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusActive {
+		t.Errorf("status after failed enqueue = %q, want active (rollback)", got.Status)
+	}
+	if got.LastTriggeredAt != nil {
+		t.Errorf("last_triggered_at should be nil after rollback, got %v", got.LastTriggeredAt)
+	}
+	if got := f.countTriggers(t, ctx, alert.ID); got != 0 {
+		t.Errorf("trigger row count after rollback = %d, want 0", got)
+	}
+	if len(f.outbox.captured) != 0 {
+		t.Errorf("outbox should not have captured the failed row, got %d", len(f.outbox.captured))
+	}
+
+	// Clear the failure and re-tick; the alert should now fire cleanly.
+	f.outbox.failNext = nil
+	f.evaluator.RunOnce(ctx)
+	got, err = f.svc.Get(ctx, f.tenantID, alert.ID)
+	if err != nil {
+		t.Fatalf("get after recovery: %v", err)
+	}
+	if got.Status != domain.BillingAlertStatusTriggered {
+		t.Errorf("status after recovery tick = %q, want triggered", got.Status)
+	}
+	if len(f.outbox.captured) != 1 {
+		t.Errorf("expected 1 outbox row after recovery, got %d", len(f.outbox.captured))
+	}
+}
+
+// TestCreateAlert_RLS: cross-tenant resource references (customer, meter)
+// surface as 404, not an authorization-bypass leak. The customer / meter
+// lookups in Service.Create are tenant-scoped via RLS — a misrouted ID
+// returns ErrNotFound.
+func TestCreateAlert_RLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: skipped in -short mode")
+	}
+	f := newAlertFixture(t, "Alerts CreateRLS")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tenantB := testutil.CreateTestTenant(t, f.db, "Alerts CreateRLS B")
+
+	custB, err := f.customerSvc.Create(ctx, tenantB, customer.CreateInput{
+		ExternalID: "cus_b", DisplayName: "B", Email: "b@example.test",
+	})
+	if err != nil {
+		t.Fatalf("create cust B: %v", err)
+	}
+
+	threshold := int64(500)
+	_, err = f.svc.Create(ctx, f.tenantID, billingalert.CreateRequest{
+		Title:          "cross-tenant",
+		CustomerID:     custB.ID, // belongs to tenant B; tenant A is creating
+		AmountCentsGTE: &threshold,
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+	})
+	if !errors.Is(err, errs.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for cross-tenant customer, got %v", err)
+	}
+}
+
+// countTriggers returns the number of billing_alert_triggers rows for an
+// alert under the fixture's tenant. Used by integration tests that need
+// to assert on persistence side-effects beyond what the public service
+// surface returns.
+func (f *alertFixture) countTriggers(t *testing.T, ctx context.Context, alertID string) int {
+	t.Helper()
+	tx, err := f.db.BeginTx(ctx, postgres.TxTenant, f.tenantID)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer postgres.Rollback(tx)
+	var n int
+	if err := tx.QueryRowContext(ctx, `SELECT count(*) FROM billing_alert_triggers WHERE alert_id = $1`, alertID).Scan(&n); err != nil {
+		t.Fatalf("count triggers: %v", err)
+	}
+	return n
+}
+
+// fakeOutbox satisfies billingalert.OutboxEnqueuer with a fail-next hook
+// for atomicity tests + a captured slice the test can introspect. The
+// enqueue runs inside the caller's tx exactly like the real
+// *webhook.OutboxStore — but skips the actual INSERT. Atomicity of the
+// caller's tx is exercised through failNext: when it returns an error,
+// the caller MUST roll back, so the trigger row + status update are
+// reverted.
+type fakeOutbox struct {
+	captured []capturedOutboxRow
+	failNext error
+}
+
+type capturedOutboxRow struct {
+	tenantID  string
+	eventType string
+	payload   map[string]any
+}
+
+func (f *fakeOutbox) Enqueue(ctx context.Context, tx *sql.Tx, tenantID, eventType string, payload map[string]any) (string, error) {
+	if f.failNext != nil {
+		err := f.failNext
+		return "", err
+	}
+	f.captured = append(f.captured, capturedOutboxRow{
+		tenantID:  tenantID,
+		eventType: eventType,
+		payload:   payload,
+	})
+	return "vlx_evt_" + eventType, nil
+}
+
+// fixtureSubLister adapts *subscription.PostgresStore →
+// billingalert.SubscriptionLister with the same translation the
+// production adapters do — kept here so the integration test owns no
+// state beyond what fixture seeding produces.
+type fixtureSubLister struct {
+	store *subscription.PostgresStore
+}
+
+func (a *fixtureSubLister) List(ctx context.Context, filter billingalert.SubscriptionListFilter) ([]domain.Subscription, int, error) {
+	return a.store.List(ctx, subscription.ListFilter{
+		TenantID:   filter.TenantID,
+		CustomerID: filter.CustomerID,
+	})
+}

--- a/internal/billingalert/postgres.go
+++ b/internal/billingalert/postgres.go
@@ -1,0 +1,428 @@
+package billingalert
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+)
+
+// PostgresStore is the canonical Store implementation. Every method
+// opens its own tenant-scoped tx via postgres.TxTenant — RLS hides
+// cross-tenant rows so a misrouted request returns ErrNotFound.
+type PostgresStore struct {
+	db *postgres.DB
+}
+
+func NewPostgresStore(db *postgres.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// ErrAlreadyFired is returned by FireInTx when the UNIQUE
+// (alert_id, period_from) constraint catches a duplicate insert. The
+// evaluator treats this as a no-op (another replica or a previous
+// crashed-and-retried tick already fired this period).
+var ErrAlreadyFired = errors.New("billingalert: already fired this period")
+
+const billingAlertColumns = `
+	id, tenant_id, customer_id, title,
+	COALESCE(meter_id, ''),
+	COALESCE(dimensions, '{}'::jsonb),
+	threshold_amount_cents, threshold_quantity,
+	recurrence, status,
+	last_triggered_at, last_period_start,
+	created_at, updated_at
+`
+
+func (s *PostgresStore) Create(ctx context.Context, tenantID string, alert domain.BillingAlert) (domain.BillingAlert, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	dimsJSON, err := marshalDimensions(alert.Filter.Dimensions)
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+
+	var amount sql.NullInt64
+	if alert.Threshold.AmountCentsGTE != nil {
+		amount = sql.NullInt64{Int64: *alert.Threshold.AmountCentsGTE, Valid: true}
+	}
+	var qty sql.NullString
+	if alert.Threshold.QuantityGTE != nil {
+		qty = sql.NullString{String: alert.Threshold.QuantityGTE.String(), Valid: true}
+	}
+
+	var meterID sql.NullString
+	if strings.TrimSpace(alert.Filter.MeterID) != "" {
+		meterID = sql.NullString{String: alert.Filter.MeterID, Valid: true}
+	}
+
+	id := postgres.NewID("vlx_alrt")
+	row := tx.QueryRowContext(ctx, `
+		INSERT INTO billing_alerts (
+			id, tenant_id, customer_id, title, meter_id, dimensions,
+			threshold_amount_cents, threshold_quantity, recurrence, status
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active')
+		RETURNING `+billingAlertColumns,
+		id, tenantID, alert.CustomerID, alert.Title,
+		meterID, dimsJSON, amount, qty, string(alert.Recurrence),
+	)
+	out, err := scanAlert(row)
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.BillingAlert{}, err
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) Get(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	row := tx.QueryRowContext(ctx, `SELECT `+billingAlertColumns+` FROM billing_alerts WHERE id = $1`, id)
+	out, err := scanAlert(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.BillingAlert{}, errs.ErrNotFound
+	}
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.BillingAlert{}, err
+	}
+	return out, nil
+}
+
+func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.BillingAlert, int, error) {
+	if filter.Limit <= 0 {
+		filter.Limit = 50
+	}
+	if filter.Limit > 200 {
+		filter.Limit = 200
+	}
+	if filter.Offset < 0 {
+		filter.Offset = 0
+	}
+
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, filter.TenantID)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer postgres.Rollback(tx)
+
+	var (
+		conds  []string
+		args   []any
+		argIdx = 1
+	)
+	if strings.TrimSpace(filter.CustomerID) != "" {
+		conds = append(conds, fmt.Sprintf("customer_id = $%d", argIdx))
+		args = append(args, filter.CustomerID)
+		argIdx++
+	}
+	if strings.TrimSpace(string(filter.Status)) != "" {
+		conds = append(conds, fmt.Sprintf("status = $%d", argIdx))
+		args = append(args, string(filter.Status))
+		argIdx++
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	var total int
+	if err := tx.QueryRowContext(ctx,
+		"SELECT count(*) FROM billing_alerts "+where, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	args = append(args, filter.Limit, filter.Offset)
+	rows, err := tx.QueryContext(ctx,
+		"SELECT "+billingAlertColumns+" FROM billing_alerts "+where+
+			" ORDER BY created_at DESC LIMIT $"+itoa(argIdx)+" OFFSET $"+itoa(argIdx+1),
+		args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.BillingAlert
+	for rows.Next() {
+		alert, err := scanAlert(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		out = append(out, alert)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+func (s *PostgresStore) Archive(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	row := tx.QueryRowContext(ctx, `
+		UPDATE billing_alerts
+		SET status = 'archived', updated_at = now()
+		WHERE id = $1
+		RETURNING `+billingAlertColumns,
+		id,
+	)
+	out, err := scanAlert(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.BillingAlert{}, errs.ErrNotFound
+	}
+	if err != nil {
+		return domain.BillingAlert{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.BillingAlert{}, err
+	}
+	return out, nil
+}
+
+// ListCandidates returns alerts the evaluator should evaluate this
+// tick. Runs under TxBypass because the evaluator is cross-tenant
+// (one leader per cluster) and needs to see every armed alert.
+//
+// The partial index idx_billing_alerts_evaluator keeps this scan
+// bounded to currently-firing-eligible rows.
+func (s *PostgresStore) ListCandidates(ctx context.Context, limit int) ([]domain.BillingAlert, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	tx, err := s.db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		return nil, err
+	}
+	defer postgres.Rollback(tx)
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT `+billingAlertColumns+`
+		FROM billing_alerts
+		WHERE status IN ('active','triggered_for_period')
+		ORDER BY created_at
+		LIMIT $1
+	`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []domain.BillingAlert
+	for rows.Next() {
+		alert, err := scanAlert(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, alert)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// FireInTx inserts the trigger row + updates the alert's status. The
+// caller (the evaluator) holds the tx open across this method and
+// the outbox enqueue, then commits both atomically.
+func (s *PostgresStore) FireInTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	alert domain.BillingAlert,
+	trigger domain.BillingAlertTrigger,
+	newStatus domain.BillingAlertStatus,
+) (domain.BillingAlertTrigger, error) {
+	id := postgres.NewID("vlx_atrg")
+	qty := trigger.ObservedQuantity
+	if qty.Equal(decimal.Zero) {
+		qty = decimal.Zero
+	}
+
+	row := tx.QueryRowContext(ctx, `
+		INSERT INTO billing_alert_triggers (
+			id, tenant_id, alert_id, period_from, period_to,
+			observed_amount_cents, observed_quantity, currency
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, tenant_id, alert_id, period_from, period_to,
+			observed_amount_cents, observed_quantity, currency, triggered_at
+	`,
+		id, alert.TenantID, alert.ID, trigger.PeriodFrom, trigger.PeriodTo,
+		trigger.ObservedAmountCents, qty.String(), trigger.Currency,
+	)
+
+	var inserted domain.BillingAlertTrigger
+	var qtyStr string
+	if err := row.Scan(
+		&inserted.ID, &inserted.TenantID, &inserted.AlertID,
+		&inserted.PeriodFrom, &inserted.PeriodTo,
+		&inserted.ObservedAmountCents, &qtyStr, &inserted.Currency,
+		&inserted.TriggeredAt,
+	); err != nil {
+		// Postgres unique-violation (SQLSTATE 23505). Surface as our
+		// sentinel so the evaluator can swallow + skip without
+		// double-emitting.
+		if postgres.IsUniqueViolation(err) {
+			return domain.BillingAlertTrigger{}, ErrAlreadyFired
+		}
+		return domain.BillingAlertTrigger{}, fmt.Errorf("insert billing_alert_trigger: %w", err)
+	}
+	parsed, err := decimal.NewFromString(qtyStr)
+	if err != nil {
+		return domain.BillingAlertTrigger{}, fmt.Errorf("parse observed_quantity %q: %w", qtyStr, err)
+	}
+	inserted.ObservedQuantity = parsed
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE billing_alerts
+		SET status = $2,
+		    last_triggered_at = $3,
+		    last_period_start = $4,
+		    updated_at = now()
+		WHERE id = $1
+	`, alert.ID, string(newStatus), inserted.TriggeredAt, trigger.PeriodFrom); err != nil {
+		return domain.BillingAlertTrigger{}, fmt.Errorf("update billing_alert: %w", err)
+	}
+
+	return inserted, nil
+}
+
+func (s *PostgresStore) Rearm(ctx context.Context, tenantID, alertID string) error {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return err
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE billing_alerts
+		SET status = 'active', updated_at = now()
+		WHERE id = $1 AND status = 'triggered_for_period'
+	`, alertID); err != nil {
+		return fmt.Errorf("rearm billing_alert: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (s *PostgresStore) BeginTenantTx(ctx context.Context, tenantID string) (*sql.Tx, error) {
+	return s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+}
+
+// rowScanner abstracts QueryRowContext / Rows.Scan into one helper so
+// per-column scan code only lives in scanAlert.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAlert(rs rowScanner) (domain.BillingAlert, error) {
+	var (
+		alert      domain.BillingAlert
+		meterID    string
+		dimsJSON   []byte
+		amountNI   sql.NullInt64
+		qtyNS      sql.NullString
+		recurrence string
+		status     string
+		lastTrig   sql.NullTime
+		lastPeriod sql.NullTime
+	)
+	if err := rs.Scan(
+		&alert.ID, &alert.TenantID, &alert.CustomerID, &alert.Title,
+		&meterID, &dimsJSON,
+		&amountNI, &qtyNS,
+		&recurrence, &status,
+		&lastTrig, &lastPeriod,
+		&alert.CreatedAt, &alert.UpdatedAt,
+	); err != nil {
+		return domain.BillingAlert{}, err
+	}
+
+	alert.Filter.MeterID = meterID
+	if len(dimsJSON) > 0 {
+		var dims map[string]any
+		if err := json.Unmarshal(dimsJSON, &dims); err != nil {
+			return domain.BillingAlert{}, fmt.Errorf("unmarshal dimensions: %w", err)
+		}
+		alert.Filter.Dimensions = dims
+	}
+	if alert.Filter.Dimensions == nil {
+		alert.Filter.Dimensions = map[string]any{}
+	}
+
+	if amountNI.Valid {
+		v := amountNI.Int64
+		alert.Threshold.AmountCentsGTE = &v
+	}
+	if qtyNS.Valid {
+		parsed, err := decimal.NewFromString(qtyNS.String)
+		if err != nil {
+			return domain.BillingAlert{}, fmt.Errorf("parse threshold_quantity: %w", err)
+		}
+		alert.Threshold.QuantityGTE = &parsed
+	}
+
+	alert.Recurrence = domain.BillingAlertRecurrence(recurrence)
+	alert.Status = domain.BillingAlertStatus(status)
+	if lastTrig.Valid {
+		t := lastTrig.Time
+		alert.LastTriggeredAt = &t
+	}
+	if lastPeriod.Valid {
+		t := lastPeriod.Time
+		alert.LastPeriodStart = &t
+	}
+	return alert, nil
+}
+
+// marshalDimensions converts the always-object map to JSON bytes for
+// the JSONB column. nil → '{}' (the always-object identity).
+func marshalDimensions(dims map[string]any) ([]byte, error) {
+	if dims == nil {
+		dims = map[string]any{}
+	}
+	return json.Marshal(dims)
+}
+
+// itoa converts a small positive int to its decimal string. Avoids
+// pulling in strconv just to interpolate parameter indices.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [16]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/billingalert/service.go
+++ b/internal/billingalert/service.go
@@ -1,0 +1,210 @@
+package billingalert
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+)
+
+// Service is the read/write surface backing the four /v1/billing/alerts
+// endpoints. Wire-handlers translate JSON to/from the request types
+// here; the service validates inputs, verifies referential integrity,
+// and delegates persistence to Store.
+type Service struct {
+	store     Store
+	customers CustomerLookup
+	meters    MeterLookup
+}
+
+// NewService wires the composition. customers and meters can be the
+// same store implementation (customer.Store satisfies CustomerLookup,
+// pricing.Service satisfies MeterLookup) — the narrow seam exists so
+// the unit tests can use fakes.
+func NewService(store Store, customers CustomerLookup, meters MeterLookup) *Service {
+	return &Service{store: store, customers: customers, meters: meters}
+}
+
+// CreateRequest is the input shape for Service.Create. Decoupled from
+// the HTTP wire shape so wire-shape changes don't force service-layer
+// signatures to change in lockstep.
+type CreateRequest struct {
+	Title          string
+	CustomerID     string
+	MeterID        string
+	Dimensions     map[string]any
+	AmountCentsGTE *int64
+	QuantityGTE    *decimal.Decimal
+	Recurrence     domain.BillingAlertRecurrence
+}
+
+// MaxTitleLen caps the dashboard-visible title. 200 chars matches
+// other display fields (plan.name, coupon.code) and keeps the column
+// indexable without bloat.
+const MaxTitleLen = 200
+
+// MaxDimensionKeys mirrors the cap on usage_events.dimensions and
+// meter_pricing_rules.dimension_match — keeps the JSONB column
+// cheap to validate on every insert.
+const MaxDimensionKeys = 16
+
+// Create validates the request, verifies the customer / meter exist
+// for this tenant, and persists the alert. Cross-tenant customer or
+// meter IDs surface as 404 via RLS — the lookup returns ErrNotFound
+// and we wrap it with the appropriate field annotation.
+func (s *Service) Create(ctx context.Context, tenantID string, req CreateRequest) (domain.BillingAlert, error) {
+	title := strings.TrimSpace(req.Title)
+	customerID := strings.TrimSpace(req.CustomerID)
+
+	if title == "" {
+		return domain.BillingAlert{}, errs.Required("title")
+	}
+	if len(title) > MaxTitleLen {
+		return domain.BillingAlert{}, errs.Invalid("title", fmt.Sprintf("must be ≤ %d characters", MaxTitleLen))
+	}
+	if customerID == "" {
+		return domain.BillingAlert{}, errs.Required("customer_id")
+	}
+	if req.Recurrence != domain.BillingAlertRecurrenceOneTime && req.Recurrence != domain.BillingAlertRecurrencePerPeriod {
+		return domain.BillingAlert{}, errs.Invalid("recurrence", "must be one of one_time, per_period")
+	}
+
+	// Threshold validation: exactly one of amount_gte / usage_gte must
+	// be set. Both nil = no fire condition; both set = ambiguous.
+	hasAmount := req.AmountCentsGTE != nil
+	hasQty := req.QuantityGTE != nil
+	if !hasAmount && !hasQty {
+		return domain.BillingAlert{}, errs.Required("threshold")
+	}
+	if hasAmount && hasQty {
+		return domain.BillingAlert{}, errs.Invalid("threshold", "exactly one of amount_gte or usage_gte must be set")
+	}
+	if hasAmount && *req.AmountCentsGTE <= 0 {
+		return domain.BillingAlert{}, errs.Invalid("threshold.amount_gte", "must be > 0")
+	}
+	if hasQty && req.QuantityGTE.Sign() <= 0 {
+		return domain.BillingAlert{}, errs.Invalid("threshold.usage_gte", "must be > 0")
+	}
+
+	meterID := strings.TrimSpace(req.MeterID)
+	if hasQty && meterID == "" {
+		return domain.BillingAlert{}, errs.Invalid(
+			"threshold.usage_gte",
+			"only valid when filter.meter_id is set — cross-meter quantity sums are not well-defined",
+		)
+	}
+
+	// Dimensions must be a scalar-leaf map (same contract usage events
+	// follow). Empty / nil → '{}' — always-object idiom downstream.
+	if len(req.Dimensions) > 0 && meterID == "" {
+		return domain.BillingAlert{}, errs.Invalid(
+			"filter.dimensions",
+			"only valid when filter.meter_id is set — cross-meter dimension filtering not supported in v1",
+		)
+	}
+	if err := validateDimensions(req.Dimensions); err != nil {
+		return domain.BillingAlert{}, err
+	}
+
+	// RLS-safe existence checks. Cross-tenant IDs return ErrNotFound
+	// from the store; we surface as a 404 with the field tagged so the
+	// frontend can route the message.
+	if _, err := s.customers.Get(ctx, tenantID, customerID); err != nil {
+		return domain.BillingAlert{}, err
+	}
+	if meterID != "" {
+		if _, err := s.meters.GetMeter(ctx, tenantID, meterID); err != nil {
+			return domain.BillingAlert{}, err
+		}
+	}
+
+	dims := req.Dimensions
+	if dims == nil {
+		dims = map[string]any{}
+	}
+
+	alert := domain.BillingAlert{
+		TenantID:   tenantID,
+		CustomerID: customerID,
+		Title:      title,
+		Filter: domain.BillingAlertFilter{
+			MeterID:    meterID,
+			Dimensions: dims,
+		},
+		Threshold: domain.BillingAlertThreshold{
+			AmountCentsGTE: req.AmountCentsGTE,
+			QuantityGTE:    req.QuantityGTE,
+		},
+		Recurrence: req.Recurrence,
+		Status:     domain.BillingAlertStatusActive,
+	}
+
+	return s.store.Create(ctx, tenantID, alert)
+}
+
+// Get fetches a single alert by ID. Cross-tenant ID returns
+// ErrNotFound (RLS hides the row).
+func (s *Service) Get(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return domain.BillingAlert{}, errs.Required("id")
+	}
+	return s.store.Get(ctx, tenantID, id)
+}
+
+// List paginates alerts for the tenant. Filter shape matches the wire
+// query params; empty fields are ignored.
+func (s *Service) List(ctx context.Context, filter ListFilter) ([]domain.BillingAlert, int, error) {
+	filter.TenantID = strings.TrimSpace(filter.TenantID)
+	if filter.TenantID == "" {
+		return nil, 0, errs.Required("tenant_id")
+	}
+	// Trim status to the known enum or treat as no filter. Unknown
+	// values surface as 422 so the caller knows their filter was
+	// dropped — silently accepting "unknown" would mask client bugs.
+	if filter.Status != "" {
+		switch filter.Status {
+		case domain.BillingAlertStatusActive,
+			domain.BillingAlertStatusTriggered,
+			domain.BillingAlertStatusTriggeredForPeriod,
+			domain.BillingAlertStatusArchived:
+			// ok
+		default:
+			return nil, 0, errs.Invalid("status", "must be one of active, triggered, triggered_for_period, archived")
+		}
+	}
+	return s.store.List(ctx, filter)
+}
+
+// Archive flips the alert's status to archived. Idempotent — archiving
+// an already-archived alert returns the same shape with no error.
+func (s *Service) Archive(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return domain.BillingAlert{}, errs.Required("id")
+	}
+	return s.store.Archive(ctx, tenantID, id)
+}
+
+// validateDimensions enforces the same scalar-leaf, max-keys contract
+// usage events follow. Dimensions feed pricing-rule subset matches at
+// fire time; bounding the per-row JSONB protects the GIN index from
+// pathological tenants.
+func validateDimensions(dims map[string]any) error {
+	if len(dims) > MaxDimensionKeys {
+		return errs.Invalid("filter.dimensions", fmt.Sprintf("at most %d keys (got %d)", MaxDimensionKeys, len(dims)))
+	}
+	for k, v := range dims {
+		switch v.(type) {
+		case nil, string, bool, float64, float32, int, int32, int64:
+			// scalar
+		default:
+			return errs.Invalid("filter.dimensions", fmt.Sprintf("key %q value must be a scalar (string/number/bool), got %T", k, v))
+		}
+	}
+	return nil
+}

--- a/internal/billingalert/service_test.go
+++ b/internal/billingalert/service_test.go
@@ -1,0 +1,349 @@
+package billingalert
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+)
+
+// TestService_Create_Validation table-drives every input check the
+// service performs before persistence. Each row is a minimal request +
+// the expected validation field — all rows MUST surface a DomainError
+// tagged with the right field so the dashboard can route the message.
+func TestService_Create_Validation(t *testing.T) {
+	amount := int64(10000)
+	zeroAmount := int64(0)
+	negAmount := int64(-1)
+	qty := decimal.RequireFromString("100")
+	zeroQty := decimal.Zero
+
+	cases := []struct {
+		name      string
+		req       CreateRequest
+		wantField string
+	}{
+		{
+			name:      "title_required",
+			req:       CreateRequest{Title: "  ", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime, AmountCentsGTE: &amount},
+			wantField: "title",
+		},
+		{
+			name:      "title_too_long",
+			req:       CreateRequest{Title: strings.Repeat("x", MaxTitleLen+1), CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime, AmountCentsGTE: &amount},
+			wantField: "title",
+		},
+		{
+			name:      "customer_required",
+			req:       CreateRequest{Title: "ok", CustomerID: "  ", Recurrence: domain.BillingAlertRecurrenceOneTime, AmountCentsGTE: &amount},
+			wantField: "customer_id",
+		},
+		{
+			name:      "recurrence_invalid",
+			req:       CreateRequest{Title: "ok", CustomerID: "vlx_cus", Recurrence: "weekly", AmountCentsGTE: &amount},
+			wantField: "recurrence",
+		},
+		{
+			name:      "threshold_required",
+			req:       CreateRequest{Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime},
+			wantField: "threshold",
+		},
+		{
+			name: "threshold_both_set",
+			req: CreateRequest{
+				Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime,
+				AmountCentsGTE: &amount, QuantityGTE: &qty, MeterID: "vlx_mtr",
+			},
+			wantField: "threshold",
+		},
+		{
+			name:      "amount_zero",
+			req:       CreateRequest{Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime, AmountCentsGTE: &zeroAmount},
+			wantField: "threshold.amount_gte",
+		},
+		{
+			name:      "amount_negative",
+			req:       CreateRequest{Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime, AmountCentsGTE: &negAmount},
+			wantField: "threshold.amount_gte",
+		},
+		{
+			name: "quantity_zero",
+			req: CreateRequest{
+				Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime,
+				QuantityGTE: &zeroQty, MeterID: "vlx_mtr",
+			},
+			wantField: "threshold.usage_gte",
+		},
+		{
+			name: "usage_without_meter",
+			req: CreateRequest{
+				Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime,
+				QuantityGTE: &qty, // no MeterID
+			},
+			wantField: "threshold.usage_gte",
+		},
+		{
+			name: "dimensions_without_meter",
+			req: CreateRequest{
+				Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime,
+				AmountCentsGTE: &amount,
+				Dimensions:     map[string]any{"model": "gpt-4"},
+			},
+			wantField: "filter.dimensions",
+		},
+		{
+			name: "dimensions_too_many_keys",
+			req: CreateRequest{
+				Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime,
+				AmountCentsGTE: &amount, MeterID: "vlx_mtr",
+				Dimensions: makeDimensionMap(MaxDimensionKeys + 1),
+			},
+			wantField: "filter.dimensions",
+		},
+		{
+			name: "dimensions_non_scalar_value",
+			req: CreateRequest{
+				Title: "ok", CustomerID: "vlx_cus", Recurrence: domain.BillingAlertRecurrenceOneTime,
+				AmountCentsGTE: &amount, MeterID: "vlx_mtr",
+				Dimensions: map[string]any{"nested": map[string]any{"x": 1}},
+			},
+			wantField: "filter.dimensions",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewService(&fakeStore{}, &fakeCustomers{ok: true}, &fakeMeters{ok: true})
+			_, err := svc.Create(context.Background(), "vlx_tenant", tc.req)
+			if err == nil {
+				t.Fatalf("expected validation error, got nil")
+			}
+			if got := errs.Field(err); got != tc.wantField {
+				t.Errorf("field = %q, want %q (err=%v)", got, tc.wantField, err)
+			}
+			if !errors.Is(err, errs.ErrValidation) {
+				t.Errorf("error must be a validation kind, got %v", err)
+			}
+		})
+	}
+}
+
+// TestService_Create_HappyPath ensures the simplest valid request reaches
+// the store.Create call cleanly with the trimmed, normalized inputs.
+func TestService_Create_HappyPath(t *testing.T) {
+	amount := int64(50000)
+	store := &fakeStore{}
+	svc := NewService(store, &fakeCustomers{ok: true}, &fakeMeters{ok: true})
+
+	req := CreateRequest{
+		Title:          "  Acme spend > $500  ",
+		CustomerID:     "  vlx_cus_abc  ",
+		Recurrence:     domain.BillingAlertRecurrencePerPeriod,
+		AmountCentsGTE: &amount,
+	}
+	_, err := svc.Create(context.Background(), "vlx_tenant", req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !store.created {
+		t.Fatal("expected store.Create to be called")
+	}
+	if store.lastAlert.Title != "Acme spend > $500" {
+		t.Errorf("title not trimmed: %q", store.lastAlert.Title)
+	}
+	if store.lastAlert.CustomerID != "vlx_cus_abc" {
+		t.Errorf("customer_id not trimmed: %q", store.lastAlert.CustomerID)
+	}
+	// Always-object idiom: nil dimensions become {}.
+	if store.lastAlert.Filter.Dimensions == nil {
+		t.Error("filter.dimensions should be {} not nil")
+	}
+}
+
+// TestService_Create_CustomerNotFound checks the cross-tenant 404 path:
+// when the customer lookup returns ErrNotFound (RLS hides cross-tenant
+// rows), Create propagates the same sentinel so the handler can map to 404.
+func TestService_Create_CustomerNotFound(t *testing.T) {
+	amount := int64(10000)
+	svc := NewService(&fakeStore{}, &fakeCustomers{notFound: true}, &fakeMeters{ok: true})
+	_, err := svc.Create(context.Background(), "vlx_tenant", CreateRequest{
+		Title:          "ok",
+		CustomerID:     "vlx_cus_other_tenant",
+		Recurrence:     domain.BillingAlertRecurrenceOneTime,
+		AmountCentsGTE: &amount,
+	})
+	if !errors.Is(err, errs.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestService_Create_MeterNotFound checks the same 404 propagation for
+// the meter lookup when filter.meter_id is set.
+func TestService_Create_MeterNotFound(t *testing.T) {
+	qty := decimal.RequireFromString("100")
+	svc := NewService(&fakeStore{}, &fakeCustomers{ok: true}, &fakeMeters{notFound: true})
+	_, err := svc.Create(context.Background(), "vlx_tenant", CreateRequest{
+		Title:       "ok",
+		CustomerID:  "vlx_cus",
+		Recurrence:  domain.BillingAlertRecurrenceOneTime,
+		QuantityGTE: &qty,
+		MeterID:     "vlx_mtr_other_tenant",
+	})
+	if !errors.Is(err, errs.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestService_List_StatusValidation drops unknown filter values rather
+// than silently serving them — frontend bugs must surface as 422.
+func TestService_List_StatusValidation(t *testing.T) {
+	svc := NewService(&fakeStore{}, &fakeCustomers{ok: true}, &fakeMeters{ok: true})
+
+	_, _, err := svc.List(context.Background(), ListFilter{
+		TenantID: "vlx_tenant",
+		Status:   "weird_status",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unknown status")
+	}
+	if errs.Field(err) != "status" {
+		t.Errorf("expected field=status, got %q", errs.Field(err))
+	}
+
+	// Empty status is fine — no filter.
+	_, _, err = svc.List(context.Background(), ListFilter{TenantID: "vlx_tenant"})
+	if err != nil {
+		t.Errorf("empty status should be OK, got %v", err)
+	}
+
+	// Each known status passes.
+	for _, s := range []domain.BillingAlertStatus{
+		domain.BillingAlertStatusActive,
+		domain.BillingAlertStatusTriggered,
+		domain.BillingAlertStatusTriggeredForPeriod,
+		domain.BillingAlertStatusArchived,
+	} {
+		_, _, err := svc.List(context.Background(), ListFilter{TenantID: "vlx_tenant", Status: s})
+		if err != nil {
+			t.Errorf("status %q should pass, got %v", s, err)
+		}
+	}
+}
+
+// TestService_Get_RequiresID — defence in depth: the handler already
+// pulls id from the URL pattern, but the service still validates so a
+// direct call from a future internal caller can't bypass.
+func TestService_Get_RequiresID(t *testing.T) {
+	svc := NewService(&fakeStore{}, &fakeCustomers{ok: true}, &fakeMeters{ok: true})
+	_, err := svc.Get(context.Background(), "vlx_tenant", "  ")
+	if errs.Field(err) != "id" {
+		t.Errorf("expected field=id, got %q (err=%v)", errs.Field(err), err)
+	}
+}
+
+// TestService_Archive_Idempotent checks the documented contract: archive
+// returns the alert (status=archived) on each call without erroring on
+// already-archived rows. The store fake's Archive implementation mirrors
+// that behaviour (RETURNING the post-update row works the same on
+// repeat).
+func TestService_Archive_Idempotent(t *testing.T) {
+	svc := NewService(&fakeStore{
+		archived: domain.BillingAlert{
+			ID:     "vlx_alrt_1",
+			Status: domain.BillingAlertStatusArchived,
+		},
+	}, &fakeCustomers{ok: true}, &fakeMeters{ok: true})
+
+	first, err := svc.Archive(context.Background(), "vlx_tenant", "vlx_alrt_1")
+	if err != nil {
+		t.Fatalf("first archive: %v", err)
+	}
+	if first.Status != domain.BillingAlertStatusArchived {
+		t.Errorf("expected status=archived, got %q", first.Status)
+	}
+
+	second, err := svc.Archive(context.Background(), "vlx_tenant", "vlx_alrt_1")
+	if err != nil {
+		t.Errorf("second archive errored: %v", err)
+	}
+	if second.Status != domain.BillingAlertStatusArchived {
+		t.Errorf("second archive status not stable: %q", second.Status)
+	}
+}
+
+// makeDimensionMap returns a fresh map with `n` simple string entries.
+// Used to construct over-cap dimension fixtures without copy/paste.
+func makeDimensionMap(n int) map[string]any {
+	out := make(map[string]any, n)
+	for i := 0; i < n; i++ {
+		out["k"+itoa(i)] = "v"
+	}
+	return out
+}
+
+// fakeStore is the in-memory Store the service tests drive. We only
+// implement enough surface to satisfy the Service paths exercised here;
+// integration tests exercise the real PostgresStore.
+type fakeStore struct {
+	created   bool
+	lastAlert domain.BillingAlert
+	archived  domain.BillingAlert
+}
+
+func (f *fakeStore) Create(ctx context.Context, tenantID string, alert domain.BillingAlert) (domain.BillingAlert, error) {
+	f.created = true
+	f.lastAlert = alert
+	return alert, nil
+}
+func (f *fakeStore) Get(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+	return f.lastAlert, nil
+}
+func (f *fakeStore) List(ctx context.Context, filter ListFilter) ([]domain.BillingAlert, int, error) {
+	return nil, 0, nil
+}
+func (f *fakeStore) Archive(ctx context.Context, tenantID, id string) (domain.BillingAlert, error) {
+	if f.archived.ID == "" {
+		f.archived = domain.BillingAlert{ID: id, Status: domain.BillingAlertStatusArchived}
+	}
+	return f.archived, nil
+}
+func (f *fakeStore) ListCandidates(ctx context.Context, limit int) ([]domain.BillingAlert, error) {
+	return nil, nil
+}
+func (f *fakeStore) FireInTx(ctx context.Context, tx *sql.Tx, alert domain.BillingAlert, trigger domain.BillingAlertTrigger, newStatus domain.BillingAlertStatus) (domain.BillingAlertTrigger, error) {
+	return trigger, nil
+}
+func (f *fakeStore) Rearm(ctx context.Context, tenantID, alertID string) error { return nil }
+func (f *fakeStore) BeginTenantTx(ctx context.Context, tenantID string) (*sql.Tx, error) {
+	return nil, nil
+}
+
+type fakeCustomers struct {
+	ok       bool
+	notFound bool
+}
+
+func (f *fakeCustomers) Get(ctx context.Context, tenantID, id string) (domain.Customer, error) {
+	if f.notFound {
+		return domain.Customer{}, errs.ErrNotFound
+	}
+	return domain.Customer{ID: id, TenantID: tenantID}, nil
+}
+
+type fakeMeters struct {
+	ok       bool
+	notFound bool
+}
+
+func (f *fakeMeters) GetMeter(ctx context.Context, tenantID, id string) (domain.Meter, error) {
+	if f.notFound {
+		return domain.Meter{}, errs.ErrNotFound
+	}
+	return domain.Meter{ID: id, TenantID: tenantID}, nil
+}

--- a/internal/billingalert/store.go
+++ b/internal/billingalert/store.go
@@ -1,0 +1,141 @@
+// Package billingalert implements operator-configured billing alerts —
+// thresholds that fire a webhook + dashboard notification when a
+// customer's cycle spend crosses a limit. See
+// docs/design-billing-alerts.md for the full design.
+//
+// The package is composed of:
+//   - Store / postgres.go : persistence with RLS + outbox-enqueue helper.
+//   - Service              : Create / Get / List / Archive surface.
+//   - Handler              : chi router for the four HTTP endpoints.
+//   - Evaluator            : background trigger that scans active alerts
+//     on a tick and emits billing.alert.triggered
+//     via the webhook outbox atomically.
+//
+// Cross-domain dependencies are narrow interfaces (CustomerLookup,
+// SubscriptionLister, PricingReader, OutboxEnqueuer) so this package
+// doesn't import its sibling domains directly.
+package billingalert
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// Store is the persistence surface for billing alerts. Each method opens
+// a tenant-scoped tx via postgres.TxTenant; cross-tenant IDs naturally
+// 404 because RLS hides the row.
+//
+// EnqueueOutboxRow is the bridge into the webhook outbox: the evaluator's
+// per-alert tx must insert the trigger row, update the alert's status,
+// and enqueue the outbound webhook event together. Wrapping a single tx
+// is the source of truth for atomicity.
+type Store interface {
+	Create(ctx context.Context, tenantID string, alert domain.BillingAlert) (domain.BillingAlert, error)
+	Get(ctx context.Context, tenantID, id string) (domain.BillingAlert, error)
+	List(ctx context.Context, filter ListFilter) ([]domain.BillingAlert, int, error)
+	Archive(ctx context.Context, tenantID, id string) (domain.BillingAlert, error)
+
+	// ListCandidates returns alerts the evaluator should evaluate this
+	// tick — status IN ('active','triggered_for_period') across all
+	// tenants. The evaluator runs under TxBypass (cross-tenant scan)
+	// and then opens a per-alert TxTenant for the actual read+fire+commit.
+	ListCandidates(ctx context.Context, limit int) ([]domain.BillingAlert, error)
+
+	// FireInTx is called by the evaluator inside a tenant-scoped tx
+	// after determining that an alert should fire. It inserts the
+	// trigger row, updates the alert's status / last_triggered_at /
+	// last_period_start, and returns the inserted trigger. The caller
+	// is responsible for enqueueing the outbox row in the same tx and
+	// committing.
+	//
+	// Returns ErrAlreadyFired (sentinel) when UNIQUE (alert_id,
+	// period_from) collides — the caller should treat this as a no-op
+	// (the period was already fired by another evaluator).
+	FireInTx(ctx context.Context, tx *sql.Tx, alert domain.BillingAlert, trigger domain.BillingAlertTrigger, newStatus domain.BillingAlertStatus) (domain.BillingAlertTrigger, error)
+
+	// Rearm is called by the evaluator when a per_period alert's
+	// last_period_start is older than the customer's current cycle
+	// start. Flips the alert back to 'active' so a fresh evaluation
+	// can fire on the new cycle.
+	Rearm(ctx context.Context, tenantID, alertID string) error
+
+	// BeginTenantTx is exposed so the evaluator can open the same tx
+	// it uses for FireInTx and pass it to OutboxEnqueuer.Enqueue.
+	BeginTenantTx(ctx context.Context, tenantID string) (*sql.Tx, error)
+}
+
+// ListFilter is the query shape for the list endpoint.
+type ListFilter struct {
+	TenantID   string
+	CustomerID string
+	Status     domain.BillingAlertStatus
+	Limit      int
+	Offset     int
+}
+
+// OutboxEnqueuer is the narrow surface the evaluator needs from the
+// webhook outbox. Mirrors webhook.OutboxStore.Enqueue — implemented by
+// *webhook.OutboxStore in production, by a fake in unit tests.
+//
+// The Enqueue runs inside the caller's tx so the outbox row commits
+// atomically with the alert state change.
+type OutboxEnqueuer interface {
+	Enqueue(ctx context.Context, tx *sql.Tx, tenantID, eventType string, payload map[string]any) (string, error)
+}
+
+// CustomerLookup is the narrow surface used to verify customer
+// existence on Create. Mirrors customer.Store.Get.
+type CustomerLookup interface {
+	Get(ctx context.Context, tenantID, id string) (domain.Customer, error)
+}
+
+// MeterLookup is the narrow surface used to verify meter existence on
+// Create when filter.meter_id is supplied.
+type MeterLookup interface {
+	GetMeter(ctx context.Context, tenantID, id string) (domain.Meter, error)
+}
+
+// SubscriptionLister returns the customer's subscriptions so the
+// evaluator can resolve the current billing cycle. Same shape
+// customer-usage and create_preview consume.
+type SubscriptionLister interface {
+	List(ctx context.Context, filter SubscriptionListFilter) ([]domain.Subscription, int, error)
+}
+
+// SubscriptionListFilter is decoupled from the subscription package's
+// own ListFilter so this package doesn't import its sibling. The
+// adapter in api/router.go translates between the two.
+type SubscriptionListFilter struct {
+	TenantID   string
+	CustomerID string
+}
+
+// PricingReader is the narrow read surface for resolving plan / meter
+// metadata during evaluation. Mirrors what create_preview consumes.
+type PricingReader interface {
+	GetPlan(ctx context.Context, tenantID, id string) (domain.Plan, error)
+	GetMeter(ctx context.Context, tenantID, id string) (domain.Meter, error)
+	GetRatingRule(ctx context.Context, tenantID, id string) (domain.RatingRuleVersion, error)
+	ListMeterPricingRulesByMeter(ctx context.Context, tenantID, meterID string) ([]domain.MeterPricingRule, error)
+}
+
+// UsageAggregator is the narrow aggregation surface — single method
+// from usage.Service. The evaluator's hot read.
+type UsageAggregator interface {
+	AggregateByPricingRules(ctx context.Context, tenantID, customerID, meterID string, defaultMode domain.AggregationMode, from, to time.Time) ([]domain.RuleAggregation, error)
+}
+
+// Locker mirrors postgres.DB.TryAdvisoryLock through a narrow seam so
+// the evaluator can be unit-tested without a real Postgres.
+type Locker interface {
+	TryAdvisoryLock(ctx context.Context, key int64) (Lock, bool, error)
+}
+
+// Lock is a held cluster-wide lock. Release frees it. Same shape as
+// billing.Lock.
+type Lock interface {
+	Release()
+}

--- a/internal/billingalert/wire_shape_test.go
+++ b/internal/billingalert/wire_shape_test.go
@@ -1,0 +1,396 @@
+package billingalert
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// TestWireShape_SnakeCase pins the JSON contract Track B's billing-alerts
+// dashboard depends on — both the four /v1/billing/alerts endpoints and the
+// outbound billing.alert.triggered webhook payload. Drift here (e.g.
+// dropping a json:"…" tag and falling back to PascalCase, or `dimensions`
+// marshaling as null when empty) breaks the frontend at runtime, so we
+// marshal a fully-populated alert + webhook payload and assert:
+//
+//   - Every documented snake_case key is present at the right level.
+//   - No PascalCase keys leak through (caught by missing struct tags).
+//   - `filter.dimensions` is `{}` not null when empty (always-object idiom).
+//   - `threshold` always emits both `amount_gte` and `usage_gte`, with the
+//     unset side as JSON null — the dashboard reads both without
+//     conditional indexing.
+//   - Decimal usage_gte / observed.quantity round-trip as strings (per
+//     ADR-005), not JSON numbers that would lose precision.
+//
+// This is the merge gate for /v1/billing/alerts. See
+// docs/design-billing-alerts.md "Wire shape" + "Webhook payload".
+func TestWireShape_SnakeCase(t *testing.T) {
+	t.Run("AlertResponse_AmountThreshold_FullDimensions", func(t *testing.T) {
+		amount := int64(50000) // $500
+		triggered := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+		periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+		alert := domain.BillingAlert{
+			ID:         "vlx_alrt_abc",
+			TenantID:   "vlx_tenant_xyz",
+			CustomerID: "vlx_cus_abc",
+			Title:      "Acme spend > $500",
+			Filter: domain.BillingAlertFilter{
+				MeterID:    "vlx_mtr_tokens",
+				Dimensions: map[string]any{"model": "gpt-4", "operation": "input"},
+			},
+			Threshold: domain.BillingAlertThreshold{
+				AmountCentsGTE: &amount,
+			},
+			Recurrence:      domain.BillingAlertRecurrencePerPeriod,
+			Status:          domain.BillingAlertStatusTriggeredForPeriod,
+			LastTriggeredAt: &triggered,
+			LastPeriodStart: &periodStart,
+			CreatedAt:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:       triggered,
+		}
+
+		raw := marshalToMap(t, toWireAlert(alert))
+
+		// Top-level snake_case keys.
+		topLevel := []string{
+			"id",
+			"title",
+			"customer_id",
+			"filter",
+			"threshold",
+			"recurrence",
+			"status",
+			"last_triggered_at",
+			"last_period_start",
+			"created_at",
+			"updated_at",
+		}
+		for _, k := range topLevel {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("response missing %q (keys=%v)", k, mapKeys(raw))
+			}
+		}
+
+		// Forbidden PascalCase keys.
+		for _, k := range []string{
+			"ID", "Title", "CustomerID", "Filter", "Threshold",
+			"Recurrence", "Status", "LastTriggeredAt", "LastPeriodStart",
+			"CreatedAt", "UpdatedAt",
+		} {
+			if _, ok := raw[k]; ok {
+				t.Errorf("response leaked PascalCase key %q", k)
+			}
+		}
+
+		// filter.{meter_id, dimensions} both present; dimensions is an object.
+		filter, ok := raw["filter"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter must marshal as JSON object, got %T", raw["filter"])
+		}
+		for _, k := range []string{"meter_id", "dimensions"} {
+			if _, ok := filter[k]; !ok {
+				t.Errorf("filter missing %q (keys=%v)", k, mapKeys(filter))
+			}
+		}
+		dims, ok := filter["dimensions"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter.dimensions must marshal as JSON object, got %T", filter["dimensions"])
+		}
+		if dims["model"] != "gpt-4" || dims["operation"] != "input" {
+			t.Errorf("dimensions content lost: %v", dims)
+		}
+
+		// threshold always emits both keys; the unset side is JSON null.
+		thresh, ok := raw["threshold"].(map[string]any)
+		if !ok {
+			t.Fatalf("threshold must marshal as JSON object, got %T", raw["threshold"])
+		}
+		if _, ok := thresh["amount_gte"]; !ok {
+			t.Errorf("threshold missing amount_gte (keys=%v)", mapKeys(thresh))
+		}
+		if _, ok := thresh["usage_gte"]; !ok {
+			t.Errorf("threshold missing usage_gte (keys=%v) — must always emit both keys", mapKeys(thresh))
+		}
+		// usage_gte should be JSON null when only amount_gte is set.
+		if thresh["usage_gte"] != nil {
+			t.Errorf("threshold.usage_gte should be null when only amount_gte set, got %v (%T)", thresh["usage_gte"], thresh["usage_gte"])
+		}
+		// amount_gte unmarshals as float64 (no precision loss for int64 ≤ 2^53).
+		if amt, ok := thresh["amount_gte"].(float64); !ok || amt != 50000 {
+			t.Errorf("threshold.amount_gte should be 50000, got %v (%T)", thresh["amount_gte"], thresh["amount_gte"])
+		}
+	})
+
+	t.Run("AlertResponse_UsageThreshold_StringDecimal", func(t *testing.T) {
+		// Usage threshold side: usage_gte must round-trip as a JSON
+		// string (not number) to preserve fractional precision for
+		// AI-usage primitives like cached-token ratios.
+		qty := decimal.RequireFromString("1234567.891234")
+		alert := domain.BillingAlert{
+			ID:         "vlx_alrt_xyz",
+			CustomerID: "vlx_cus_abc",
+			Title:      "Tokens > 1.2M this cycle",
+			Filter: domain.BillingAlertFilter{
+				MeterID:    "vlx_mtr_tokens",
+				Dimensions: map[string]any{},
+			},
+			Threshold: domain.BillingAlertThreshold{
+				QuantityGTE: &qty,
+			},
+			Recurrence: domain.BillingAlertRecurrenceOneTime,
+			Status:     domain.BillingAlertStatusActive,
+			CreatedAt:  time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:  time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		}
+
+		raw := marshalToMap(t, toWireAlert(alert))
+		thresh, ok := raw["threshold"].(map[string]any)
+		if !ok {
+			t.Fatalf("threshold must marshal as JSON object, got %T", raw["threshold"])
+		}
+		usage, isString := thresh["usage_gte"].(string)
+		if !isString {
+			t.Fatalf("threshold.usage_gte must marshal as JSON string (decimal precision), got %T", thresh["usage_gte"])
+		}
+		if usage != "1234567.891234" {
+			t.Errorf("usage_gte precision lost: got %q want %q", usage, "1234567.891234")
+		}
+		// amount_gte should be JSON null when only usage_gte is set.
+		if thresh["amount_gte"] != nil {
+			t.Errorf("threshold.amount_gte should be null when only usage_gte set, got %v", thresh["amount_gte"])
+		}
+
+		// last_triggered_at / last_period_start are nil (alert never fired) —
+		// must serialize as JSON null, not omitted.
+		if v, ok := raw["last_triggered_at"]; !ok {
+			t.Errorf("last_triggered_at should be present (as null) when never fired")
+		} else if v != nil {
+			t.Errorf("last_triggered_at should be null when never fired, got %v", v)
+		}
+	})
+
+	t.Run("AlertResponse_EmptyDimensions_MarshalAsObject", func(t *testing.T) {
+		// The always-object idiom: dimensions is `{}` not null even when
+		// the alert has no dimension filter. Dashboard rendering iterates
+		// without a null guard.
+		amount := int64(10000)
+		alert := domain.BillingAlert{
+			ID:         "vlx_alrt_no_dims",
+			CustomerID: "vlx_cus_abc",
+			Title:      "No-filter spend alert",
+			Filter: domain.BillingAlertFilter{
+				MeterID:    "",
+				Dimensions: nil, // toWireAlert must normalize → {}
+			},
+			Threshold:  domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+			Recurrence: domain.BillingAlertRecurrenceOneTime,
+			Status:     domain.BillingAlertStatusActive,
+		}
+
+		raw := marshalToMap(t, toWireAlert(alert))
+		filter, ok := raw["filter"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter must marshal as JSON object")
+		}
+		dims, ok := filter["dimensions"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter.dimensions must marshal as JSON object even when empty, got %T", filter["dimensions"])
+		}
+		if len(dims) != 0 {
+			t.Errorf("filter.dimensions should be empty in this fixture, got %d keys", len(dims))
+		}
+		// meter_id is omitempty; missing key is OK.
+		if _, ok := filter["meter_id"]; ok {
+			t.Errorf("filter.meter_id should be omitted (omitempty) when empty, got %v", filter["meter_id"])
+		}
+	})
+
+	t.Run("WebhookPayload_SnakeCaseAndDecimalString", func(t *testing.T) {
+		// The outbound webhook payload is the persistent contract for
+		// every alert subscriber. Track B's CLI sample output and the
+		// docs example pin this exact shape.
+		amount := int64(50000)
+		triggered := time.Date(2026, 4, 26, 12, 5, 30, 123456789, time.UTC)
+		alert := domain.BillingAlert{
+			ID:         "vlx_alrt_abc",
+			TenantID:   "vlx_tenant_xyz",
+			CustomerID: "vlx_cus_abc",
+			Title:      "Acme spend > $500",
+			Filter: domain.BillingAlertFilter{
+				MeterID:    "vlx_mtr_tokens",
+				Dimensions: map[string]any{"model": "gpt-4"},
+			},
+			Threshold:  domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+			Recurrence: domain.BillingAlertRecurrencePerPeriod,
+			Status:     domain.BillingAlertStatusTriggeredForPeriod,
+		}
+		trigger := domain.BillingAlertTrigger{
+			ID:                  "vlx_atrg_001",
+			TenantID:            "vlx_tenant_xyz",
+			AlertID:             alert.ID,
+			PeriodFrom:          time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			PeriodTo:            time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			ObservedAmountCents: 60000,
+			ObservedQuantity:    decimal.RequireFromString("9876543.210987"),
+			Currency:            "USD",
+			TriggeredAt:         triggered,
+		}
+
+		payload := buildEventPayload(alert, trigger)
+		raw := marshalToMap(t, payload)
+
+		// Top-level snake_case keys for the data envelope. The webhook
+		// dispatcher wraps this under {id, type, data: <payload>}; the
+		// payload itself is what we inspect here.
+		topLevel := []string{
+			"alert_id", "customer_id", "title", "threshold",
+			"observed", "currency", "triggered_at", "period",
+			"filter", "recurrence",
+		}
+		for _, k := range topLevel {
+			if _, ok := raw[k]; !ok {
+				t.Errorf("payload missing %q (keys=%v)", k, mapKeys(raw))
+			}
+		}
+		// Sanity: the payload uses snake_case throughout — no PascalCase
+		// or camelCase leak from struct fields when we move to a typed
+		// payload struct in the future.
+		for _, k := range []string{"alertId", "customerId", "triggeredAt", "AlertID", "CustomerID"} {
+			if _, ok := raw[k]; ok {
+				t.Errorf("payload leaked non-snake_case key %q", k)
+			}
+		}
+
+		// observed.{amount_cents, quantity}; quantity must be a string.
+		observed, ok := raw["observed"].(map[string]any)
+		if !ok {
+			t.Fatalf("observed must marshal as JSON object, got %T", raw["observed"])
+		}
+		for _, k := range []string{"amount_cents", "quantity"} {
+			if _, ok := observed[k]; !ok {
+				t.Errorf("observed missing %q (keys=%v)", k, mapKeys(observed))
+			}
+		}
+		qty, isString := observed["quantity"].(string)
+		if !isString {
+			t.Fatalf("observed.quantity must marshal as JSON string (decimal precision), got %T", observed["quantity"])
+		}
+		if qty != "9876543.210987" {
+			t.Errorf("observed.quantity precision lost: got %q want %q", qty, "9876543.210987")
+		}
+
+		// period.{from, to, source}.
+		period, ok := raw["period"].(map[string]any)
+		if !ok {
+			t.Fatalf("period must marshal as JSON object, got %T", raw["period"])
+		}
+		for _, k := range []string{"from", "to", "source"} {
+			if _, ok := period[k]; !ok {
+				t.Errorf("period missing %q (keys=%v)", k, mapKeys(period))
+			}
+		}
+		if period["source"] != "current_billing_cycle" {
+			t.Errorf("period.source should be 'current_billing_cycle', got %v", period["source"])
+		}
+
+		// filter.{meter_id, dimensions} both present; dimensions is an object.
+		filter, ok := raw["filter"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter must marshal as JSON object")
+		}
+		for _, k := range []string{"meter_id", "dimensions"} {
+			if _, ok := filter[k]; !ok {
+				t.Errorf("filter missing %q (keys=%v)", k, mapKeys(filter))
+			}
+		}
+		dims, ok := filter["dimensions"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter.dimensions must marshal as JSON object, got %T", filter["dimensions"])
+		}
+		if dims["model"] != "gpt-4" {
+			t.Errorf("dimensions content lost: %v", dims)
+		}
+
+		// threshold always emits both keys; usage_gte must be null here.
+		thresh, ok := raw["threshold"].(map[string]any)
+		if !ok {
+			t.Fatalf("threshold must marshal as JSON object")
+		}
+		for _, k := range []string{"amount_gte", "usage_gte"} {
+			if _, ok := thresh[k]; !ok {
+				t.Errorf("threshold missing %q (must always emit both keys)", k)
+			}
+		}
+		if thresh["usage_gte"] != nil {
+			t.Errorf("threshold.usage_gte should be null when only amount_gte set, got %v", thresh["usage_gte"])
+		}
+
+		// recurrence is a JSON string (not the typed Go enum).
+		if _, isString := raw["recurrence"].(string); !isString {
+			t.Errorf("recurrence must marshal as JSON string, got %T", raw["recurrence"])
+		}
+	})
+
+	t.Run("WebhookPayload_EmptyDimensions_MarshalAsObject", func(t *testing.T) {
+		// Same always-object guarantee for the webhook side: subscriber
+		// code reads payload.filter.dimensions without a null guard.
+		amount := int64(10000)
+		alert := domain.BillingAlert{
+			ID:         "vlx_alrt_no_dims",
+			TenantID:   "vlx_tenant_xyz",
+			CustomerID: "vlx_cus_abc",
+			Title:      "No-dim alert",
+			Filter:     domain.BillingAlertFilter{Dimensions: nil},
+			Threshold:  domain.BillingAlertThreshold{AmountCentsGTE: &amount},
+			Recurrence: domain.BillingAlertRecurrenceOneTime,
+		}
+		trigger := domain.BillingAlertTrigger{
+			AlertID:             alert.ID,
+			ObservedAmountCents: 12000,
+			ObservedQuantity:    decimal.Zero,
+			Currency:            "USD",
+			TriggeredAt:         time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC),
+		}
+
+		raw := marshalToMap(t, buildEventPayload(alert, trigger))
+		filter, ok := raw["filter"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter must marshal as JSON object")
+		}
+		dims, ok := filter["dimensions"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter.dimensions must marshal as JSON object even when empty, got %T", filter["dimensions"])
+		}
+		if len(dims) != 0 {
+			t.Errorf("filter.dimensions should be empty in this fixture, got %d keys", len(dims))
+		}
+	})
+}
+
+// marshalToMap is a small helper that round-trips any value through
+// encoding/json into a generic map for key-by-key inspection. Mirrors
+// the helper in preview_wire_shape_test.go.
+func marshalToMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	blob, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(blob, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return raw
+}
+
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/domain/billing_alert.go
+++ b/internal/domain/billing_alert.go
@@ -60,18 +60,18 @@ type BillingAlertFilter struct {
 // state machine driven by the evaluator; LastTriggeredAt and
 // LastPeriodStart are nil until the alert fires for the first time.
 type BillingAlert struct {
-	ID                string                 `json:"id"`
-	TenantID          string                 `json:"tenant_id,omitempty"`
-	CustomerID        string                 `json:"customer_id"`
-	Title             string                 `json:"title"`
-	Filter            BillingAlertFilter     `json:"filter"`
-	Threshold         BillingAlertThreshold  `json:"threshold"`
-	Recurrence        BillingAlertRecurrence `json:"recurrence"`
-	Status            BillingAlertStatus     `json:"status"`
-	LastTriggeredAt   *time.Time             `json:"last_triggered_at"`
-	LastPeriodStart   *time.Time             `json:"last_period_start"`
-	CreatedAt         time.Time              `json:"created_at"`
-	UpdatedAt         time.Time              `json:"updated_at"`
+	ID              string                 `json:"id"`
+	TenantID        string                 `json:"tenant_id,omitempty"`
+	CustomerID      string                 `json:"customer_id"`
+	Title           string                 `json:"title"`
+	Filter          BillingAlertFilter     `json:"filter"`
+	Threshold       BillingAlertThreshold  `json:"threshold"`
+	Recurrence      BillingAlertRecurrence `json:"recurrence"`
+	Status          BillingAlertStatus     `json:"status"`
+	LastTriggeredAt *time.Time             `json:"last_triggered_at"`
+	LastPeriodStart *time.Time             `json:"last_period_start"`
+	CreatedAt       time.Time              `json:"created_at"`
+	UpdatedAt       time.Time              `json:"updated_at"`
 }
 
 // BillingAlertTrigger is one historical fire event for an alert. The

--- a/internal/domain/billing_alert.go
+++ b/internal/domain/billing_alert.go
@@ -1,0 +1,104 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// BillingAlertStatus is the lifecycle of an alert.
+//   - Active: armed, awaiting threshold crossing.
+//   - Triggered: a one_time alert has fired and will not fire again. Stays
+//     in this state until archived.
+//   - TriggeredForPeriod: a per_period alert has fired in the current
+//     billing cycle; the evaluator transitions back to Active when the
+//     customer's cycle rolls over.
+//   - Archived: soft-disabled by the operator; the evaluator skips
+//     archived rows entirely.
+type BillingAlertStatus string
+
+const (
+	BillingAlertStatusActive             BillingAlertStatus = "active"
+	BillingAlertStatusTriggered          BillingAlertStatus = "triggered"
+	BillingAlertStatusTriggeredForPeriod BillingAlertStatus = "triggered_for_period"
+	BillingAlertStatusArchived           BillingAlertStatus = "archived"
+)
+
+// BillingAlertRecurrence controls how often an alert can fire.
+//   - OneTime: at most once per alert lifetime.
+//   - PerPeriod: at most once per billing cycle; rearms on cycle rollover.
+type BillingAlertRecurrence string
+
+const (
+	BillingAlertRecurrenceOneTime   BillingAlertRecurrence = "one_time"
+	BillingAlertRecurrencePerPeriod BillingAlertRecurrence = "per_period"
+)
+
+// BillingAlertThreshold carries the firing threshold. Exactly one of
+// AmountCentsGTE or QuantityGTE is non-nil — the table CHECK constraint
+// enforces this and the service layer validates it on Create. Both are
+// surfaced on the wire (one as null) so clients can read both without
+// branching on cardinality — same always-object idiom dimension_match
+// uses.
+type BillingAlertThreshold struct {
+	AmountCentsGTE *int64           `json:"amount_gte"`
+	QuantityGTE    *decimal.Decimal `json:"usage_gte"`
+}
+
+// BillingAlertFilter narrows the events an alert evaluates against.
+//   - MeterID empty → cross-meter alert (sum of customer's cycle spend).
+//   - MeterID set → only that meter's resolved spend.
+//   - Dimensions only meaningful with MeterID set; rejected with 422
+//     otherwise. Always-object idiom: empty filter marshals as {} not
+//     null so dashboard rendering can iterate without nil guards.
+type BillingAlertFilter struct {
+	MeterID    string         `json:"meter_id,omitempty"`
+	Dimensions map[string]any `json:"dimensions"`
+}
+
+// BillingAlert is the persisted alert configuration. Status is a
+// state machine driven by the evaluator; LastTriggeredAt and
+// LastPeriodStart are nil until the alert fires for the first time.
+type BillingAlert struct {
+	ID                string                 `json:"id"`
+	TenantID          string                 `json:"tenant_id,omitempty"`
+	CustomerID        string                 `json:"customer_id"`
+	Title             string                 `json:"title"`
+	Filter            BillingAlertFilter     `json:"filter"`
+	Threshold         BillingAlertThreshold  `json:"threshold"`
+	Recurrence        BillingAlertRecurrence `json:"recurrence"`
+	Status            BillingAlertStatus     `json:"status"`
+	LastTriggeredAt   *time.Time             `json:"last_triggered_at"`
+	LastPeriodStart   *time.Time             `json:"last_period_start"`
+	CreatedAt         time.Time              `json:"created_at"`
+	UpdatedAt         time.Time              `json:"updated_at"`
+}
+
+// BillingAlertTrigger is one historical fire event for an alert. The
+// evaluator inserts one row per fire inside the same tx that mutates the
+// alert's status and enqueues the outbound webhook — see
+// docs/design-billing-alerts.md "Atomicity contract".
+//
+// UNIQUE (alert_id, period_from) is the per-period idempotency key: two
+// replicas racing the evaluator can both attempt to insert; one wins,
+// the other gets a unique-violation that rolls its tx back and prevents
+// double-emission.
+type BillingAlertTrigger struct {
+	ID                  string          `json:"id"`
+	TenantID            string          `json:"tenant_id,omitempty"`
+	AlertID             string          `json:"alert_id"`
+	PeriodFrom          time.Time       `json:"period_from"`
+	PeriodTo            time.Time       `json:"period_to"`
+	ObservedAmountCents int64           `json:"observed_amount_cents"`
+	ObservedQuantity    decimal.Decimal `json:"observed_quantity"`
+	Currency            string          `json:"currency"`
+	TriggeredAt         time.Time       `json:"triggered_at"`
+}
+
+// IsTerminal returns true when the alert's status excludes it from
+// future evaluation. one_time→triggered and any→archived are terminal;
+// per_period→triggered_for_period is NOT terminal (the evaluator may
+// rearm on cycle rollover).
+func (s BillingAlertStatus) IsTerminal() bool {
+	return s == BillingAlertStatusTriggered || s == BillingAlertStatusArchived
+}

--- a/internal/domain/webhook_outbound.go
+++ b/internal/domain/webhook_outbound.go
@@ -107,4 +107,5 @@ const (
 	EventCustomerCouponAttached             = "customer.coupon.attached"
 	EventCustomerCouponRevoked              = "customer.coupon.revoked"
 	EventInvoiceCouponApplied               = "invoice.coupon.applied"
+	EventBillingAlertTriggered              = "billing.alert.triggered"
 )

--- a/internal/platform/migrate/migrate.go
+++ b/internal/platform/migrate/migrate.go
@@ -163,6 +163,34 @@ func Rollback(dsn string, steps int) (uint, error) {
 	return v, nil
 }
 
+// EmbeddedMigrationCount returns the number of .up.sql files in the embedded
+// migrations directory. Differs from EmbeddedLatestVersion when version
+// numbers are non-contiguous (e.g. one branch skipped a number to
+// coordinate with a sibling parallel branch). The migrate library's
+// Steps(-N) operates on a per-file basis, so callers that want to roll
+// back "every applied migration" should use this count, not the latest
+// version number.
+func EmbeddedMigrationCount() (int, error) {
+	entries, err := sqlFS.ReadDir("sql")
+	if err != nil {
+		return 0, fmt.Errorf("read embedded migrations: %w", err)
+	}
+
+	var n int
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if migrationFilenamePattern.MatchString(entry.Name()) {
+			n++
+		}
+	}
+	if n == 0 {
+		return 0, fmt.Errorf("no up-migrations found in embedded fs")
+	}
+	return n, nil
+}
+
 // EmbeddedLatestVersion returns the highest migration version packaged into
 // this binary. Used by CheckSchemaReady to compare against the database's
 // current version.

--- a/internal/platform/migrate/roundtrip_test.go
+++ b/internal/platform/migrate/roundtrip_test.go
@@ -91,9 +91,12 @@ func TestMigrationRoundTrip(t *testing.T) {
 	}
 }
 
-// countAppliedMigrations reads schema_migrations via a direct connection so
-// we know how many Steps(-N) to request without assuming contiguous version
-// integers.
+// countAppliedMigrations counts the number of .up.sql files in the embedded
+// migrations directory. The migrate library's Steps(-N) treats each .up.sql
+// as one step regardless of its version-number gap, so we need the file
+// count, not the latest version number — these can diverge when a branch
+// intentionally skips a number to coordinate with a sibling parallel
+// branch (e.g. one branch owns 0056, the other 0057, both stack on main).
 func countAppliedMigrations(dsn string) (int, error) {
 	db, err := sql.Open("pgx", dsn)
 	if err != nil {
@@ -101,18 +104,7 @@ func countAppliedMigrations(dsn string) (int, error) {
 	}
 	defer func() { _ = db.Close() }()
 
-	// The golang-migrate schema_migrations table holds exactly one row (the
-	// current version). To count applied steps we enumerate the embedded
-	// migration files — the library's Steps(-N) treats each .up.sql as one
-	// step regardless of version-number gaps.
-	latest, err := migrate.EmbeddedLatestVersion()
-	if err != nil {
-		return 0, err
-	}
-	// Assumes contiguous 1..N numbering, which Velox enforces in the sql/
-	// directory. If we ever skip numbers intentionally, switch to counting
-	// the files directly.
-	return int(latest), nil
+	return migrate.EmbeddedMigrationCount()
 }
 
 func rewriteDBName(t *testing.T, dsn, newName string) string {

--- a/internal/platform/migrate/sql/0057_billing_alerts.down.sql
+++ b/internal/platform/migrate/sql/0057_billing_alerts.down.sql
@@ -1,0 +1,4 @@
+-- Reverse of 0057_billing_alerts.up.sql.
+
+DROP TABLE IF EXISTS billing_alert_triggers;
+DROP TABLE IF EXISTS billing_alerts;

--- a/internal/platform/migrate/sql/0057_billing_alerts.up.sql
+++ b/internal/platform/migrate/sql/0057_billing_alerts.up.sql
@@ -1,0 +1,127 @@
+-- Billing alerts: operator-configured thresholds that fire a webhook +
+-- dashboard notification when a customer's cycle spend crosses a limit.
+-- Stripe-equivalent "Billing Alerts" Tier 1 surface.
+--
+-- Two tables:
+--
+--   billing_alerts          — the alert configuration (one row per alert)
+--   billing_alert_triggers  — one row per fire event, with UNIQUE
+--                             (alert_id, period_from) for idempotency
+--                             across evaluator retries / replica races
+--
+-- See docs/design-billing-alerts.md for the full design including
+-- recurrence semantics, atomicity contract, and edge cases.
+
+CREATE TABLE billing_alerts (
+    id                     TEXT PRIMARY KEY DEFAULT 'vlx_alrt_' || encode(gen_random_bytes(12), 'hex'),
+    tenant_id              TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    -- Mode partition. Defaulting to live keeps any future un-mode-aware
+    -- INSERT path safe — a missing app.livemode session var routes to
+    -- live by the RLS policy, matching every other mode-aware table.
+    livemode               BOOLEAN NOT NULL DEFAULT true,
+    customer_id            TEXT NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+    title                  TEXT NOT NULL,
+    -- Optional meter filter. ON DELETE SET NULL so that deleting the
+    -- meter doesn't cascade-delete alerts the operator may want to
+    -- repurpose; the evaluator surfaces the missing-meter case as a
+    -- warning and the operator can edit or archive.
+    meter_id               TEXT REFERENCES meters(id) ON DELETE SET NULL,
+    -- Dimension filter for multi-dim meters. JSONB '{}' is the always-
+    -- object identity (no filter); a non-empty object is a strict-
+    -- superset match against rule dimension_match.
+    dimensions             JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Exactly one of these two threshold columns is set; the CHECK
+    -- below enforces it. Quantity is NUMERIC(38,12) to match the
+    -- usage_events.quantity precision; amount is BIGINT cents.
+    threshold_amount_cents BIGINT,
+    threshold_quantity     NUMERIC(38,12),
+    recurrence             TEXT NOT NULL CHECK (recurrence IN ('one_time','per_period')),
+    status                 TEXT NOT NULL DEFAULT 'active'
+                                CHECK (status IN ('active','triggered','triggered_for_period','archived')),
+    last_triggered_at      TIMESTAMPTZ,
+    last_period_start      TIMESTAMPTZ,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Exactly one threshold field set. Adding both or neither is a
+    -- caller error that the service-layer validation also catches; the
+    -- DB CHECK is the safety net that prevents a malformed migration
+    -- backfill or admin INSERT from creating an unfireable row.
+    CHECK ( (threshold_amount_cents IS NOT NULL)::int + (threshold_quantity IS NOT NULL)::int = 1 )
+);
+
+-- Hot read: dashboard list + filter alerts by customer + status.
+CREATE INDEX idx_billing_alerts_tenant_customer
+    ON billing_alerts (tenant_id, customer_id, status);
+
+-- Evaluator hot scan: only candidate-firing rows. Excludes archived and
+-- already-triggered one_time rows by predicate so the evaluator's per-
+-- tick scan stays bounded by the count of currently-armed alerts.
+CREATE INDEX idx_billing_alerts_evaluator
+    ON billing_alerts (status)
+    WHERE status IN ('active','triggered_for_period');
+
+-- Standard tenant + mode isolation. FORCE applies the policy even to
+-- the table owner so a misconfigured connection string can't bypass it.
+-- Mode predicate matches the project-wide convention from migration
+-- 0020_test_mode: livemode unset/'on' → live, 'off' → test.
+ALTER TABLE billing_alerts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE billing_alerts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON billing_alerts FOR ALL USING (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR (
+        tenant_id = current_setting('app.tenant_id', true)
+        AND livemode = (current_setting('app.livemode', true) IS DISTINCT FROM 'off')
+    )
+);
+
+GRANT ALL ON TABLE billing_alerts TO velox_app;
+
+CREATE TABLE billing_alert_triggers (
+    id                    TEXT PRIMARY KEY DEFAULT 'vlx_atrg_' || encode(gen_random_bytes(12), 'hex'),
+    tenant_id             TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    livemode              BOOLEAN NOT NULL DEFAULT true,
+    alert_id              TEXT NOT NULL REFERENCES billing_alerts(id) ON DELETE CASCADE,
+    period_from           TIMESTAMPTZ NOT NULL,
+    period_to             TIMESTAMPTZ NOT NULL,
+    observed_amount_cents BIGINT NOT NULL,
+    observed_quantity     NUMERIC(38,12) NOT NULL DEFAULT 0,
+    currency              TEXT NOT NULL,
+    triggered_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Per-period idempotency. Two replicas racing the evaluator can
+    -- both attempt to insert; one wins, the other gets a unique-
+    -- violation that rolls its entire tx back (status update + outbox
+    -- enqueue) so no double-emission.
+    UNIQUE (alert_id, period_from)
+);
+
+-- Hot read: dashboard "trigger history for this alert".
+CREATE INDEX idx_billing_alert_triggers_alert
+    ON billing_alert_triggers (alert_id, triggered_at DESC);
+
+ALTER TABLE billing_alert_triggers ENABLE ROW LEVEL SECURITY;
+ALTER TABLE billing_alert_triggers FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON billing_alert_triggers FOR ALL USING (
+    current_setting('app.bypass_rls', true) = 'on'
+    OR (
+        tenant_id = current_setting('app.tenant_id', true)
+        AND livemode = (current_setting('app.livemode', true) IS DISTINCT FROM 'off')
+    )
+);
+
+GRANT ALL ON TABLE billing_alert_triggers TO velox_app;
+
+-- Wire the BEFORE INSERT livemode trigger from migration 0021 onto both
+-- new mode-aware tables. This makes the row's livemode column track the
+-- app.livemode session var instead of the column DEFAULT, so a TxTenant
+-- under test-mode session correctly lands rows with livemode=false even
+-- when the INSERT statement omits the column. Same pattern as every
+-- mode-aware table created after migration 0021.
+CREATE TRIGGER set_livemode
+    BEFORE INSERT ON billing_alerts
+    FOR EACH ROW EXECUTE FUNCTION set_livemode_from_session();
+
+CREATE TRIGGER set_livemode
+    BEFORE INSERT ON billing_alert_triggers
+    FOR EACH ROW EXECUTE FUNCTION set_livemode_from_session();

--- a/internal/platform/postgres/advisory_lock.go
+++ b/internal/platform/postgres/advisory_lock.go
@@ -12,10 +12,11 @@ import (
 // namespaced high enough (>1e7) to not collide with any key the golang-migrate
 // library picks when it hashes schema names.
 const (
-	LockKeyBillingScheduler int64 = 76540001
-	LockKeyDunningScheduler int64 = 76540002
-	LockKeyOutboxDispatcher int64 = 76540003
-	LockKeyEmailDispatcher  int64 = 76540004
+	LockKeyBillingScheduler      int64 = 76540001
+	LockKeyDunningScheduler      int64 = 76540002
+	LockKeyOutboxDispatcher      int64 = 76540003
+	LockKeyEmailDispatcher       int64 = 76540004
+	LockKeyBillingAlertEvaluator int64 = 76540005
 )
 
 // AdvisoryLock is a held Postgres session-scoped advisory lock. Release MUST

--- a/internal/platform/postgres/rls_isolation_test.go
+++ b/internal/platform/postgres/rls_isolation_test.go
@@ -226,6 +226,7 @@ func TestRLSIsolation_AllModeAwareTablesHaveLivemodePredicate(t *testing.T) {
 		"test_clocks", "usage_events",
 		"webhook_deliveries", "webhook_endpoints", "webhook_events", "webhook_outbox",
 		"payment_methods", "customer_portal_sessions", "customer_portal_magic_links",
+		"billing_alerts", "billing_alert_triggers",
 	}
 
 	tx, err := db.BeginTx(ctx, postgres.TxBypass, "")

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -91,6 +91,7 @@ func cleanDB(t *testing.T, pool *sql.DB) {
 				coupon_redemptions, coupons, customer_dunning_overrides,
 				customer_price_overrides, webhook_deliveries, webhook_events,
 				webhook_endpoints, idempotency_keys, audit_log, tenant_settings,
+				billing_alert_triggers, billing_alerts,
 				tenants
 			CASCADE;
 		EXCEPTION WHEN undefined_table THEN

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -376,6 +376,25 @@ export const api = {
   // API key, no need to re-paste secret/publishable.
   setStripeWebhookSecret: (mode: 'live' | 'test', webhook_secret: string) =>
     apiRequest<StripeProviderCredentials>('PATCH', `/settings/stripe/${mode}/webhook`, { webhook_secret }),
+
+  // Billing alerts: operator-configured thresholds that fire a webhook +
+  // dashboard notification when a customer's cycle spend crosses a limit.
+  // Wire snake_case, dimensions as always-object {}, decimal as string per ADR-005.
+  listBillingAlerts: (params?: { customer_id?: string; status?: BillingAlertStatus; limit?: number; offset?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.customer_id) q.set('customer_id', params.customer_id)
+    if (params?.status) q.set('status', params.status)
+    if (params?.limit != null) q.set('limit', String(params.limit))
+    if (params?.offset != null) q.set('offset', String(params.offset))
+    const qs = q.toString()
+    return apiRequest<{ data: BillingAlert[]; total: number }>('GET', `/billing/alerts${qs ? '?' + qs : ''}`)
+  },
+  getBillingAlert: (id: string) =>
+    apiRequest<BillingAlert>('GET', `/billing/alerts/${id}`),
+  createBillingAlert: (data: CreateBillingAlertRequest) =>
+    apiRequest<BillingAlert>('POST', '/billing/alerts', data),
+  archiveBillingAlert: (id: string) =>
+    apiRequest<BillingAlert>('POST', `/billing/alerts/${id}/archive`),
 }
 
 // Types
@@ -1103,6 +1122,56 @@ export interface UsageAnalyticsResponse {
   data: UsagePoint[]
   top_meters: TopMeterUsage[]
   totals: { events: number; quantity: number }
+}
+
+// Billing alerts. Mirrors internal/billingalert/handler.go wireAlert.
+// dimensions is always an object ({} when absent); threshold always has
+// both keys present (one as null) so the dashboard can read both
+// without a conditional null guard.
+export type BillingAlertStatus = 'active' | 'triggered' | 'triggered_for_period' | 'archived'
+export type BillingAlertRecurrence = 'one_time' | 'per_period'
+
+export interface BillingAlertFilter {
+  meter_id?: string
+  dimensions: Record<string, unknown>
+}
+
+export interface BillingAlertThreshold {
+  // BIGINT cents, e.g. 100_00 for $100. Mutually exclusive with usage_gte.
+  amount_gte: number | null
+  // Decimal-as-string per ADR-005 (NUMERIC(38,12) preserves precision over
+  // the wire). Mutually exclusive with amount_gte.
+  usage_gte: string | null
+}
+
+export interface BillingAlert {
+  id: string
+  title: string
+  customer_id: string
+  filter: BillingAlertFilter
+  threshold: BillingAlertThreshold
+  recurrence: BillingAlertRecurrence
+  status: BillingAlertStatus
+  last_triggered_at: string | null
+  last_period_start: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateBillingAlertRequest {
+  title: string
+  customer_id: string
+  // Optional: omit for "all meters / all dimensions" semantics.
+  filter?: {
+    meter_id?: string
+    dimensions?: Record<string, unknown>
+  }
+  // Exactly one of amount_gte / usage_gte must be set. usage_gte is decimal-as-string.
+  threshold: {
+    amount_gte?: number
+    usage_gte?: string
+  }
+  recurrence: BillingAlertRecurrence
 }
 
 export async function downloadPDF(invoiceId: string, invoiceNumber: string) {

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -18,6 +18,20 @@ const entries: {
 }[] = [
   {
     date: '2026-04-26',
+    title: 'Billing alerts — Stripe Tier 1 alert thresholds with webhook delivery',
+    tag: 'feature',
+    body: 'Operator-configurable thresholds that fire a webhook + dashboard notification when a customer\'s cycle spend (or per-meter usage) crosses a limit. Four endpoints under /v1/billing/alerts (create, get, list, archive); a background evaluator leader-elects via Postgres advisory lock, scans armed alerts, aggregates the customer\'s current cycle through the same LATERAL JOIN the cycle scan uses (so alert math = invoice math by construction), and on threshold cross fires billing.alert.triggered through the webhook outbox in the same tx as the alert state mutation. UNIQUE (alert_id, period_from) gives per-period idempotency across replica races. Mounted under PermInvoiceRead / PermInvoiceWrite.',
+    bullets: [
+      'Two recurrence modes: one_time transitions to a terminal triggered status (fires once, ever); per_period transitions to triggered_for_period each cycle and re-arms when the next cycle begins.',
+      'Threshold contract: exactly one of amount_gte (BIGINT cents) or usage_gte (decimal-as-string per ADR-005) — DB CHECK + service validation both enforce. Wire shape always emits both keys with one as null so the dashboard reads both fields without a conditional null guard.',
+      'Filter contract: optional meter_id (alert fires on aggregate when omitted), plus optional dimensions object (always-object {} idiom — no null guard) for multi-dim meters. Service-layer validation: ≤16 dimension keys, scalar values only, dimensions only valid when meter_id is set.',
+      'Atomicity guarantee: trigger insert + alert state mutation + outbox enqueue all commit in one tx. If the outbox enqueue fails (simulated in TestEvaluator_AtomicityOnRollback), the entire tx rolls back so no double-emission and no half-fired state survives a partial failure.',
+      'Mode-aware tables (billing_alerts, billing_alert_triggers) ship with the standard tenant + livemode RLS policy from migration 0020 and the BEFORE INSERT livemode-from-session trigger from migration 0021. New regression entries in TestRLSIsolation_AllModeAwareTablesHaveLivemodePredicate.',
+      '24 unit tests + 9 integration tests against real Postgres pin the behavior: one-time-fire, per-period-fire-and-rearm, double-fire-idempotent (UNIQUE constraint), archived-skipped, below-threshold-no-fire, no-subscription-warning, multi-tenant RLS isolation, atomicity-on-rollback, and a TestWireShape_SnakeCase merge gate.',
+    ],
+  },
+  {
+    date: '2026-04-26',
     title: 'Create-preview endpoint — Stripe Tier 1 invoice.upcoming parity',
     tag: 'feature',
     body: 'POST /v1/invoices/create_preview returns the same totals the cycle scan would bill — without writing a row. Multi-dim aware by construction: the preview path runs through usage.AggregateByPricingRules (LATERAL JOIN with priority + claim across the five aggregation modes), so a meter with cached-input vs uncached vs output rules previews into the same buckets the invoice will land in. Mounted under PermInvoiceRead. Both the in-app debug surface (/v1/billing/preview/{id}) and the new Tier 1 surface return one shape so TypeScript clients and dashboards share one type.',


### PR DESCRIPTION
## Summary

Stripe Tier 1 parity for **Billing Alerts** — operator-configurable thresholds that fire `billing.alert.triggered` through the webhook outbox + dashboard notification when a customer's cycle spend (or per-meter usage) crosses a limit. Closes the Week 5d slice in the 90-day plan.

- Four endpoints under `/v1/billing/alerts` (create, get, list, archive); per-method auth (`PermInvoiceRead` / `PermInvoiceWrite`); mounted before `/billing` so chi picks the more-specific pattern.
- Background evaluator leader-elects via Postgres advisory lock, scans armed alerts via the partial index `idx_billing_alerts_evaluator`, aggregates the customer's cycle through `usage.AggregateByPricingRules` (so alert math == invoice math by construction), and on threshold cross fires through the outbox in the same tx as the alert state mutation. `UNIQUE (alert_id, period_from)` gives per-period idempotency across replica races.
- Two recurrence modes: `one_time` (terminal) and `per_period` (re-arms each cycle).
- Wire snake_case (regression-gated by `TestWireShape_SnakeCase`), `dimensions` as always-object `{}`, `usage_gte` as decimal-as-string per ADR-005.
- Migration 0057 (skips 0056 — owned by the parallel Week 5c agent so both branches stack cleanly). Two new mode-aware tables; both wire the standard livemode RLS policy + BEFORE INSERT livemode-from-session trigger; both added to `TestRLSIsolation_AllModeAwareTablesHaveLivemodePredicate`.
- 24 unit tests + 9 integration tests against real Postgres; all green.
- TS client (`web-v2/src/lib/api.ts`) types + methods, CHANGELOG + Changelog.tsx + parallel-handoff entries.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] `go test -short ./...` — all 40+ packages pass
- [x] `go test -p 1 -short=false ./internal/billingalert/...` — 24 unit + 9 integration tests pass against real Postgres
- [x] `go test -p 1 -short=false -run TestRLSIsolation ./internal/platform/postgres/...` — passes including new `billing_alerts` + `billing_alert_triggers` regression entries
- [x] `go test -count=1 -run TestWireShape ./internal/billingalert/...` — merge gate passes
- [ ] CI green on the full `-p 1 ./... -short=false` matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)