### PR TITLE
fix(invoice): India reverse-charge PDF shows supplier GSTIN + correct legend (closes #9)

### DIFF
--- a/MANUAL_TEST.md
+++ b/MANUAL_TEST.md
@@ -399,6 +399,9 @@ Stripe-Tax-enabled path.
 - [ ] Customer with no country: normal 18% applies (can't prove export)
 - [ ] Export customer with `tax_exempt = true`: tax = $0, `tax_name = ""` (exempt overrides export annotation)
 - [ ] Clear `tax_home_country`: US customer now charged 18% (no home country → can't zero-rate)
+- [ ] India B2B reverse-charge invoice PDF shows supplier GSTIN in header (e.g. `GSTIN: 27AAEPM1234C1Z5`) under the company contact line
+- [ ] India reverse-charge legend reads "Tax payable on reverse charge basis: YES" (not the EU "VAT to be accounted for" wording)
+- [ ] EU reverse-charge invoice PDF retains EU wording ("Reverse charge — VAT to be accounted for by the recipient.")
 
 ## FLOW B12: Subscription activity timeline (T0-18)
 

--- a/internal/hostedinvoice/handler.go
+++ b/internal/hostedinvoice/handler.go
@@ -400,6 +400,8 @@ func (h *Handler) downloadPDF(w http.ResponseWriter, r *http.Request) {
 				PostalCode:   ts.CompanyPostalCode,
 				Country:      ts.CompanyCountry,
 				BrandColor:   ts.BrandColor,
+				TaxID:        ts.TaxID,
+				TaxIDType:    invoice.SupplierTaxIDTypeFromCountry(ts.CompanyCountry),
 			}
 		}
 	}

--- a/internal/invoice/handler.go
+++ b/internal/invoice/handler.go
@@ -553,6 +553,8 @@ func (h *Handler) sendEmail(w http.ResponseWriter, r *http.Request) {
 				PostalCode:   ts.CompanyPostalCode,
 				Country:      ts.CompanyCountry,
 				BrandColor:   ts.BrandColor,
+				TaxID:        ts.TaxID,
+				TaxIDType:    SupplierTaxIDTypeFromCountry(ts.CompanyCountry),
 			}
 		}
 	}
@@ -950,6 +952,8 @@ func (h *Handler) downloadPDF(w http.ResponseWriter, r *http.Request) {
 				PostalCode:   ts.CompanyPostalCode,
 				Country:      ts.CompanyCountry,
 				BrandColor:   ts.BrandColor,
+				TaxID:        ts.TaxID,
+				TaxIDType:    SupplierTaxIDTypeFromCountry(ts.CompanyCountry),
 			}
 		}
 	}

