### PR TITLE
feat(dashboard): one-off invoice composer on customer page (Week 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,44 @@ Two surfaces mirror this file:
 
 ### Added
 
+- **One-off invoice composer — 30-second draft + send from customer page** (2026-04-26) —
+  Week 7 ships a primary "New invoice" button at the top-right of every
+  customer detail page that opens a drawer composing an invoice without a
+  parent subscription. Three field groups: a currency selector (defaults to
+  the customer's billing-profile currency, falls back to USD); a
+  line-items grid with description / type (`add_on` / `base_fee` / `usage`)
+  / quantity / `unit_amount_cents` / a computed total + a remove button per
+  row; and a memo Textarea. Two terminal actions: "Save draft" creates the
+  invoice in `draft` status and routes to the invoice detail page; "Save &
+  send" runs the same draft path then immediately calls finalize +
+  `send_email` so the customer receives a hosted-invoice link in the same
+  click. Validation is inline before submit — at least one line item,
+  description required per line, integer `quantity > 0`, integer
+  `unit_amount_cents > 0`. Subtotal renders live as the lines change; tax
+  is shown as "Calculated at finalize" (carries the v1 PaymentIntent-only
+  tax-neutral posture — the tenant's Stripe account holds the
+  registration). On success the dashboard toasts the invoice number, the
+  customer's invoices tab refetches, and the toast carries a "View
+  invoice" action that deep-links to the invoice page. Partial failures
+  surface the invoice number alongside the failed step's error so the
+  operator can recover from the invoice-detail surface (e.g. "draft
+  created INV-0042 but finalize failed: <reason>").
+- **Backend: invoices.subscription_id is now optional** —
+  Migration 0060 drops the NOT NULL constraint on `invoices.subscription_id`
+  so the new composer (and any future ad-hoc charge path) can write a draft
+  without a parent subscription. The partial unique idempotency index on
+  `(tenant_id, subscription_id, billing_period_start) WHERE
+  billing_reason='cycle'` already treats NULLs as distinct, so two one-off
+  drafts coexist for the same period without colliding with cycle invoices.
+  `Service.Create` no longer rejects empty `subscription_id` and now
+  defaults `billing_period_start` / `billing_period_end` to "now" when both
+  are zero (one-off invoices have no canonical cycle window). Default
+  `line_type` for `AddLineItem` flips from `"manual"` to `add_on` so the
+  CHECK constraint on `invoice_line_items.line_type` (added migration 0017,
+  set: `base_fee` / `usage` / `add_on` / `discount` / `tax`) accepts the
+  default. Backwards-compatible: cycle-invoice creation paths still pass
+  `subscription_id` and the column reads identically when present.
+
 - **Plan migration tool — bulk plan swaps with preview + commit** (2026-04-26) —
   Week 6 deliverable #2 ships an operator-facing surface for moving a cohort of
   subscribers from one plan to another. Three endpoints under

--- a/internal/invoice/postgres.go
+++ b/internal/invoice/postgres.go
@@ -21,7 +21,7 @@ func NewPostgresStore(db *postgres.DB) *PostgresStore {
 	return &PostgresStore{db: db}
 }
 
-const invCols = `id, tenant_id, customer_id, subscription_id, invoice_number, status,
+const invCols = `id, tenant_id, customer_id, COALESCE(subscription_id,''), invoice_number, status,
 	payment_status, currency, subtotal_cents, discount_cents, tax_amount_cents, tax_rate_bp,
 	COALESCE(tax_name,''), COALESCE(tax_country,''), COALESCE(tax_id,''),
 	total_amount_cents, amount_due_cents, amount_paid_cents, credits_applied_cents,
@@ -65,7 +65,7 @@ func (s *PostgresStore) Create(ctx context.Context, tenantID string, inv domain.
 			tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason, billing_reason)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39)
 		RETURNING `+invCols,
-		id, tenantID, inv.CustomerID, inv.SubscriptionID, inv.InvoiceNumber,
+		id, tenantID, inv.CustomerID, postgres.NullableString(inv.SubscriptionID), inv.InvoiceNumber,
 		inv.Status, inv.PaymentStatus, inv.Currency,
 		inv.SubtotalCents, inv.DiscountCents, inv.TaxAmountCents, inv.TaxName,
 		inv.TaxCountry, inv.TaxID,
@@ -776,7 +776,7 @@ func (s *PostgresStore) CreateWithLineItems(ctx context.Context, tenantID string
 			tax_status, tax_deferred_at, tax_retry_count, tax_pending_reason, billing_reason)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40)
 		RETURNING `+invCols,
-		id, tenantID, inv.CustomerID, inv.SubscriptionID, inv.InvoiceNumber,
+		id, tenantID, inv.CustomerID, postgres.NullableString(inv.SubscriptionID), inv.InvoiceNumber,
 		inv.Status, inv.PaymentStatus, inv.Currency,
 		inv.SubtotalCents, inv.DiscountCents, inv.TaxAmountCents, inv.TaxRateBP,
 		inv.TaxName,

--- a/internal/invoice/service.go
+++ b/internal/invoice/service.go
@@ -79,9 +79,11 @@ func (s *Service) Create(ctx context.Context, tenantID string, input CreateInput
 	if input.CustomerID == "" {
 		return domain.Invoice{}, errs.Required("customer_id")
 	}
-	if input.SubscriptionID == "" {
-		return domain.Invoice{}, errs.Required("subscription_id")
-	}
+	// SubscriptionID is OPTIONAL: cycle invoices carry a subscription, one-off
+	// invoices (operator composer, ad-hoc charges) do not. The DB column is
+	// nullable as of migration 0060; the cycle-idempotency partial unique
+	// index ignores NULLs so two one-off invoices can coexist for the same
+	// (customer, period) without colliding.
 
 	currency := strings.ToUpper(strings.TrimSpace(input.Currency))
 	if currency == "" {
@@ -94,6 +96,18 @@ func (s *Service) Create(ctx context.Context, tenantID string, input CreateInput
 	}
 
 	now := s.clock.Now()
+	// One-off invoices that omit a billing window default to "now → now" so
+	// the NOT NULL period columns get sane values. Cycle invoices always
+	// pass an explicit window from the engine.
+	periodStart := input.BillingPeriodStart
+	periodEnd := input.BillingPeriodEnd
+	if periodStart.IsZero() {
+		periodStart = now
+	}
+	if periodEnd.IsZero() {
+		periodEnd = now
+	}
+
 	invoiceNumber, err := s.numberer.NextInvoiceNumber(ctx, tenantID)
 	if err != nil {
 		return domain.Invoice{}, fmt.Errorf("allocate invoice number: %w", err)
@@ -108,8 +122,8 @@ func (s *Service) Create(ctx context.Context, tenantID string, input CreateInput
 		Status:             domain.InvoiceDraft,
 		PaymentStatus:      domain.PaymentPending,
 		Currency:           currency,
-		BillingPeriodStart: input.BillingPeriodStart,
-		BillingPeriodEnd:   input.BillingPeriodEnd,
+		BillingPeriodStart: periodStart,
+		BillingPeriodEnd:   periodEnd,
 		IssuedAt:           &issuedAt,
 		DueAt:              &dueAt,
 		NetPaymentTermDays: netDays,
@@ -257,7 +271,12 @@ func (s *Service) AddLineItem(ctx context.Context, tenantID, invoiceID string, i
 
 	lineType := strings.TrimSpace(input.LineType)
 	if lineType == "" {
-		lineType = "manual"
+		// add_on is the default for operator-added line items (one-off invoice
+		// composer, ad-hoc charges). Engine-driven cycle invoices always pass
+		// an explicit type (base_fee / usage). The DB CHECK accepts only:
+		// base_fee, usage, add_on, discount, tax — so the previous "manual"
+		// fallback would have been rejected by Postgres on insert.
+		lineType = string(domain.LineTypeAddOn)
 	}
 
 	amountCents := input.Quantity * input.UnitAmountCents

--- a/internal/invoice/service_test.go
+++ b/internal/invoice/service_test.go
@@ -377,10 +377,20 @@ func TestCreate(t *testing.T) {
 		}
 	})
 
-	t.Run("missing subscription_id", func(t *testing.T) {
-		_, err := svc.Create(ctx, "t1", CreateInput{CustomerID: "c"})
-		if err == nil {
-			t.Fatal("expected error")
+	t.Run("one-off invoice — subscription_id optional", func(t *testing.T) {
+		// Operator-issued one-off invoices (composer on the customer page)
+		// have no parent subscription. Create must succeed, persist an empty
+		// SubscriptionID, and default the billing window to the clock so the
+		// NOT NULL period columns get sane values.
+		inv, err := svc.Create(ctx, "t1", CreateInput{CustomerID: "c", Currency: "USD"})
+		if err != nil {
+			t.Fatalf("expected one-off create to succeed, got %v", err)
+		}
+		if inv.SubscriptionID != "" {
+			t.Errorf("subscription_id: got %q, want empty", inv.SubscriptionID)
+		}
+		if inv.BillingPeriodStart.IsZero() || inv.BillingPeriodEnd.IsZero() {
+			t.Errorf("billing period must default to clock now when omitted")
 		}
 	})
 }

--- a/internal/platform/migrate/sql/0060_invoice_subscription_optional.down.sql
+++ b/internal/platform/migrate/sql/0060_invoice_subscription_optional.down.sql
@@ -1,0 +1,4 @@
+-- Reverse migration 0060: re-impose NOT NULL on invoices.subscription_id.
+-- Will fail if any one-off invoices exist (subscription_id IS NULL rows);
+-- operators must delete or backfill those rows before downgrading.
+ALTER TABLE invoices ALTER COLUMN subscription_id SET NOT NULL;

--- a/internal/platform/migrate/sql/0060_invoice_subscription_optional.up.sql
+++ b/internal/platform/migrate/sql/0060_invoice_subscription_optional.up.sql
@@ -1,0 +1,18 @@
+-- Allow one-off invoices: subscription_id becomes nullable.
+--
+-- Background: invoices.subscription_id was NOT NULL because every cycle
+-- invoice originates from a subscription. With the customer-page invoice
+-- composer (Week 7) we ship one-off invoices that have no parent
+-- subscription. Making the column nullable is the cleanest way to model
+-- this without a separate "manual_invoices" table or a synthetic-sub
+-- shim. List/get/finalize/void/send all already tolerate empty/null
+-- subscription_id at the read path.
+--
+-- The existing partial unique index on
+-- (tenant_id, subscription_id, billing_period_start, billing_period_end)
+-- WHERE status != 'voided' enforces "one cycle invoice per period". With
+-- a nullable column Postgres treats NULL as distinct from NULL, so two
+-- one-off invoices with no subscription can coexist for the same
+-- billing_period — exactly what we want. The index keeps its cycle-
+-- idempotency guarantee for subscription-bound invoices unchanged.
+ALTER TABLE invoices ALTER COLUMN subscription_id DROP NOT NULL;

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -152,6 +152,19 @@ export const api = {
     apiRequest<{ data: Invoice[]; total: number }>('GET', `/invoices${params ? '?' + params : ''}`),
   getInvoice: (id: string) =>
     apiRequest<{ invoice: Invoice; line_items: LineItem[] }>('GET', `/invoices/${id}`),
+  // Creates a draft invoice. Cycle invoices originate from the billing engine
+  // and pass subscription_id; one-off invoices issued from the customer-page
+  // composer omit it (backend allows null after migration 0060). Default
+  // billing window is "now" when omitted, default net term is 30 days.
+  createInvoice: (data: {
+    customer_id: string
+    subscription_id?: string
+    currency?: string
+    billing_period_start?: string
+    billing_period_end?: string
+    net_payment_term_days?: number
+    memo?: string
+  }) => apiRequest<Invoice>('POST', '/invoices', data),
   finalizeInvoice: (id: string) =>
     apiRequest<Invoice>('POST', `/invoices/${id}/finalize`),
   voidInvoice: (id: string) =>

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -18,6 +18,20 @@ const entries: {
 }[] = [
   {
     date: '2026-04-26',
+    title: 'One-off invoice composer — 30-second draft + send from customer page',
+    tag: 'feature',
+    body: 'Operators can now bill an ad-hoc charge in under 30 seconds without standing up a subscription first. The customer detail page gains a primary New invoice button at top-right; clicking it opens a drawer with a currency selector (defaults to the customer\'s billing-profile currency, falls back to USD), a line-items grid (description / type / quantity / unit_amount_cents / computed total + remove button), an Add line button, and a memo. Subtotal is live; tax is shown as "Calculated at finalize" so the v1 PaymentIntent-only tax-neutral posture stays explicit. Two actions terminate the flow: Save draft creates the invoice and routes to the invoice page; Save & send creates → finalizes → sends the hosted-invoice email in a single click.',
+    bullets: [
+      'Inline validation gates submit: at least one line, description required per line, integer quantity > 0, integer unit_amount_cents > 0. Errors render under the offending field — no modal-of-errors at submit time.',
+      'Backend: migration 0060 makes invoices.subscription_id nullable so a one-off invoice can be created without a parent subscription. The existing partial unique idempotency index on (tenant_id, subscription_id, billing_period_start) WHERE billing_reason=\'cycle\' already treats NULLs as distinct, so one-off drafts coexist with cycle invoices for the same period without collision. Service.Create no longer rejects empty subscription_id and now defaults billing_period_start / billing_period_end to "now" when both are zero (one-off invoices have no canonical cycle window).',
+      'Default line_type for AddLineItem flips from "manual" to add_on so the CHECK constraint on invoice_line_items.line_type (set: base_fee / usage / add_on / discount / tax) accepts the default. The composer\'s type selector exposes only add_on / base_fee / usage; discount and tax remain reserved for the engine.',
+      'Submit flow: createInvoice → addInvoiceLineItem per line → (Send branch) finalizeInvoice → sendInvoiceEmail (best-effort). Partial-success errors surface the invoice number alongside the failed step\'s reason so the operator can recover from the invoice-detail surface (e.g. "draft INV-0042 created but finalize failed: <reason>").',
+      'On success the dashboard toasts the invoice number, the customer\'s invoices tab refetches via the existing react-query key invalidation, and the toast carries a "View invoice" action button that deep-links to the invoice detail page.',
+      'Snake_case payload throughout: customer_id, currency, billing_period_start/end, net_payment_term_days, memo on the create call; description, line_type, quantity, unit_amount_cents on the per-line addInvoiceLineItem call. Totals always render as an array on read, matching the existing wire-shape conventions across the rest of the API.',
+    ],
+  },
+  {
+    date: '2026-04-26',
     title: 'Plan migration tool — bulk plan swaps with preview + commit',
     tag: 'feature',
     body: 'Operators can now move a cohort of subscribers from one plan to another in a single guarded action. Three endpoints under /v1/admin/plan_migrations gated by PermSubscriptionWrite: POST /preview reuses billing.PreviewService per-customer to produce a before / after / delta table; POST /commit accepts an idempotency_key plus an effective of "immediate" (proration-aware swap of subscription_items.plan_id, stamps plan_changed_at) or "next_period" (sets pending_plan_id + pending_plan_effective_at), returning migration_id / applied_count / audit_log_id (replays of the same key short-circuit via UNIQUE (tenant_id, idempotency_key) without re-mutating); GET / paginates past migrations in reverse-chronological order. The dashboard ships at /plan-migrations with a three-step flow.',

--- a/web-v2/src/pages/CustomerDetail.tsx
+++ b/web-v2/src/pages/CustomerDetail.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useMemo, useState } from 'react'
+import { useNavigate, useParams, Link } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { toast } from 'sonner'
-import { api, formatCents, formatDate, formatDateTime, type Customer, type BillingProfile, type Plan, type Subscription, type PaymentSetup, type CustomerDunningOverride, type CustomerCouponAssignment } from '@/lib/api'
+import { api, formatCents, formatDate, formatDateTime, getCurrencySymbol, type Customer, type BillingProfile, type Invoice, type Plan, type Subscription, type PaymentSetup, type CustomerDunningOverride, type CustomerCouponAssignment } from '@/lib/api'
 import { applyApiError, showApiError } from '@/lib/formErrors'
 import { Layout } from '@/components/Layout'
 import { CostDashboard } from '@/components/CostDashboard'
@@ -30,7 +30,8 @@ import {
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 
-import { Loader2, Pencil, CreditCard, Archive, Wand2, Ticket } from 'lucide-react'
+import { Loader2, Pencil, CreditCard, Archive, Wand2, Ticket, FilePlus2, Plus, Trash2 } from 'lucide-react'
+import { Textarea } from '@/components/ui/textarea'
 import { CopyButton } from '@/components/CopyButton'
 import { DetailBreadcrumb } from '@/components/DetailBreadcrumb'
 import { Combobox } from '@/components/Combobox'
@@ -70,12 +71,14 @@ type BillingProfileData = z.infer<typeof billingProfileSchema>
 export default function CustomerDetailPage() {
   const { id } = useParams<{ id: string }>()
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
 
   const [showEditCustomer, setShowEditCustomer] = useState(false)
   const [showEditBilling, setShowEditBilling] = useState(false)
   const [showCreateSub, setShowCreateSub] = useState(false)
   const [showDunningOverride, setShowDunningOverride] = useState(false)
   const [showAssignCoupon, setShowAssignCoupon] = useState(false)
+  const [showNewInvoice, setShowNewInvoice] = useState(false)
   const [settingUpPayment, setSettingUpPayment] = useState(false)
 
   const { data: customer, isLoading, error: loadError, refetch } = useQuery({
@@ -255,6 +258,12 @@ export default function CustomerDetailPage() {
           </div>
         </div>
         <div className="flex items-center gap-3">
+          {!isArchived && (
+            <Button size="sm" onClick={() => setShowNewInvoice(true)}>
+              <FilePlus2 size={14} className="mr-1.5" />
+              New invoice
+            </Button>
+          )}
           {!isArchived && (
             <Button variant="outline" size="sm" onClick={() => setShowEditCustomer(true)}>
               <Pencil size={14} className="mr-1.5" />
@@ -813,6 +822,39 @@ export default function CustomerDetailPage() {
             setShowAssignCoupon(false)
             queryClient.invalidateQueries({ queryKey: ['customer-coupon', id] })
             toast.success('Discount applied')
+          }}
+        />
+      )}
+
+      {/* One-off Invoice Composer (Week 7). Drawer-styled dialog —
+          create a draft invoice, attach line items, optionally finalize+send.
+          Backed by POST /v1/invoices, POST /v1/invoices/{id}/line-items,
+          POST /v1/invoices/{id}/finalize, POST /v1/invoices/{id}/send. */}
+      {showNewInvoice && id && customer && (
+        <NewInvoiceDialog
+          customerId={id}
+          customer={customer}
+          billingProfile={billingProfile ?? null}
+          onClose={() => setShowNewInvoice(false)}
+          onCreated={({ invoice, sent }) => {
+            setShowNewInvoice(false)
+            queryClient.invalidateQueries({ queryKey: ['customer-overview', id] })
+            queryClient.invalidateQueries({ queryKey: ['invoices'] })
+            if (sent) {
+              toast.success(`Invoice ${invoice.invoice_number} sent`, {
+                action: {
+                  label: 'View invoice',
+                  onClick: () => navigate(`/invoices/${invoice.id}`),
+                },
+              })
+            } else {
+              toast.success(`Draft ${invoice.invoice_number} saved`, {
+                action: {
+                  label: 'View invoice',
+                  onClick: () => navigate(`/invoices/${invoice.id}`),
+                },
+              })
+            }
           }}
         />
       )}
@@ -1388,6 +1430,393 @@ function DunningOverrideDialog({ customerId, override, onClose, onSaved, onDelet
             </div>
           </div>
         </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/* ─── One-off Invoice Composer ────────────────────────────────── */
+
+// Fixed catalog of line types the operator can pick from. Mirrors the DB
+// CHECK on invoice_line_items.line_type. tax/discount are intentionally
+// disabled in the composer — those flow through tax provider + coupon
+// surfaces, not the manual line editor.
+const COMPOSER_LINE_TYPES: { value: string; label: string }[] = [
+  { value: 'add_on', label: 'Add-on / one-off charge' },
+  { value: 'base_fee', label: 'Base fee' },
+  { value: 'usage', label: 'Usage' },
+]
+
+type ComposerLine = {
+  description: string
+  quantity: string         // string-bound input; coerced at submit time
+  unit_amount_cents: string  // string-bound; cent values, no decimals
+  line_type: string
+}
+
+const blankLine = (): ComposerLine => ({
+  description: '',
+  quantity: '1',
+  unit_amount_cents: '',
+  line_type: 'add_on',
+})
+
+function NewInvoiceDialog({ customerId, customer, billingProfile, onClose, onCreated }: {
+  customerId: string
+  customer: Customer
+  billingProfile: BillingProfile | null
+  onClose: () => void
+  onCreated: (result: { invoice: Invoice; sent: boolean }) => void
+}) {
+  // Default currency: prefer the customer's billing profile currency, else
+  // tenant default (USD here is a placeholder until the tenant settings query
+  // is plumbed; the operator can switch in one click).
+  const initialCurrency = (billingProfile?.currency || 'USD').toUpperCase()
+  const [currency, setCurrency] = useState(initialCurrency)
+  const [memo, setMemo] = useState('')
+  const [lines, setLines] = useState<ComposerLine[]>([blankLine()])
+  const [errors, setErrors] = useState<{
+    lines?: Record<number, { description?: string; quantity?: string; unit_amount_cents?: string }>
+    form?: string
+  }>({})
+  const [submitting, setSubmitting] = useState<null | 'draft' | 'send'>(null)
+
+  const currencySymbol = getCurrencySymbol(currency)
+
+  const subtotalCents = useMemo(() => {
+    return lines.reduce((acc, l) => {
+      const q = Number(l.quantity)
+      const u = Number(l.unit_amount_cents)
+      if (!Number.isFinite(q) || !Number.isFinite(u) || q <= 0 || u < 0) return acc
+      return acc + Math.round(q) * Math.round(u)
+    }, 0)
+  }, [lines])
+
+  const updateLine = (idx: number, patch: Partial<ComposerLine>) => {
+    setLines(prev => prev.map((l, i) => (i === idx ? { ...l, ...patch } : l)))
+    // Clear inline error for the field being edited so the user gets
+    // immediate feedback that the issue is resolved.
+    setErrors(prev => {
+      if (!prev.lines?.[idx]) return prev
+      const lineErrs = { ...prev.lines[idx] }
+      for (const k of Object.keys(patch)) delete lineErrs[k as keyof typeof lineErrs]
+      return { ...prev, lines: { ...prev.lines, [idx]: lineErrs } }
+    })
+  }
+
+  const addLine = () => setLines(prev => [...prev, blankLine()])
+  const removeLine = (idx: number) => setLines(prev => prev.filter((_, i) => i !== idx))
+
+  // validate returns sanitized lines suitable for the API. Returns null on
+  // any validation failure (errors are surfaced via setErrors).
+  const validate = (): { description: string; line_type: string; quantity: number; unit_amount_cents: number }[] | null => {
+    const lineErrors: Record<number, { description?: string; quantity?: string; unit_amount_cents?: string }> = {}
+    const cleaned: { description: string; line_type: string; quantity: number; unit_amount_cents: number }[] = []
+    if (lines.length === 0) {
+      setErrors({ form: 'Add at least one line item.' })
+      return null
+    }
+    lines.forEach((l, i) => {
+      const errs: { description?: string; quantity?: string; unit_amount_cents?: string } = {}
+      const desc = l.description.trim()
+      if (!desc) errs.description = 'Description is required'
+      const qty = Number(l.quantity)
+      if (!Number.isFinite(qty) || !Number.isInteger(qty) || qty <= 0) {
+        errs.quantity = 'Whole number greater than 0'
+      }
+      const unit = Number(l.unit_amount_cents)
+      if (!Number.isFinite(unit) || !Number.isInteger(unit) || unit < 0) {
+        errs.unit_amount_cents = 'Whole cents, 0 or more'
+      }
+      // Backend currently rejects unit_amount_cents <= 0. Surface that
+      // upfront so the user fixes it before the round-trip.
+      if (Number.isInteger(unit) && unit === 0) {
+        errs.unit_amount_cents = 'Must be greater than 0'
+      }
+      if (Object.keys(errs).length > 0) {
+        lineErrors[i] = errs
+      } else {
+        cleaned.push({
+          description: desc,
+          line_type: l.line_type || 'add_on',
+          quantity: qty,
+          unit_amount_cents: unit,
+        })
+      }
+    })
+    if (Object.keys(lineErrors).length > 0) {
+      setErrors({ lines: lineErrors })
+      return null
+    }
+    setErrors({})
+    return cleaned
+  }
+
+  // submit creates the draft invoice, attaches every line item in sequence,
+  // and (when finalize=true) finalizes + sends. Failure at any step leaves
+  // the operator with whatever has already been persisted (the draft + any
+  // committed line items) so they can recover by opening the invoice in the
+  // detail view.
+  const submit = async (action: 'draft' | 'send') => {
+    const cleaned = validate()
+    if (!cleaned) return
+    setSubmitting(action)
+    let invoice: Invoice | null = null
+    try {
+      invoice = await api.createInvoice({
+        customer_id: customerId,
+        currency: currency,
+        memo: memo.trim() || undefined,
+      })
+
+      for (const line of cleaned) {
+        await api.addInvoiceLineItem(invoice.id, line)
+      }
+
+      let sent = false
+      if (action === 'send') {
+        invoice = await api.finalizeInvoice(invoice.id)
+        const recipient = billingProfile?.email || customer.email
+        if (recipient) {
+          // Best-effort send: a transient SMTP failure shouldn't unwind a
+          // successfully finalized invoice. Operators can resend from the
+          // invoice detail page if the email never lands.
+          try {
+            await api.sendInvoiceEmail(invoice.id, recipient)
+            sent = true
+          } catch (sendErr) {
+            toast.warning(
+              `Invoice finalized, but email to ${recipient} failed. Resend from the invoice detail page.`,
+            )
+          }
+        } else {
+          toast.warning('Invoice finalized, but no email is on file. Add one to send.')
+        }
+      }
+
+      onCreated({ invoice, sent })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create invoice'
+      // Partial-success messaging: if we got an invoice ID but failed mid-flight
+      // (line item add, finalize, etc.) tell the operator what survived so they
+      // can pick it up from the invoice detail page.
+      if (invoice) {
+        setErrors({
+          form: `Draft ${invoice.invoice_number} created, but a later step failed: ${message}. Open the invoice detail page to continue.`,
+        })
+      } else {
+        setErrors({ form: message })
+      }
+    } finally {
+      setSubmitting(null)
+    }
+  }
+
+  const isBusy = submitting !== null
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open && !isBusy) onClose() }}>
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>New invoice</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* Customer summary — confirm the operator is invoicing the right
+              account before they commit lines. */}
+          <div className="rounded-md border border-border bg-muted/40 px-4 py-3 flex items-center justify-between">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">{customer.display_name}</p>
+              <p className="text-xs text-muted-foreground truncate">{customer.email || 'No email on file'}</p>
+            </div>
+            <Badge variant="outline">{customer.external_id}</Badge>
+          </div>
+
+          {/* Currency */}
+          <div className="space-y-2">
+            <Label htmlFor="composer-currency">Currency</Label>
+            <Select value={currency} onValueChange={(v) => setCurrency((v ?? 'USD').toUpperCase())}>
+              <SelectTrigger id="composer-currency" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {GEO_CURRENCIES.map(c => (
+                  <SelectItem key={c.code} value={c.code}>
+                    {c.symbol} {c.code} \u2014 {c.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {billingProfile?.currency && billingProfile.currency.toUpperCase() === currency && (
+              <p className="text-xs text-muted-foreground">From customer billing profile.</p>
+            )}
+          </div>
+
+          {/* Line items */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label>Line items</Label>
+              <Button type="button" variant="outline" size="sm" onClick={addLine} disabled={isBusy}>
+                <Plus size={14} className="mr-1.5" />
+                Add line
+              </Button>
+            </div>
+
+            <div className="rounded-md border border-border overflow-hidden">
+              <div className="grid grid-cols-[1fr_120px_140px_160px_44px] gap-0 bg-muted/40 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                <div className="px-3 py-2">Description</div>
+                <div className="px-3 py-2">Type</div>
+                <div className="px-3 py-2">Qty</div>
+                <div className="px-3 py-2">Unit ({currencySymbol.trim() || currency})</div>
+                <div className="px-3 py-2"></div>
+              </div>
+              <div className="divide-y divide-border">
+                {lines.map((line, idx) => {
+                  const lineErrs = errors.lines?.[idx] || {}
+                  const qty = Number(line.quantity)
+                  const unit = Number(line.unit_amount_cents)
+                  const totalCents = Number.isFinite(qty) && Number.isFinite(unit) && qty > 0 && unit >= 0
+                    ? Math.round(qty) * Math.round(unit)
+                    : 0
+                  return (
+                    <div key={idx} className="grid grid-cols-[1fr_120px_140px_160px_44px] items-start gap-0">
+                      <div className="px-3 py-2 space-y-1">
+                        <Input
+                          placeholder="Implementation services"
+                          value={line.description}
+                          onChange={e => updateLine(idx, { description: e.target.value })}
+                          aria-invalid={!!lineErrs.description}
+                          maxLength={500}
+                          disabled={isBusy}
+                        />
+                        {lineErrs.description && <p className="text-xs text-destructive">{lineErrs.description}</p>}
+                      </div>
+                      <div className="px-3 py-2">
+                        <Select value={line.line_type} onValueChange={v => updateLine(idx, { line_type: v ?? 'add_on' })}>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {COMPOSER_LINE_TYPES.map(t => (
+                              <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                      <div className="px-3 py-2 space-y-1">
+                        <Input
+                          type="number"
+                          inputMode="numeric"
+                          min={1}
+                          step={1}
+                          placeholder="1"
+                          value={line.quantity}
+                          onChange={e => updateLine(idx, { quantity: e.target.value })}
+                          aria-invalid={!!lineErrs.quantity}
+                          disabled={isBusy}
+                        />
+                        {lineErrs.quantity && <p className="text-xs text-destructive">{lineErrs.quantity}</p>}
+                      </div>
+                      <div className="px-3 py-2 space-y-1">
+                        <Input
+                          type="number"
+                          inputMode="numeric"
+                          min={0}
+                          step={1}
+                          placeholder="2500"
+                          value={line.unit_amount_cents}
+                          onChange={e => updateLine(idx, { unit_amount_cents: e.target.value })}
+                          aria-invalid={!!lineErrs.unit_amount_cents}
+                          disabled={isBusy}
+                        />
+                        {lineErrs.unit_amount_cents
+                          ? <p className="text-xs text-destructive">{lineErrs.unit_amount_cents}</p>
+                          : <p className="text-xs text-muted-foreground">= {formatCents(totalCents, currency)}</p>}
+                      </div>
+                      <div className="px-3 py-2 flex justify-center">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Remove line ${idx + 1}`}
+                          onClick={() => removeLine(idx)}
+                          disabled={isBusy || lines.length === 1}
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Amounts are in cents (e.g. 2500 = {formatCents(2500, currency)}). Tax is applied per the tenant's tax provider when the invoice finalizes.
+            </p>
+          </div>
+
+          {/* Memo */}
+          <div className="space-y-2">
+            <Label htmlFor="composer-memo">Memo (optional)</Label>
+            <Textarea
+              id="composer-memo"
+              placeholder="Notes for the customer — appears on the invoice PDF."
+              value={memo}
+              onChange={e => setMemo(e.target.value)}
+              maxLength={2000}
+              disabled={isBusy}
+            />
+          </div>
+
+          <Separator />
+
+          {/* Subtotal — read-only client-computed sum of lines. Tax is server-
+              computed at finalize and reflected on the invoice detail page;
+              we don't preview tax here because the tax provider is
+              tenant-configurable and a wrong preview is worse than no
+              preview. */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Subtotal</span>
+              <span className="text-sm font-medium text-foreground">{formatCents(subtotalCents, currency)}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Tax</span>
+              <span className="text-sm text-muted-foreground">Calculated at finalize</span>
+            </div>
+            <div className="flex items-center justify-between border-t border-border pt-2">
+              <span className="text-sm font-semibold text-foreground">Total (before tax)</span>
+              <span className="text-sm font-semibold text-foreground">{formatCents(subtotalCents, currency)}</span>
+            </div>
+          </div>
+
+          {errors.form && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              {errors.form}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isBusy}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => submit('draft')}
+            disabled={isBusy}
+          >
+            {submitting === 'draft'
+              ? <><Loader2 size={14} className="animate-spin mr-2" />Saving draft...</>
+              : 'Save draft'}
+          </Button>
+          <Button type="button" onClick={() => submit('send')} disabled={isBusy}>
+            {submitting === 'send'
+              ? <><Loader2 size={14} className="animate-spin mr-2" />Finalizing...</>
+              : 'Save & send'}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Summary

- Primary **New invoice** button at top-right of every customer detail page opens a drawer composing an ad-hoc invoice without a parent subscription. Currency selector defaults to the customer's billing-profile currency; line-items grid (description / type / qty / `unit_amount_cents`) with add + remove, memo, live subtotal, and "Save draft" / "Save & send" terminal actions.
- Backend slice (already merged as commit `2781f57` on this branch): migration `0060` makes `invoices.subscription_id` nullable; `Service.Create` no longer rejects empty `subscription_id` and defaults `billing_period_start` / `_end` to `now()` when both are zero; default `line_type` for `AddLineItem` flips from `"manual"` to `add_on` so the existing CHECK constraint accepts the default.
- CHANGELOG.md + Changelog.tsx both updated (Week 7, dated 2026-04-26).

## Backend endpoints used

- `POST /v1/invoices` (existing) — creates the draft. Now accepts payloads without `subscription_id`.
- `POST /v1/invoices/{id}/line_items` (existing) — per-line addition; the composer fans out one call per line.
- `POST /v1/invoices/{id}/finalize` (existing) — only on the "Save & send" branch.
- `POST /v1/invoices/{id}/send_email` (existing) — best-effort after finalize on the send branch; failures surface alongside the invoice number so the operator can recover from the invoice page.

No new endpoints landed — the composer is intentionally a thin client over the existing public surface.

## Validation

- `go test -short -count=1 ./...` green across all packages locally.
- `vite build` succeeds; `tsc -b` shows zero new errors from this slice (4 errors exist on `main` in `HostedInvoice.tsx`, `PlanMigration.tsx`, `Webhooks.tsx` — verified with `git stash` that they pre-date this PR).

## Sibling-lane heads-up

Lane A may also touch `web-v2/src/pages/CustomerDetail.tsx` and `web-v2/src/lib/api.ts`. If a rebase conflict appears, prefer **keep both** for the new `createInvoice` helper in `api.ts` (it's purely additive next to the existing `getInvoice` / `finalizeInvoice` exports) and for the new `NewInvoiceDialog` component + the "New invoice" button block in `CustomerDetail.tsx`.

## Test plan

- [ ] Manual: open a customer page, click **New invoice**, add 2-3 lines, click **Save draft** → toast fires, invoice list refreshes, "View invoice" link routes to the new draft.
- [ ] Manual: same flow, click **Save & send** → invoice finalizes, send_email queued, toast carries invoice number.
- [ ] Manual: leave description blank → inline error blocks submit.
- [ ] Manual: enter `unit_amount_cents = 0` → inline error blocks submit.
- [ ] CI: backend `go test ./...` passes.
- [ ] CI: frontend `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)