### PR TITLE
feat(tax): Stripe-canonical tax_id_type codes (closes #11)

### DIFF
--- a/MANUAL_TEST.md
+++ b/MANUAL_TEST.md
@@ -523,15 +523,19 @@ preview before commit. Driven by `/admin/plan_migrations`.
 ## FLOW B11: Tax-ID format validation
 
 `UpsertBillingProfile` normalizes (trim + uppercase) and format-validates `tax_id`
-against `tax_id_type`. Known kinds: GSTIN, EU VAT, AU ABN. Unknown kinds pass through.
+against `tax_id_type`. Storage uses Stripe-canonical codes (`in_gst`, `eu_vat`,
+`au_abn`); legacy Velox shorthand (`gstin`, `vat`, `abn`) is still accepted on
+input and normalized to the canonical code before write. Unknown kinds pass through.
 
-- [ ] `gstin` + `27aaepm1234c1z5` → saved as `27AAEPM1234C1Z5`
-- [ ] `in_gst` / `in_gstin` aliases accepted
-- [ ] `vat` + `DE123456789` → accepted
-- [ ] `abn` + `51824753556` → accepted
-- [ ] Malformed: `gstin` + `27INVALID` → 422 `"invalid GSTIN format: expected 15-char code like 27AAEPM1234C1Z5"`
-- [ ] Malformed: `vat` + `12` → 422 `"invalid EU VAT format"`
-- [ ] Malformed: `abn` + `123` → 422 `"invalid ABN format: expected 11 digits"`
+- [ ] `in_gst` + `27AAEPM1234C1Z5` → saved as `27AAEPM1234C1Z5`, `tax_id_type` stored as `in_gst`
+- [ ] Legacy `gstin` input → normalized to `in_gst` on write (backend `NormalizeTaxIDType`)
+- [ ] `eu_vat` + `DE123456789` → accepted
+- [ ] `au_abn` + `51824753556` → accepted
+- [ ] Unknown Stripe code (`za_vat` + any value) → accepted as-is
+- [ ] Customer detail → Edit billing profile: `tax_id_type` Combobox shows alphabetized list of Stripe codes with country-code badges, searchable by code or label
+- [ ] Malformed: `in_gst` + `27INVALID` → 422 `"invalid GSTIN format: expected 15-char code like 27AAEPM1234C1Z5"`
+- [ ] Malformed: `eu_vat` + `12` → 422 `"invalid EU VAT format"`
+- [ ] Malformed: `au_abn` + `123` → 422 `"invalid ABN format: expected 11 digits"`
 - [ ] Unknown kind: `br_cnpj` + `12.345.678/0001-90` → accepted as-is
 - [ ] Empty `tax_id` → always accepted regardless of kind
 

--- a/internal/customer/service.go
+++ b/internal/customer/service.go
@@ -162,6 +162,9 @@ func (s *Service) UpsertBillingProfile(ctx context.Context, tenantID string, bp 
 	}
 	// Normalize + format-validate tax IDs. Unknown kinds pass through untouched
 	// so we don't reject jurisdictions we haven't added explicit support for.
+	// Type is normalized to its canonical Stripe code so storage stays
+	// consistent regardless of which alias the caller supplied.
+	bp.TaxIDType = tax.NormalizeTaxIDType(bp.TaxIDType)
 	bp.TaxID = tax.NormalizeTaxID(bp.TaxID)
 	if err := tax.ValidateTaxID(bp.TaxIDType, bp.TaxID); err != nil {
 		return domain.CustomerBillingProfile{}, errs.Invalid("tax_id", err.Error())

--- a/internal/tax/taxid.go
+++ b/internal/tax/taxid.go
@@ -6,13 +6,15 @@ import (
 	"strings"
 )
 
-// TaxIDKind is the canonical identifier for a tax-ID scheme. Kept as strings
-// rather than constants so unknown schemes pass through without rejection —
-// validation runs only when we know the format.
+// Tax-ID kind canonical codes. We use Stripe's documented codes as primary
+// (see https://stripe.com/docs/api/customer_tax_ids/object) so operators see
+// the same identifiers in Stripe webhooks, the Stripe Dashboard, and Velox.
+// Velox shorthand (gstin/vat/abn) is still accepted on input — see
+// NormalizeTaxIDType — so existing data continues to work without a backfill.
 const (
-	TaxIDKindGSTIN = "gstin" // India Goods & Services Tax Identification Number
-	TaxIDKindVAT   = "vat"   // European Union VAT identification number (format-only)
-	TaxIDKindABN   = "abn"   // Australian Business Number (format-only)
+	TaxIDKindINGST = "in_gst" // India GSTIN — Stripe canonical
+	TaxIDKindEUVAT = "eu_vat" // EU VAT — Stripe canonical
+	TaxIDKindAUABN = "au_abn" // Australia ABN — Stripe canonical
 )
 
 // gstinPattern matches the Indian GSTIN format:
@@ -36,11 +38,34 @@ var euVATPattern = regexp.MustCompile(`^[A-Z]{2}[A-Z0-9]{2,12}$`)
 // australianABNPattern: 11 digits.
 var australianABNPattern = regexp.MustCompile(`^[0-9]{11}$`)
 
+// NormalizeTaxIDType maps any accepted alias for a tax-ID kind to its
+// canonical Stripe code so storage stays consistent. Unknown kinds pass
+// through untouched (lowercased + trimmed) — Velox doesn't reject
+// jurisdictions it hasn't added explicit format support for. Empty input
+// returns empty.
+func NormalizeTaxIDType(kind string) string {
+	k := strings.ToLower(strings.TrimSpace(kind))
+	switch k {
+	case "gstin", "in_gstin", TaxIDKindINGST:
+		return TaxIDKindINGST
+	case "vat", TaxIDKindEUVAT:
+		return TaxIDKindEUVAT
+	case "abn", TaxIDKindAUABN:
+		return TaxIDKindAUABN
+	}
+	return k
+}
+
 // ValidateTaxID checks that a tax ID conforms to the format for its declared
 // kind. Returns nil for unknown kinds (pass-through) so we don't reject tax
 // IDs from jurisdictions we haven't added explicit support for. An empty
 // value is always valid — callers should check presence separately if the
 // field is required.
+//
+// Both the canonical Stripe code (in_gst, eu_vat, au_abn) and the legacy
+// Velox shorthand (gstin, vat, abn) are accepted as input so previously
+// stored data still validates after the canonical-rename. New writes
+// normalize to the Stripe code via NormalizeTaxIDType before persistence.
 //
 // Kind matching is case-insensitive on the key; the value itself is
 // normalized (uppercased, whitespace trimmed) before format validation.
@@ -50,15 +75,15 @@ func ValidateTaxID(kind, value string) error {
 		return nil
 	}
 	switch strings.ToLower(strings.TrimSpace(kind)) {
-	case TaxIDKindGSTIN, "in_gst", "in_gstin":
+	case TaxIDKindINGST, "gstin", "in_gstin":
 		if !gstinPattern.MatchString(value) {
 			return fmt.Errorf("invalid GSTIN format: expected 15-char code like 27AAEPM1234C1Z5")
 		}
-	case TaxIDKindVAT, "eu_vat":
+	case TaxIDKindEUVAT, "vat":
 		if !euVATPattern.MatchString(value) {
 			return fmt.Errorf("invalid EU VAT format: expected 2-letter country prefix + alphanumerics")
 		}
-	case TaxIDKindABN, "au_abn":
+	case TaxIDKindAUABN, "abn":
 		if !australianABNPattern.MatchString(value) {
 			return fmt.Errorf("invalid ABN format: expected 11 digits")
 		}

--- a/internal/tax/taxid_test.go
+++ b/internal/tax/taxid_test.go
@@ -26,13 +26,14 @@ func TestValidateTaxID_GSTIN(t *testing.T) {
 		"09AAACH7409R1ZZ",
 	}
 	for _, v := range valid {
-		if err := ValidateTaxID("gstin", v); err != nil {
-			t.Errorf("ValidateTaxID(gstin, %q) unexpected error: %v", v, err)
+		// Stripe-canonical kind is the primary form.
+		if err := ValidateTaxID("in_gst", v); err != nil {
+			t.Errorf("ValidateTaxID(in_gst, %q) unexpected error: %v", v, err)
 		}
 	}
-	// Alternate kind aliases must also work.
-	if err := ValidateTaxID("in_gst", "27AAEPM1234C1Z5"); err != nil {
-		t.Errorf("in_gst alias rejected: %v", err)
+	// Legacy Velox shorthand and the in_gstin alias must still validate.
+	if err := ValidateTaxID("gstin", "27AAEPM1234C1Z5"); err != nil {
+		t.Errorf("legacy gstin alias rejected: %v", err)
 	}
 	if err := ValidateTaxID("IN_GSTIN", "27AAEPM1234C1Z5"); err != nil {
 		t.Errorf("IN_GSTIN alias rejected: %v", err)
@@ -46,13 +47,13 @@ func TestValidateTaxID_GSTIN(t *testing.T) {
 		"AAEPM12345C1Z5",   // state code not numeric
 	}
 	for _, v := range invalid {
-		if err := ValidateTaxID("gstin", v); err == nil {
-			t.Errorf("ValidateTaxID(gstin, %q) expected error, got nil", v)
+		if err := ValidateTaxID("in_gst", v); err == nil {
+			t.Errorf("ValidateTaxID(in_gst, %q) expected error, got nil", v)
 		}
 	}
 
 	// Lowercase input should be normalized and accepted (validator is case-insensitive).
-	if err := ValidateTaxID("gstin", "27aaepm1234c1z5"); err != nil {
+	if err := ValidateTaxID("in_gst", "27aaepm1234c1z5"); err != nil {
 		t.Errorf("lowercase GSTIN should normalize and pass: %v", err)
 	}
 }
@@ -60,39 +61,41 @@ func TestValidateTaxID_GSTIN(t *testing.T) {
 func TestValidateTaxID_VAT(t *testing.T) {
 	valid := []string{"DE123456789", "FRAB123456789", "GB123456789"}
 	for _, v := range valid {
-		if err := ValidateTaxID("vat", v); err != nil {
-			t.Errorf("ValidateTaxID(vat, %q) unexpected error: %v", v, err)
+		if err := ValidateTaxID("eu_vat", v); err != nil {
+			t.Errorf("ValidateTaxID(eu_vat, %q) unexpected error: %v", v, err)
 		}
 	}
-	if err := ValidateTaxID("eu_vat", "DE123456789"); err != nil {
-		t.Errorf("eu_vat alias rejected: %v", err)
+	// Legacy Velox shorthand still validates.
+	if err := ValidateTaxID("vat", "DE123456789"); err != nil {
+		t.Errorf("legacy vat alias rejected: %v", err)
 	}
 
 	invalid := []string{"D1", "123456789", "DEABCDEFGHIJKLM"} // too short prefix, no prefix, too long
 	for _, v := range invalid {
-		if err := ValidateTaxID("vat", v); err == nil {
-			t.Errorf("ValidateTaxID(vat, %q) expected error, got nil", v)
+		if err := ValidateTaxID("eu_vat", v); err == nil {
+			t.Errorf("ValidateTaxID(eu_vat, %q) expected error, got nil", v)
 		}
 	}
 }
 
 func TestValidateTaxID_ABN(t *testing.T) {
-	if err := ValidateTaxID("abn", "51824753556"); err != nil {
+	if err := ValidateTaxID("au_abn", "51824753556"); err != nil {
 		t.Errorf("valid ABN rejected: %v", err)
 	}
-	if err := ValidateTaxID("au_abn", "51824753556"); err != nil {
-		t.Errorf("au_abn alias rejected: %v", err)
+	// Legacy Velox shorthand still validates.
+	if err := ValidateTaxID("abn", "51824753556"); err != nil {
+		t.Errorf("legacy abn alias rejected: %v", err)
 	}
-	if err := ValidateTaxID("abn", "51824753"); err == nil {
+	if err := ValidateTaxID("au_abn", "51824753"); err == nil {
 		t.Error("short ABN should be rejected")
 	}
-	if err := ValidateTaxID("abn", "5182475355A"); err == nil {
+	if err := ValidateTaxID("au_abn", "5182475355A"); err == nil {
 		t.Error("ABN with letters should be rejected")
 	}
 }
 
 func TestValidateTaxID_EmptyValuePasses(t *testing.T) {
-	if err := ValidateTaxID("gstin", ""); err != nil {
+	if err := ValidateTaxID("in_gst", ""); err != nil {
 		t.Errorf("empty value should pass: %v", err)
 	}
 	if err := ValidateTaxID("", ""); err != nil {
@@ -101,11 +104,61 @@ func TestValidateTaxID_EmptyValuePasses(t *testing.T) {
 }
 
 func TestValidateTaxID_UnknownKindPassesThrough(t *testing.T) {
-	// Jurisdictions without explicit support must not be rejected.
+	// Jurisdictions without explicit support must not be rejected — Velox
+	// stores the type as-is and lets Stripe / downstream tax engines apply
+	// any format rules.
 	if err := ValidateTaxID("br_cnpj", "12.345.678/0001-90"); err != nil {
 		t.Errorf("unknown kind should pass through: %v", err)
 	}
 	if err := ValidateTaxID("sg_uen", "anything"); err != nil {
 		t.Errorf("unknown kind should pass through: %v", err)
+	}
+}
+
+func TestNormalizeTaxIDType_VeloxShorthandToCanonical(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"gstin", "in_gst"},
+		{"GSTIN", "in_gst"},
+		{"in_gstin", "in_gst"},
+		{"in_gst", "in_gst"},
+		{"vat", "eu_vat"},
+		{"VAT", "eu_vat"},
+		{"eu_vat", "eu_vat"},
+		{"abn", "au_abn"},
+		{"ABN", "au_abn"},
+		{"au_abn", "au_abn"},
+		// Pass-through: any other Stripe code lands as-is (lowercased).
+		{"unknown_kind", "unknown_kind"},
+		{"za_vat", "za_vat"},
+		{"  us_ein  ", "us_ein"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := NormalizeTaxIDType(tc.in); got != tc.want {
+			t.Errorf("NormalizeTaxIDType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestValidateTaxID_AcceptsBothFormats(t *testing.T) {
+	// Same value must validate identically under canonical Stripe codes
+	// and legacy Velox shorthand — required so old data continues to work
+	// without a backfill.
+	pairs := []struct {
+		canonical, legacy, value string
+	}{
+		{"in_gst", "gstin", "27AAEPM1234C1Z5"},
+		{"eu_vat", "vat", "DE123456789"},
+		{"au_abn", "abn", "51824753556"},
+	}
+	for _, p := range pairs {
+		errCanonical := ValidateTaxID(p.canonical, p.value)
+		errLegacy := ValidateTaxID(p.legacy, p.value)
+		if (errCanonical == nil) != (errLegacy == nil) {
+			t.Errorf("ValidateTaxID disagrees for %q: canonical(%q)=%v, legacy(%q)=%v",
+				p.value, p.canonical, errCanonical, p.legacy, errLegacy)
+		}
 	}
 }

--- a/web-v2/src/lib/taxIdTypes.ts
+++ b/web-v2/src/lib/taxIdTypes.ts
@@ -1,0 +1,99 @@
+// Stripe-canonical tax_id_type codes. Source of truth:
+// https://stripe.com/docs/api/customer_tax_ids/object#tax_id_object-type
+//
+// Velox stores `tax_id_type` in this exact form (the backend's
+// NormalizeTaxIDType folds legacy Velox shorthand — gstin/vat/abn — to the
+// canonical Stripe code on write). The dashboard always writes canonical;
+// legacy values read back from older rows are pinned at the top of the
+// dropdown with a "Legacy" annotation so existing data isn't lost.
+
+export interface TaxIdTypeOption {
+  value: string
+  label: string
+  country: string
+}
+
+export const STRIPE_TAX_ID_TYPES: ReadonlyArray<TaxIdTypeOption> = [
+  { value: 'ad_nrt', label: 'Andorra NRT', country: 'AD' },
+  { value: 'ae_trn', label: 'UAE TRN', country: 'AE' },
+  { value: 'ar_cuit', label: 'Argentina CUIT', country: 'AR' },
+  { value: 'au_abn', label: 'Australia ABN', country: 'AU' },
+  { value: 'au_arn', label: 'Australia ARN', country: 'AU' },
+  { value: 'br_cnpj', label: 'Brazil CNPJ', country: 'BR' },
+  { value: 'br_cpf', label: 'Brazil CPF', country: 'BR' },
+  { value: 'ca_bn', label: 'Canada BN', country: 'CA' },
+  { value: 'ca_gst_hst', label: 'Canada GST/HST', country: 'CA' },
+  { value: 'ca_pst_bc', label: 'Canada PST British Columbia', country: 'CA' },
+  { value: 'ca_pst_mb', label: 'Canada PST Manitoba', country: 'CA' },
+  { value: 'ca_pst_sk', label: 'Canada PST Saskatchewan', country: 'CA' },
+  { value: 'ca_qst', label: 'Canada QST Quebec', country: 'CA' },
+  { value: 'ch_vat', label: 'Switzerland VAT', country: 'CH' },
+  { value: 'cl_tin', label: 'Chile TIN', country: 'CL' },
+  { value: 'co_nit', label: 'Colombia NIT', country: 'CO' },
+  { value: 'eg_tin', label: 'Egypt TIN', country: 'EG' },
+  { value: 'es_cif', label: 'Spain CIF', country: 'ES' },
+  { value: 'eu_oss_vat', label: 'EU OSS VAT', country: 'EU' },
+  { value: 'eu_vat', label: 'EU VAT', country: 'EU' },
+  { value: 'gb_vat', label: 'United Kingdom VAT', country: 'GB' },
+  { value: 'hk_br', label: 'Hong Kong BR', country: 'HK' },
+  { value: 'hu_tin', label: 'Hungary TIN', country: 'HU' },
+  { value: 'id_npwp', label: 'Indonesia NPWP', country: 'ID' },
+  { value: 'il_vat', label: 'Israel VAT', country: 'IL' },
+  { value: 'in_gst', label: 'India GSTIN', country: 'IN' },
+  { value: 'is_vat', label: 'Iceland VAT', country: 'IS' },
+  { value: 'jp_cn', label: 'Japan CN', country: 'JP' },
+  { value: 'jp_rn', label: 'Japan RN', country: 'JP' },
+  { value: 'jp_trn', label: 'Japan TRN', country: 'JP' },
+  { value: 'kr_brn', label: 'South Korea BRN', country: 'KR' },
+  { value: 'li_uid', label: 'Liechtenstein UID', country: 'LI' },
+  { value: 'mx_rfc', label: 'Mexico RFC', country: 'MX' },
+  { value: 'my_frp', label: 'Malaysia FRP', country: 'MY' },
+  { value: 'my_itn', label: 'Malaysia ITN', country: 'MY' },
+  { value: 'my_sst', label: 'Malaysia SST', country: 'MY' },
+  { value: 'no_vat', label: 'Norway VAT', country: 'NO' },
+  { value: 'nz_gst', label: 'New Zealand GST', country: 'NZ' },
+  { value: 'ph_tin', label: 'Philippines TIN', country: 'PH' },
+  { value: 'ru_inn', label: 'Russia INN', country: 'RU' },
+  { value: 'ru_kpp', label: 'Russia KPP', country: 'RU' },
+  { value: 'sa_vat', label: 'Saudi Arabia VAT', country: 'SA' },
+  { value: 'sg_gst', label: 'Singapore GST', country: 'SG' },
+  { value: 'sg_uen', label: 'Singapore UEN', country: 'SG' },
+  { value: 'si_tin', label: 'Slovenia TIN', country: 'SI' },
+  { value: 'th_vat', label: 'Thailand VAT', country: 'TH' },
+  { value: 'tr_tin', label: 'Turkey TIN', country: 'TR' },
+  { value: 'tw_vat', label: 'Taiwan VAT', country: 'TW' },
+  { value: 'ua_vat', label: 'Ukraine VAT', country: 'UA' },
+  { value: 'us_ein', label: 'United States EIN', country: 'US' },
+  { value: 'za_vat', label: 'South Africa VAT', country: 'ZA' },
+] as const
+
+export type StripeTaxIdType = typeof STRIPE_TAX_ID_TYPES[number]['value']
+
+// Hint text printed under the tax-ID input for the codes Velox knows how to
+// format-validate. Other codes pass through silently — Stripe / downstream
+// tax engines apply any format rules.
+export const TAX_ID_HINTS: Record<string, string> = {
+  in_gst: 'e.g. 27AAEPM1234C1Z5 (15-char India GSTIN)',
+  eu_vat: 'e.g. DE123456789 — 2-letter country prefix + alphanumerics',
+  gb_vat: 'e.g. GB123456789',
+  au_abn: 'e.g. 51824753556 — 11 digits',
+  us_ein: 'e.g. 12-3456789',
+}
+
+const CANONICAL_VALUES = new Set<string>(STRIPE_TAX_ID_TYPES.map(t => t.value))
+
+// Builds the option list for the tax_id_type dropdown. If `currentValue` is a
+// non-canonical legacy code (e.g. "gstin" left over from a row written before
+// the Stripe-canonical migration), pin a "Legacy" option at the top so the
+// existing value renders. Once the user re-saves, the backend normalizes it
+// to the canonical Stripe code via NormalizeTaxIDType.
+export function taxIdTypeOptions(currentValue: string): TaxIdTypeOption[] {
+  const sorted = [...STRIPE_TAX_ID_TYPES].sort((a, b) => a.label.localeCompare(b.label))
+  if (currentValue && !CANONICAL_VALUES.has(currentValue)) {
+    return [
+      { value: currentValue, label: `${currentValue} (Legacy)`, country: '' },
+      ...sorted,
+    ]
+  }
+  return sorted
+}

--- a/web-v2/src/pages/CustomerDetail.tsx
+++ b/web-v2/src/pages/CustomerDetail.tsx
@@ -43,6 +43,7 @@ import {
   stateLabelForCountry,
   postalPlaceholderForCountry,
 } from '@/lib/geo'
+import { TAX_ID_HINTS, taxIdTypeOptions } from '@/lib/taxIdTypes'
 
 const statusVariant = statusBadgeVariant
 
@@ -1160,14 +1161,6 @@ function CreateSubscriptionDialog({ customerId, plans, onClose, onCreated }: {
 
 /* ─── Edit Billing Profile ───────────────────────────────────── */
 
-const TAX_ID_HINTS: Record<string, string> = {
-  gst: 'e.g. 29ABCDE1234F1Z5 (India GSTIN)',
-  vat: 'e.g. GB123456789 (UK), DE123456789 (EU)',
-  ein: 'e.g. 12-3456789 (US Employer ID)',
-  abn: 'e.g. 12 345 678 901 (Australia)',
-  other: 'Enter the identifier in your jurisdiction\u2019s format',
-}
-
 function EditBillingProfileDialog({ customerId, customer, profile, onClose, onSaved }: {
   customerId: string
   customer: Customer
@@ -1392,19 +1385,22 @@ function EditBillingProfileDialog({ customerId, customer, profile, onClose, onSa
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label>Tax ID Type</Label>
-                  <Select value={form.tax_id_type} onValueChange={(val) => setValue('tax_id_type', val ?? '', { shouldDirty: true })}>
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select type..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="">None</SelectItem>
-                      <SelectItem value="gst">GST</SelectItem>
-                      <SelectItem value="vat">VAT</SelectItem>
-                      <SelectItem value="ein">EIN</SelectItem>
-                      <SelectItem value="abn">ABN</SelectItem>
-                      <SelectItem value="other">Other</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <Combobox
+                    value={form.tax_id_type}
+                    onChange={(val) => setValue('tax_id_type', val, { shouldDirty: true })}
+                    options={taxIdTypeOptions(form.tax_id_type).map(t => ({
+                      value: t.value,
+                      label: t.label,
+                      keywords: [t.value, t.country].filter(Boolean),
+                      prefix: (
+                        <span className="text-muted-foreground font-mono text-[11px] w-7 inline-block text-center">
+                          {t.country || '\u2014'}
+                        </span>
+                      ),
+                    }))}
+                    placeholder="Select type..."
+                    clearable
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label>Tax ID</Label>


### PR DESCRIPTION
## Summary

- Make Stripe-canonical codes (`in_gst`, `eu_vat`, `au_abn`) the primary `tax_id_type` form so operators see the same identifiers in Stripe webhooks, the Stripe Dashboard, and Velox
- Legacy Velox shorthand (`gstin`, `vat`, `abn`, `in_gstin`) still validates on input and is normalized to the canonical Stripe code via the new `tax.NormalizeTaxIDType` before persistence — no migration needed since Velox is pre-launch / local-only
- Customer detail's Edit Billing Profile dialog replaces the 5-option Select with a searchable Combobox of 50 Stripe-canonical codes, sorted alphabetically by label, with country-code badges and code-or-label keyword search; legacy non-canonical reads are pinned at top with a "Legacy" annotation so older rows render until re-saved

## Files

- `internal/tax/taxid.go` — rename constants to `TaxIDKindINGST/EUVAT/AUABN`; add `NormalizeTaxIDType`; keep legacy aliases in `ValidateTaxID` switch
- `internal/customer/service.go` — call `NormalizeTaxIDType` before write in `UpsertBillingProfile`
- `internal/tax/taxid_test.go` — canonical codes are primary; new `TestNormalizeTaxIDType_VeloxShorthandToCanonical` and `TestValidateTaxID_AcceptsBothFormats`
- `web-v2/src/lib/taxIdTypes.ts` (new) — `STRIPE_TAX_ID_TYPES` table + `taxIdTypeOptions(currentValue)` helper that pins legacy values
- `web-v2/src/pages/CustomerDetail.tsx` — Combobox replaces Select; imports moved to shared module
- `MANUAL_TEST.md` — FLOW B11 rewrites bullets around canonical codes

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/tax/... ./internal/customer/... -short` — all pass (incl. new tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — succeeds
- [ ] Manual: open Customer Detail → Edit Billing Profile → tax_id_type Combobox shows alphabetized list, search works, country badges render
- [ ] Manual: POST `tax_id_type=gstin` via API → DB stores `in_gst`
- [ ] Manual: pre-existing row with `tax_id_type=gstin` → legacy option pins at top of dropdown; re-saving normalizes

## Conventions followed

- No DB migration (per "no speculative backfill" — pre-launch local data only)
- Public `tax_id_type` field name unchanged; only canonical values change
- Backend acceptance is permissive (legacy + canonical); storage is canonical
- Frontend always writes canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)