--- a/internal/invoice/pdf.go
+++ b/internal/invoice/pdf.go
@@ -28,6 +28,109 @@ type CompanyInfo struct {
 	// to the neutral palette — the exact palette existing PDFs used before
 	// this field was introduced.
 	BrandColor string
+	// TaxID is the SUPPLIER's tax identifier printed in the invoice header
+	// (GSTIN, EU VAT, ABN, etc.). Mandatory on Indian B2B invoices under
+	// Rule 46 of the CGST Rules; widely expected on EU/AU invoices too.
+	// Empty = no header line rendered (legacy behaviour preserved).
+	TaxID string
+	// TaxIDType is the canonical kind of TaxID: "gstin" / "in_gst" /
+	// "in_gstin" for India, "vat" / "eu_vat" for EU, "abn" / "au_abn" for
+	// Australia. Drives both the header label ("GSTIN: ..." vs "VAT: ...")
+	// and the reverse-charge legend wording. Unknown/empty values fall back
+	// to a generic "Tax ID:" label.
+	TaxIDType string
+}
+
+// SupplierTaxIDTypeFromCountry infers a TaxIDType from the supplier's
+// registered country when settings doesn't store the type explicitly. Used
+// by handlers that build CompanyInfo from TenantSettings (which currently
+// carries TaxID without a separate kind column). Returns the empty string
+// for countries we don't have an opinion on — the PDF then prints a
+// generic "Tax ID:" label rather than misrepresenting the scheme.
+//
+// Mapping is intentionally narrow: only India, Australia, and the EU/UK
+// have unambiguous single-scheme codes. Multi-scheme countries (US: EIN
+// vs SSN vs state IDs) require an explicit type from the operator and are
+// left unmapped here.
+func SupplierTaxIDTypeFromCountry(country string) string {
+	c := strings.ToUpper(strings.TrimSpace(country))
+	switch c {
+	case "IN", "INDIA":
+		return "gstin"
+	case "AU", "AUSTRALIA":
+		return "abn"
+	case "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR",
+		"DE", "GR", "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL",
+		"PL", "PT", "RO", "SK", "SI", "ES", "SE", "GB", "UK":
+		return "vat"
+	default:
+		return ""
+	}
+}
+
+// supplierTaxIDLabel maps a TaxIDType to the in-PDF label prefix. Unknown or
+// empty kinds fall back to a generic "Tax ID" so the value still appears on
+// the invoice without misrepresenting the scheme.
+func supplierTaxIDLabel(taxIDType string) string {
+	switch strings.ToLower(strings.TrimSpace(taxIDType)) {
+	case "gstin", "in_gst", "in_gstin":
+		return "GSTIN"
+	case "vat", "eu_vat":
+		return "VAT"
+	case "abn", "au_abn":
+		return "ABN"
+	default:
+		return "Tax ID"
+	}
+}
+
+// reverseChargeLegend resolves the statutory disclosure text for a
+// reverse-charge invoice. India GST (Rule 46(p), CGST §9(3)/9(4)) and EU
+// VAT (Art. 196 of the VAT Directive) carry materially different mandated
+// wording, so the legend branches on jurisdiction. Pure helper —
+// unit-testable without rendering a PDF.
+func reverseChargeLegend(inv domain.Invoice, supplier CompanyInfo, billTo BillToInfo, lineItems []domain.InvoiceLineItem) string {
+	indian := isIndianContext(supplier, billTo.Country) ||
+		lineItemsAreIndian(lineItems) ||
+		strings.EqualFold(strings.TrimSpace(inv.TaxCountry), "IN")
+	if indian {
+		return "Tax payable on reverse charge basis: YES — recipient is liable to pay GST under section 9(3)/9(4) of the CGST Act."
+	}
+	return "Reverse charge — VAT to be accounted for by the recipient."
+}
+
+// lineItemsAreIndian reports whether any line item carries an Indian
+// tax jurisdiction code. The tax engine stamps line-item TaxJurisdiction
+// like "IN-MH" (state-coded) or "IN" — used as a fallback signal when
+// neither supplier nor billing-country tells us the legend should be
+// India-flavoured.
+func lineItemsAreIndian(lineItems []domain.InvoiceLineItem) bool {
+	for _, li := range lineItems {
+		j := strings.ToUpper(strings.TrimSpace(li.TaxJurisdiction))
+		if j == "IN" || strings.HasPrefix(j, "IN-") {
+			return true
+		}
+	}
+	return false
+}
+
+// isIndianContext returns true when the invoice is plausibly an Indian tax
+// invoice — supplier registered in India, supplier carrying a GSTIN, or
+// recipient billed to India. Drives the reverse-charge legend wording so
+// Indian invoices use GST terminology and EU/other invoices keep the VAT
+// Directive language they had before.
+func isIndianContext(company CompanyInfo, customerCountry string) bool {
+	if strings.EqualFold(company.Country, "IN") || strings.EqualFold(company.Country, "India") {
+		return true
+	}
+	t := strings.ToLower(strings.TrimSpace(company.TaxIDType))
+	if t == "gstin" || t == "in_gst" || t == "in_gstin" {
+		return true
+	}
+	if strings.EqualFold(customerCountry, "IN") || strings.EqualFold(customerCountry, "India") {
+		return true
+	}
+	return false
 }
 
 // parseBrandColor converts a #rrggbb string to RGB. Returns ok=false for
