### PR TITLE
feat(dashboard): spend thresholds card + edit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,23 @@ A second surface mirrors this file:
 
 ### Added
 
+- **Spend thresholds dashboard surface (Track B for the
+  `PUT/DELETE /v1/subscriptions/{id}/billing-thresholds` backend that
+  shipped earlier).** New "Spend thresholds" card on the subscription
+  detail page surfaces the configured cap (subtotal cap in the sub's
+  currency, plus the per-item usage caps mapped to plan names) with a
+  hint that explains the reset-billing-cycle flag in plain English.
+  When unset, the empty-state copy explains the cycle scan is the only
+  invoice-emitting path, so operators know the default behavior.
+  `Set thresholds` / `Edit` opens a dialog that takes amount in major
+  units (× 100 to cents on submit) and per-item `usage_gte` as a
+  decimal-string (round-trips fractional meter quantities without float
+  drift, per ADR-005). `Clear thresholds` button on the destructive
+  side wires the DELETE. Validation mirrors backend: at-least-one-of,
+  subtotal must be positive, per-item must be a non-negative number.
+  Edit is hidden on canceled / archived subs (matches the backend
+  reject). Closes the Track B half of the billing-thresholds feature.
+
 - **Typed `<VeloxCostDashboard />` React wrapper at
   `web-v2/src/components/embeds/VeloxCostDashboard.tsx`.** Wraps the
   public iframe with a typed prop interface (`token`, `baseUrl`, `theme`,

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -277,6 +277,20 @@ export const api = {
     apiRequest<Subscription>('PUT', `/subscriptions/${id}/pause-collection`, body),
   resumeSubscriptionCollection: (id: string) =>
     apiRequest<Subscription>('DELETE', `/subscriptions/${id}/pause-collection`),
+  // Billing thresholds — Stripe-parity hard-cap config. PUT is replace-all
+  // (omitted item_thresholds rows are deleted by the backend store);
+  // DELETE removes the configuration entirely. The body must contain at
+  // least one of amount_gte or item_thresholds[] — a body with neither is
+  // rejected as a no-op masquerade. usage_gte arrives over the wire as a
+  // decimal-string per ADR-005 to round-trip fractional meter quantities.
+  setSubscriptionBillingThresholds: (id: string, body: {
+    amount_gte?: number
+    reset_billing_cycle?: boolean
+    item_thresholds?: { subscription_item_id: string; usage_gte: string }[]
+  }) =>
+    apiRequest<Subscription>('PUT', `/subscriptions/${id}/billing-thresholds`, body),
+  clearSubscriptionBillingThresholds: (id: string) =>
+    apiRequest<Subscription>('DELETE', `/subscriptions/${id}/billing-thresholds`),
   endSubscriptionTrial: (id: string) =>
     apiRequest<Subscription>('POST', `/subscriptions/${id}/end-trial`),
   extendSubscriptionTrial: (id: string, body: { trial_end: string }) =>
@@ -560,6 +574,25 @@ export interface ItemChangeResult {
   proration?: ProrationDetail
 }
 
+// SubscriptionItemThreshold is one per-item usage cap on a subscription.
+// usage_gte is a decimal-string (e.g. "1000000.000000000000") so meter
+// quantities that can be fractional round-trip without float drift.
+export interface SubscriptionItemThreshold {
+  subscription_item_id: string
+  usage_gte: string
+}
+
+// BillingThresholds is the Stripe-parity hard-cap config attached to a
+// subscription. Either amount_gte alone, item_thresholds[] alone, or both.
+// item_thresholds is always-array (the dashboard's .map() works in all
+// cases). amount_gte is integer cents in the subscription's currency;
+// multi-currency subs reject amount_gte at PUT time.
+export interface BillingThresholds {
+  amount_gte?: number
+  reset_billing_cycle: boolean
+  item_thresholds: SubscriptionItemThreshold[]
+}
+
 export interface Subscription {
   id: string
   code: string
@@ -585,6 +618,11 @@ export interface Subscription {
     behavior: 'keep_as_draft'
     resumes_at?: string
   }
+  // billing_thresholds is the Stripe-parity hard-cap config. Nil/missing
+  // means no cap is configured. When the running cycle subtotal crosses
+  // amount_gte, or any item's running quantity crosses its usage_gte, the
+  // billing engine fires an early finalize.
+  billing_thresholds?: BillingThresholds
   created_at: string
 }
 

--- a/web-v2/src/pages/Changelog.tsx
+++ b/web-v2/src/pages/Changelog.tsx
@@ -19,6 +19,12 @@ const entries: {
   bullets?: string[]
 }[] = [
   {
+    date: '2026-04-28',
+    title: 'Spend thresholds — dashboard surface for the Stripe-parity hard cap',
+    tag: 'feature',
+    body: 'New "Spend thresholds" card on the subscription detail page surfaces the Stripe-parity hard cap that the PUT/DELETE /v1/subscriptions/{id}/billing-thresholds backend has shipped since FEAT-7 — closing the Track B half that had been operator-blocked behind curl until now. The card displays the configured subtotal cap (in the subscription\'s currency, e.g. "$1,000.00 (resets cycle on fire)") and each per-item cap mapped to its plan name with the cap quantity rendered as "≥ 1000000 units" (trailing-zero-stripped from the NUMERIC(38,12) wire string per ADR-005, so "1000000.000000000000" surfaces as the readable "1000000"). When unset, the empty-state copy explains the cycle scan is the only invoice-emitting path, so operators understand the default behavior rather than wondering whether a threshold is silently set somewhere. The Set thresholds / Edit dialog takes the subtotal cap in major units (× 100 to integer cents on submit so the operator types "1000.00" rather than 100000), exposes the reset_billing_cycle checkbox with a plain-English description of both modes ("the new cycle starts at fire time" vs "the original cycle continues and a residual invoice fires at the natural cycle end"), and lists every subscription item with a per-item usage_gte text input that round-trips fractional decimals untouched (cached-token ratios, GPU-hours). Validation mirrors the backend layer-for-layer: at-least-one-of (subtotal or any per-item), subtotal must be a positive number, per-item must match /^\\d+(\\.\\d+)?$/. Clear thresholds button on the destructive side wires the DELETE for one-click removal. Edit is hidden on canceled / archived subs because the backend rejects there anyway. The card sits above Properties on the detail page — the threshold state is high-leverage information operators look at often during onboarding and incident response, so it surfaces in the prime visual position rather than buried below ten static rows.',
+  },
+  {
     date: '2026-04-27',
     title: 'Five new public docs pages — Account setup, Errors, Rate limits, Glossary, Troubleshooting',
     tag: 'docs',

--- a/web-v2/src/pages/SubscriptionDetail.tsx
+++ b/web-v2/src/pages/SubscriptionDetail.tsx
@@ -36,6 +36,15 @@ import { DetailBreadcrumb } from '@/components/DetailBreadcrumb'
 
 const statusVariant = statusBadgeVariant
 
+// trimDecimal strips trailing zeros from a fractional decimal string while
+// leaving integers untouched ("1000.000000000000" → "1000", "3.140" → "3.14",
+// "1000" → "1000"). Backend usage_gte arrives as a NUMERIC(38,12) string per
+// ADR-005; surface it without the bookkeeping zeros.
+function trimDecimal(s: string): string {
+  if (!s.includes('.')) return s
+  return s.replace(/0+$/, '').replace(/\.$/, '')
+}
+
 type ItemDialogState =
   | { kind: 'add' }
   | { kind: 'change-plan'; item: SubscriptionItem }
@@ -55,6 +64,7 @@ export default function SubscriptionDetailPage() {
   const [showExtendTrial, setShowExtendTrial] = useState(false)
   const [extendTrialDate, setExtendTrialDate] = useState('')
   const [itemDialog, setItemDialog] = useState<ItemDialogState>(null)
+  const [showThresholdsDialog, setShowThresholdsDialog] = useState(false)
 
   const { data: sub, isLoading, error: loadError, refetch } = useQuery({
     queryKey: ['subscription', id],
@@ -578,6 +588,52 @@ export default function SubscriptionDetailPage() {
         </CardContent>
       </Card>
 
+      {/* Spend Thresholds */}
+      <Card className="mt-6">
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div className="space-y-1">
+            <CardTitle className="text-sm">Spend thresholds</CardTitle>
+            <p className="text-xs text-muted-foreground">
+              Stripe-parity hard cap. Fires an early invoice the moment the running cycle subtotal or any item's running quantity crosses a configured cap.
+            </p>
+          </div>
+          {sub.status !== 'canceled' && sub.status !== 'archived' && (
+            <Button size="sm" variant="outline" onClick={() => setShowThresholdsDialog(true)}>
+              {sub.billing_thresholds ? 'Edit' : 'Set thresholds'}
+            </Button>
+          )}
+        </CardHeader>
+        <CardContent className={sub.billing_thresholds ? 'p-0' : undefined}>
+          {sub.billing_thresholds ? (
+            <div className="divide-y divide-border">
+              {sub.billing_thresholds.amount_gte != null && (
+                <div className="flex items-center justify-between px-6 py-3">
+                  <span className="text-sm text-muted-foreground w-40 shrink-0">Subtotal cap</span>
+                  <span className="text-sm text-foreground">
+                    {formatCents(sub.billing_thresholds.amount_gte, items[0] ? planById(items[0].plan_id)?.currency : undefined)}
+                    <span className="text-xs text-muted-foreground ml-2">
+                      ({sub.billing_thresholds.reset_billing_cycle ? 'resets cycle on fire' : 'continues cycle on fire'})
+                    </span>
+                  </span>
+                </div>
+              )}
+              {sub.billing_thresholds.item_thresholds.map(t => {
+                const ti = items.find(i => i.id === t.subscription_item_id)
+                const tp = ti ? planById(ti.plan_id) : undefined
+                return (
+                  <div key={t.subscription_item_id} className="flex items-center justify-between px-6 py-3">
+                    <span className="text-sm text-muted-foreground w-40 shrink-0">{tp?.name || t.subscription_item_id}</span>
+                    <span className="text-sm text-foreground">&ge; {trimDecimal(t.usage_gte)} units</span>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">No spend cap configured. The cycle scan is the only invoice-emitting path.</p>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Properties */}
       <Card className="mt-6">
         <CardHeader>
@@ -1001,6 +1057,17 @@ export default function SubscriptionDetailPage() {
           onRemoved={() => { setItemDialog(null); invalidateAll(); toast.success('Item removed') }}
         />
       )}
+
+      {/* Edit Billing Thresholds */}
+      {showThresholdsDialog && (
+        <EditBillingThresholdsDialog
+          subscription={sub}
+          items={items}
+          planById={planById}
+          onClose={() => setShowThresholdsDialog(false)}
+          onSaved={(verb) => { setShowThresholdsDialog(false); invalidateAll(); toast.success(verb) }}
+        />
+      )}
     </Layout>
   )
 }
@@ -1316,5 +1383,179 @@ function RemoveItemConfirm({ subscriptionID, item, plan, onClose, onRemoved }: {
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+  )
+}
+
+// EditBillingThresholdsDialog sets or clears the Stripe-parity hard cap. The
+// PUT body is replace-all: any per-item row not in the submitted list is
+// deleted by the store, so we always send the full set the operator sees.
+// amount_gte is captured in major units in the input and converted to integer
+// cents on submit; usage_gte is a decimal-string per ADR-005.
+function EditBillingThresholdsDialog({ subscription, items, planById, onClose, onSaved }: {
+  subscription: Subscription
+  items: SubscriptionItem[]
+  planById: (planID: string) => Plan | undefined
+  onClose: () => void
+  onSaved: (verb: string) => void
+}) {
+  const existing = subscription.billing_thresholds
+  const subCurrency = items[0] ? planById(items[0].plan_id)?.currency : undefined
+
+  const [amountStr, setAmountStr] = useState(
+    existing?.amount_gte != null ? (existing.amount_gte / 100).toFixed(2) : ''
+  )
+  const [resetCycle, setResetCycle] = useState(existing?.reset_billing_cycle ?? true)
+  const [perItem, setPerItem] = useState<Record<string, string>>(() => {
+    const out: Record<string, string> = {}
+    for (const t of existing?.item_thresholds ?? []) {
+      out[t.subscription_item_id] = trimDecimal(t.usage_gte)
+    }
+    return out
+  })
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const body: { amount_gte?: number; reset_billing_cycle?: boolean; item_thresholds?: { subscription_item_id: string; usage_gte: string }[] } = {
+      reset_billing_cycle: resetCycle,
+    }
+
+    const trimmedAmount = amountStr.trim()
+    if (trimmedAmount !== '') {
+      const amt = Number(trimmedAmount)
+      if (!Number.isFinite(amt) || amt <= 0) {
+        toast.error('Subtotal cap must be a positive number')
+        return
+      }
+      body.amount_gte = Math.round(amt * 100)
+    }
+
+    const itemThresholds: { subscription_item_id: string; usage_gte: string }[] = []
+    for (const item of items) {
+      const raw = (perItem[item.id] ?? '').trim()
+      if (raw === '') continue
+      if (!/^\d+(\.\d+)?$/.test(raw)) {
+        toast.error(`Per-item cap for ${planById(item.plan_id)?.name || item.id} must be a non-negative number`)
+        return
+      }
+      itemThresholds.push({ subscription_item_id: item.id, usage_gte: raw })
+    }
+    if (itemThresholds.length > 0) {
+      body.item_thresholds = itemThresholds
+    }
+
+    if (body.amount_gte == null && (body.item_thresholds == null || body.item_thresholds.length === 0)) {
+      toast.error('Set at least one cap (subtotal or per-item)')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      await api.setSubscriptionBillingThresholds(subscription.id, body)
+      onSaved(existing ? 'Thresholds updated' : 'Thresholds set')
+    } catch (err) {
+      showApiError(err, 'Failed to save thresholds')
+      setSubmitting(false)
+    }
+  }
+
+  const handleClear = async () => {
+    setSubmitting(true)
+    try {
+      await api.clearSubscriptionBillingThresholds(subscription.id)
+      onSaved('Thresholds cleared')
+    } catch (err) {
+      showApiError(err, 'Failed to clear thresholds')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open && !submitting) onClose() }}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{existing ? 'Edit spend thresholds' : 'Set spend thresholds'}</DialogTitle>
+          <DialogDescription>
+            Configure a hard cap. The billing engine fires an early invoice the moment the running cycle subtotal or any item's running quantity crosses a configured cap. At least one cap is required.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} noValidate className="space-y-5">
+          <div className="space-y-2">
+            <Label htmlFor="amount-gte">Subtotal cap{subCurrency ? ` (${subCurrency.toUpperCase()})` : ''}</Label>
+            <Input
+              id="amount-gte"
+              type="number"
+              inputMode="decimal"
+              step="0.01"
+              min="0"
+              placeholder="e.g. 1000.00"
+              value={amountStr}
+              onChange={(e) => setAmountStr(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Fires when the running cycle subtotal crosses this amount. Leave blank for no subtotal cap.
+            </p>
+          </div>
+
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="reset-cycle"
+              checked={resetCycle}
+              onCheckedChange={(v) => setResetCycle(v === true)}
+            />
+            <div className="space-y-1">
+              <Label htmlFor="reset-cycle" className="font-normal">Reset billing cycle on fire</Label>
+              <p className="text-xs text-muted-foreground">
+                When checked (default), the new cycle starts at fire time. When unchecked, the original cycle continues and a residual invoice fires at the natural cycle end.
+              </p>
+            </div>
+          </div>
+
+          {items.length > 0 && (
+            <div className="space-y-2">
+              <Label>Per-item caps</Label>
+              <div className="rounded-md border divide-y divide-border">
+                {items.map(item => {
+                  const plan = planById(item.plan_id)
+                  return (
+                    <div key={item.id} className="flex items-center gap-3 px-3 py-2">
+                      <span className="text-sm text-foreground flex-1 truncate">{plan?.name || item.id}</span>
+                      <Input
+                        type="text"
+                        inputMode="decimal"
+                        placeholder="leave blank for none"
+                        className="w-40 h-8 text-sm"
+                        value={perItem[item.id] ?? ''}
+                        onChange={(e) => setPerItem(prev => ({ ...prev, [item.id]: e.target.value }))}
+                      />
+                      <span className="text-xs text-muted-foreground w-10 shrink-0">units</span>
+                    </div>
+                  )
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Fires when any item's running cycle quantity crosses its cap. Decimal allowed (cached-token ratios, GPU-hours).
+              </p>
+            </div>
+          )}
+
+          <DialogFooter className="gap-2 sm:justify-between">
+            {existing ? (
+              <Button type="button" variant="destructive" onClick={handleClear} disabled={submitting}>
+                Clear thresholds
+              </Button>
+            ) : <span />}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? (
+                  <><Loader2 size={14} className="animate-spin mr-2" />Saving...</>
+                ) : 'Save'}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Summary

Surfaces the Stripe-parity hard cap that the `PUT/DELETE /v1/subscriptions/{id}/billing-thresholds` backend has shipped since FEAT-7 — closes the Track B half that had been operator-blocked behind curl until now.

## What ships

**Subscription detail page — new "Spend thresholds" card** (sits above Properties):

- Subtotal cap rendered in the sub's currency (e.g. `$1,000.00`) with a plain-English reset hint: "resets cycle on fire" / "continues cycle on fire"
- Per-item caps mapped to plan name, displayed as `≥ 1000000 units` — trailing zeros stripped from the NUMERIC(38,12) wire string per ADR-005
- Empty state when nothing is configured: "No spend cap configured. The cycle scan is the only invoice-emitting path." So operators understand the default rather than wondering whether a threshold is silently set
- Edit / Set thresholds button hidden on canceled / archived subs (backend rejects there anyway)

**EditBillingThresholdsDialog**:

- Subtotal cap input takes major units (× 100 to integer cents on submit so the operator types `1000.00` rather than `100000`)
- `reset_billing_cycle` checkbox with both modes documented inline
- Per-item rows for every subscription item with `usage_gte` text inputs that round-trip fractional decimals untouched (cached-token ratios, GPU-hours)
- Validation mirrors backend: at-least-one-of (subtotal or any per-item), positive subtotal, `^\d+(\.\d+)?$` per-item
- Clear thresholds button on the destructive side wires DELETE for one-click removal

**`web-v2/src/lib/api.ts`**:

- New `BillingThresholds` + `SubscriptionItemThreshold` interfaces
- `setSubscriptionBillingThresholds(id, body)` and `clearSubscriptionBillingThresholds(id)` methods
- Optional `billing_thresholds?: BillingThresholds` on `Subscription`

## Why now

Backend has been live since PR #29 (commit 7adf96b). The Track B UI was never built — `api.ts` had no threshold field on `Subscription`, no setter / clearer methods, and `SubscriptionDetail` had zero references. This PR closes that gap.

## Test plan

- [ ] Open a subscription with no thresholds — empty state copy renders, button reads "Set thresholds"
- [ ] Click Set thresholds — dialog opens, subtotal input empty, reset checkbox checked, per-item inputs blank
- [ ] Submit blank → validation: "Set at least one cap"
- [ ] Submit subtotal `1000.00` only → backend stores `100000` cents, card refreshes showing `$1,000.00 (resets cycle on fire)`, button now reads "Edit"
- [ ] Edit, add per-item cap `1000` for one item → card shows the per-item row with `≥ 1000 units`
- [ ] Uncheck reset → card hint flips to "continues cycle on fire"
- [ ] Per-item `abc` → validation rejects, no submit
- [ ] Subtotal `0` → validation rejects ("must be a positive number")
- [ ] Clear thresholds → DELETE fires, card returns to empty state
- [ ] Cancel a subscription → Edit button is hidden
- [ ] Type `1000000.000000000000` (server-stored format) and reload — card displays `1000000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)