### PR TITLE
fix(web): add /checkout/success page (closes #6)

### DIFF
--- a/web-v2/src/main.tsx
+++ b/web-v2/src/main.tsx
@@ -125,6 +125,7 @@ const CustomerPortalPage = lazy(() => import('@/pages/CustomerPortal'))
 const CustomerPortalLoginPage = lazy(() => import('@/pages/CustomerPortalLogin'))
 const HostedInvoicePage = lazy(() => import('@/pages/HostedInvoice'))
 const PublicCostDashboardPage = lazy(() => import('@/pages/PublicCostDashboard'))
+const CheckoutSuccessPage = lazy(() => import('@/pages/CheckoutSuccess'))
 const CustomerDetailPage = lazy(() => import('@/pages/CustomerDetail'))
 const InvoiceDetailPage = lazy(() => import('@/pages/InvoiceDetail'))
 const SubscriptionDetailPage = lazy(() => import('@/pages/SubscriptionDetail'))
@@ -208,6 +209,7 @@ const App = () => (
               <Route path="/customer-portal/login" element={<CustomerPortalLoginPage />} />
               <Route path="/invoice/:token" element={<HostedInvoicePage />} />
               <Route path="/public/cost-dashboard/:token" element={<PublicCostDashboardPage />} />
+              <Route path="/checkout/success" element={<CheckoutSuccessPage />} />
               <Route path="/docs" element={<DocsPage />} />
               <Route path="/docs/quickstart" element={<DocsQuickstartPage />} />
               <Route path="/docs/recipes" element={<DocsRecipesPage />} />

--- a/web-v2/src/pages/CheckoutSuccess.tsx
+++ b/web-v2/src/pages/CheckoutSuccess.tsx
@@ -1,0 +1,39 @@
+import { useSearchParams, Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { CheckCircle2 } from 'lucide-react'
+
+export default function CheckoutSuccessPage() {
+  const [searchParams] = useSearchParams()
+  const sessionId = searchParams.get('session_id')
+  const customerId = searchParams.get('customer_id')
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="p-8 text-center space-y-4">
+          <div className="w-16 h-16 rounded-full bg-emerald-50 dark:bg-emerald-500/10 flex items-center justify-center mx-auto">
+            <CheckCircle2 size={64} className="text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+          </div>
+          <h1 className="text-xl font-semibold text-foreground">Payment successful</h1>
+          <p className="text-sm text-muted-foreground">
+            Your payment was processed successfully. You can close this tab or return to the dashboard.
+          </p>
+          {sessionId && (
+            <p className="text-xs font-mono text-muted-foreground">Reference: {sessionId}</p>
+          )}
+          <div className="flex flex-col sm:flex-row gap-2 pt-2">
+            <Button asChild size="lg" className="flex-1">
+              <Link to="/">Return to dashboard</Link>
+            </Button>
+            {customerId && (
+              <Button asChild variant="outline" size="lg" className="flex-1">
+                <Link to={`/customers/${customerId}`}>View customer</Link>
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `web-v2/src/pages/CheckoutSuccess.tsx` — minimal centered-card landing page for the Stripe-Checkout success redirect, matching the public-page chrome from `HostedInvoice` / `PublicCostDashboard` (no Layout, neutral background).
- Wires `/checkout/success` into `web-v2/src/main.tsx` next to other public routes (`/invoice/:token`, `/public/cost-dashboard/:token`).
- Page handles optional `?session_id=...` (rendered as monospace reference caption) and `?customer_id=...` (adds a "View customer" secondary CTA) — defensive since `.env.example` ships the URL without `{CHECKOUT_SESSION_ID}` today.

Closes #6.

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] `npx vite build` succeeds
- [ ] Manually visit `/checkout/success`, `/checkout/success?session_id=cs_test_123`, and `/checkout/success?customer_id=cus_abc` to verify rendering and CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)