@@ -213,6 +316,17 @@ func RenderPDF(inv domain.Invoice, lineItems []domain.InvoiceLineItem, billTo Bi
 		setFont(false, 8)
 		setColor(120, 120, 120)
 		textAt(margin, y, companyContact)
+		y += 11
+	}
+
+	// Supplier tax ID line. Mandatory header field on Indian B2B invoices
+	// (Rule 46, CGST Rules) and widely expected on EU/AU invoices too.
+	// Rendered in the same muted style as contact info so it reads as
+	// header metadata, not a primary visual element.
+	if len(company) > 0 && strings.TrimSpace(company[0].TaxID) != "" {
+		setFont(false, 8)
+		setColor(120, 120, 120)
+		textAt(margin, y, supplierTaxIDLabel(company[0].TaxIDType)+": "+company[0].TaxID)
 		y += 11
 	}
 
@@ -508,7 +622,11 @@ func RenderPDF(inv domain.Invoice, lineItems []domain.InvoiceLineItem, billTo Bi
 		setFont(true, 8)
 		setColor(80, 80, 80)
 		if inv.TaxReverseCharge {
-			textAt(margin, y, "Reverse charge — VAT to be accounted for by the recipient.")
+			var supplier CompanyInfo
+			if len(company) > 0 {
+				supplier = company[0]
+			}
+			textAt(margin, y, reverseChargeLegend(inv, supplier, billTo, lineItems))
 			y += 12
 		}
 		if inv.TaxExemptReason != "" {

--- a/internal/invoice/pdf_test.go
+++ b/internal/invoice/pdf_test.go
@@ -1,6 +1,7 @@
 package invoice
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +84,253 @@ func TestRenderPDF(t *testing.T) {
 	}
 
 	t.Logf("PDF generated: %d bytes", len(pdfBytes))
+}
+
+// minimalReverseChargeInvoice returns a finalized reverse-charge invoice
+// suitable for legend / PDF tests. No tax amount, no positive subtotal —
+// the legend branches don't depend on those.
+func minimalReverseChargeInvoice() domain.Invoice {
+	now := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	due := now.AddDate(0, 0, 30)
+	periodStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	return domain.Invoice{
+		ID:                 "vlx_inv_rc",
+		InvoiceNumber:      "VLX-202604-0099",
+		Status:             domain.InvoiceFinalized,
+		PaymentStatus:      domain.PaymentPending,
+		Currency:           "INR",
+		SubtotalCents:      19900,
+		TotalAmountCents:   19900,
+		AmountDueCents:     19900,
+		BillingPeriodStart: periodStart,
+		BillingPeriodEnd:   periodEnd,
+		IssuedAt:           &now,
+		DueAt:              &due,
+		NetPaymentTermDays: 30,
+		TaxReverseCharge:   true,
+	}
+}
+
+// TestRenderPDF_IndiaSupplierGSTIN verifies the PDF render call accepts the
+// new TaxID/TaxIDType fields and produces a valid PDF with a reasonable size
+// bump from the extra header line. gopdf compresses content streams and
+// uses subset-font glyph IDs, so we cannot byte-substring the rendered text;
+// the GSTIN-line presence is validated by the helper-level tests below
+// (TestSupplierTaxIDLabel, TestRenderPDF_IndiaSupplierGSTIN_HelperPath).
+//
+// MANUAL: Visually verify "GSTIN: 27AAEPM1234C1Z5" appears under the company
+// contact info in the rendered PDF (see MANUAL_TEST.md, FLOW B10).
+func TestRenderPDF_IndiaSupplierGSTIN(t *testing.T) {
+	inv := minimalReverseChargeInvoice()
+	company := CompanyInfo{
+		Name:      "Velox India Pvt Ltd",
+		Country:   "IN",
+		TaxID:     "27AAEPM1234C1Z5",
+		TaxIDType: "gstin",
+	}
+	out, err := RenderPDF(inv, nil, BillToInfo{Name: "Acme Corp"}, nil, company)
+	if err != nil {
+		t.Fatalf("render pdf: %v", err)
+	}
+	if len(out) < 4 || string(out[:4]) != "%PDF" {
+		t.Fatal("output is not a valid PDF")
+	}
+
+	// Helper-path assertion: the supplier label resolves to "GSTIN" for the
+	// declared TaxIDType. This is what would be drawn into the PDF stream.
+	if got := supplierTaxIDLabel(company.TaxIDType); got != "GSTIN" {
+		t.Errorf("supplierTaxIDLabel(%q) = %q, want GSTIN", company.TaxIDType, got)
+	}
+}
+
+// TestRenderPDF_IndiaReverseChargeLegend verifies the India context resolves
+// to the GST-flavoured legend, not the EU "VAT to be accounted for" wording.
+func TestRenderPDF_IndiaReverseChargeLegend(t *testing.T) {
+	inv := minimalReverseChargeInvoice()
+	company := CompanyInfo{
+		Name:      "Velox India Pvt Ltd",
+		Country:   "IN",
+		TaxID:     "27AAEPM1234C1Z5",
+		TaxIDType: "gstin",
+	}
+	billTo := BillToInfo{Name: "Acme India Ltd", Country: "IN"}
+
+	got := reverseChargeLegend(inv, company, billTo, nil)
+	if !strings.Contains(got, "Tax payable on reverse charge basis: YES") {
+		t.Errorf("legend = %q, want it to contain India GST wording", got)
+	}
+	if strings.Contains(got, "VAT to be accounted for") {
+		t.Errorf("legend = %q, must not contain EU VAT wording", got)
+	}
+
+	// And the PDF still renders without error end-to-end.
+	out, err := RenderPDF(inv, nil, billTo, nil, company)
+	if err != nil {
+		t.Fatalf("render pdf: %v", err)
+	}
+	if len(out) < 4 || string(out[:4]) != "%PDF" {
+		t.Fatal("output is not a valid PDF")
+	}
+}
+
+// TestRenderPDF_EUReverseChargeLegend_Unchanged verifies a non-Indian
+// supplier (e.g. DE, EU VAT) keeps the existing EU legend wording — the fix
+// must not regress EU invoices.
+func TestRenderPDF_EUReverseChargeLegend_Unchanged(t *testing.T) {
+	inv := minimalReverseChargeInvoice()
+	inv.Currency = "EUR"
+	company := CompanyInfo{
+		Name:      "Velox GmbH",
+		Country:   "DE",
+		TaxID:     "DE123456789",
+		TaxIDType: "vat",
+	}
+	billTo := BillToInfo{Name: "Acme GmbH", Country: "FR"}
+
+	got := reverseChargeLegend(inv, company, billTo, nil)
+	if !strings.Contains(got, "VAT to be accounted for by the recipient") {
+		t.Errorf("legend = %q, want EU VAT wording preserved", got)
+	}
+	if strings.Contains(got, "GST") || strings.Contains(got, "CGST") {
+		t.Errorf("legend = %q, must not contain India GST wording for EU invoices", got)
+	}
+
+	out, err := RenderPDF(inv, nil, billTo, nil, company)
+	if err != nil {
+		t.Fatalf("render pdf: %v", err)
+	}
+	if len(out) < 4 || string(out[:4]) != "%PDF" {
+		t.Fatal("output is not a valid PDF")
+	}
+}
+
+// TestRenderPDF_NoTaxID_NoGSTINLine verifies that an empty TaxID does not
+// trigger the supplier-tax-ID header line — backward compatibility for
+// tenants who haven't set a tax ID yet.
+//
+// gopdf compresses streams, so we can't byte-search; instead we render two
+// PDFs with the only difference being TaxID populated, and assert the
+// no-tax-ID render is strictly smaller (= header line was suppressed).
+func TestRenderPDF_NoTaxID_NoGSTINLine(t *testing.T) {
+	inv := minimalReverseChargeInvoice()
+	base := CompanyInfo{Name: "Velox India Pvt Ltd", Country: "IN"}
+	withGSTIN := base
+	withGSTIN.TaxID = "27AAEPM1234C1Z5"
+	withGSTIN.TaxIDType = "gstin"
+
+	billTo := BillToInfo{Name: "Acme India Ltd", Country: "IN"}
+
+	outNo, err := RenderPDF(inv, nil, billTo, nil, base)
+	if err != nil {
+		t.Fatalf("render pdf no tax id: %v", err)
+	}
+	outYes, err := RenderPDF(inv, nil, billTo, nil, withGSTIN)
+	if err != nil {
+		t.Fatalf("render pdf with tax id: %v", err)
+	}
+
+	if len(outNo) >= len(outYes) {
+		t.Errorf("expected PDF without GSTIN to be smaller than PDF with GSTIN; got no=%d yes=%d", len(outNo), len(outYes))
+	}
+	if len(outNo) < 4 || string(outNo[:4]) != "%PDF" {
+		t.Fatal("no-tax-id output is not a valid PDF")
+	}
+}
+
+// TestSupplierTaxIDLabel covers the label-prefix mapping for the in-PDF
+// "GSTIN: ..." / "VAT: ..." / "ABN: ..." / "Tax ID: ..." rendering.
+func TestSupplierTaxIDLabel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"gstin", "GSTIN"},
+		{"in_gst", "GSTIN"},
+		{"in_gstin", "GSTIN"},
+		{"GSTIN", "GSTIN"}, // case-insensitive
+		{"vat", "VAT"},
+		{"eu_vat", "VAT"},
+		{"abn", "ABN"},
+		{"au_abn", "ABN"},
+		{"", "Tax ID"},
+		{"us_ein", "Tax ID"},
+		{"  gstin  ", "GSTIN"}, // trims whitespace
+	}
+	for _, c := range cases {
+		if got := supplierTaxIDLabel(c.in); got != c.want {
+			t.Errorf("supplierTaxIDLabel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestIsIndianContext covers each branch of the India-context detector that
+// drives reverse-charge legend selection.
+func TestIsIndianContext(t *testing.T) {
+	cases := []struct {
+		name     string
+		company  CompanyInfo
+		custCtry string
+		want     bool
+	}{
+		{"supplier IN", CompanyInfo{Country: "IN"}, "US", true},
+		{"supplier India long form", CompanyInfo{Country: "India"}, "", true},
+		{"supplier GSTIN type", CompanyInfo{TaxIDType: "gstin"}, "", true},
+		{"supplier in_gst type", CompanyInfo{TaxIDType: "in_gst"}, "", true},
+		{"supplier in_gstin type", CompanyInfo{TaxIDType: "in_gstin"}, "", true},
+		{"customer IN", CompanyInfo{Country: "DE"}, "IN", true},
+		{"customer India long form", CompanyInfo{}, "India", true},
+		{"EU supplier + EU customer", CompanyInfo{Country: "DE", TaxIDType: "vat"}, "FR", false},
+		{"US supplier + US customer", CompanyInfo{Country: "US"}, "US", false},
+		{"empty", CompanyInfo{}, "", false},
+	}
+	for _, c := range cases {
+		if got := isIndianContext(c.company, c.custCtry); got != c.want {
+			t.Errorf("%s: isIndianContext = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestReverseChargeLegend_TaxJurisdictionFallback confirms the legend
+// branches on a per-line-item Indian TaxJurisdiction (e.g. "IN-MH") even
+// when neither supplier nor billing country signals India.
+func TestReverseChargeLegend_TaxJurisdictionFallback(t *testing.T) {
+	inv := minimalReverseChargeInvoice()
+	supplier := CompanyInfo{Name: "Velox", Country: "US"}
+	billTo := BillToInfo{Name: "Acme", Country: "US"}
+	lineItems := []domain.InvoiceLineItem{
+		{TaxJurisdiction: "IN-MH"},
+	}
+	got := reverseChargeLegend(inv, supplier, billTo, lineItems)
+	if !strings.Contains(got, "Tax payable on reverse charge basis: YES") {
+		t.Errorf("expected India legend via line-item jurisdiction; got %q", got)
+	}
+}
+
+// TestSupplierTaxIDTypeFromCountry covers the country→type inference used
+// by handlers that build CompanyInfo from TenantSettings.
+func TestSupplierTaxIDTypeFromCountry(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"IN", "gstin"},
+		{"in", "gstin"},
+		{"India", "gstin"},
+		{"AU", "abn"},
+		{"DE", "vat"},
+		{"FR", "vat"},
+		{"GB", "vat"},
+		{"UK", "vat"},
+		{"US", ""},
+		{"", ""},
+		{" IN ", "gstin"},
+	}
+	for _, c := range cases {
+		if got := SupplierTaxIDTypeFromCountry(c.in); got != c.want {
+			t.Errorf("SupplierTaxIDTypeFromCountry(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
 }
 
 func TestParseBrandColor(t *testing.T) {

--- a/internal/portalapi/handler.go
+++ b/internal/portalapi/handler.go
@@ -253,6 +253,8 @@ func (h *Handler) downloadInvoicePDF(w http.ResponseWriter, r *http.Request) {
 				PostalCode:   ts.CompanyPostalCode,
 				Country:      ts.CompanyCountry,
 				BrandColor:   ts.BrandColor,
+				TaxID:        ts.TaxID,
+				TaxIDType:    invoice.SupplierTaxIDTypeFromCountry(ts.CompanyCountry),
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds `TaxID` + `TaxIDType` fields to `CompanyInfo` and renders a supplier tax-ID line in the invoice PDF header (`GSTIN: 27AAEPM1234C1Z5`, `VAT: ...`, `ABN: ...`, or generic `Tax ID:`). Mandatory under **Rule 46 of the CGST Rules** for Indian B2B invoices.
- Branches the reverse-charge legend on jurisdiction:
  - **India context** (supplier in IN, supplier carrying GSTIN, customer billed to IN, line-item `TaxJurisdiction` like `IN-MH`, or `inv.TaxCountry == IN`): "Tax payable on reverse charge basis: YES — recipient is liable to pay GST under section 9(3)/9(4) of the CGST Act."
  - **EU / default**: keeps the existing "Reverse charge — VAT to be accounted for by the recipient." wording — no regression for EU invoices.
- Wires `TaxID` + `TaxIDType` (inferred from `CompanyCountry` via a small `SupplierTaxIDTypeFromCountry` helper) at the three PDF call sites: `internal/invoice/handler.go`, `internal/portalapi/handler.go`, `internal/hostedinvoice/handler.go`.

Out of scope (per issue scope): HSN/SAC codes, Place of supply, CGST/SGST/IGST split, taxability_reason consumption — separate issues.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/invoice/... -short` passes (8 new tests cover the helpers, India/EU legend branching, and the GSTIN header line)
- [x] `go test ./... -short` — all packages green
- [ ] Manual: render an India B2B reverse-charge invoice PDF and visually confirm the GSTIN header line + new legend (FLOW B10 in MANUAL_TEST.md, updated)
- [ ] Manual: render an EU reverse-charge invoice PDF and confirm legend is unchanged

Closes #9.

Generated with Claude Code.