### PR TITLE
docs: truth-up README + design RFCs to reflect shipped state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,41 @@ A second surface mirrors this file:
 
 ### Documentation
 
+- **README + design RFCs truthed up to reflect shipped state.**
+  README's "Status" blockquote claiming multi-dim meters land 2026-05-08
+  and the `POST /v1/usage-events` endpoint accepts integer quantity only
+  was removed — multi-dim meters shipped 2026-04-25 and the endpoint has
+  taken decimal-string quantities (`NUMERIC(38, 12)`) since migration
+  `0054_usage_events_numeric_quantity`. The 13-week roadmap table that
+  mixed shipped and not-yet-shipped rows under the same heading was
+  replaced with a forward-looking `## Roadmap` section split into
+  `### Recently shipped` (multi-dim meters, pricing recipes, quickstart
+  wizard, `create_preview`, billing thresholds, billing alerts, cost
+  dashboard, plan-migration UI, bulk ops, live event stream,
+  `velox-import` CLI) and `### In flight` (Helm + Terraform self-host
+  packaging, compliance posture, first design-partner production
+  cutover) so the README states what's shipped today and what's next,
+  not what was planned three months ago. Self-host one-liner softened
+  from "five-minute self-host coming soon" to a concrete pointer at
+  `docs/self-host/postgres-backup.md` for the backup playbook that
+  already exists, with the Helm chart + Terraform module called out as
+  "under construction." Five design RFCs (`docs/design-multi-dim-meters.md`,
+  `docs/design-recipes.md`, `docs/design-billing-thresholds.md`,
+  `docs/design-billing-alerts.md`, `docs/design-customer-usage.md`) got
+  a `Status: Shipped <date> — see CHANGELOG.md` header plus a preserved
+  "kept as historical RFC" italic note so the design rationale stays
+  searchable, but no future reader is misled into thinking the work is
+  still pending. Implementation checklists in those RFCs flipped from
+  `[ ]` to `[x]` and dropped now-stale "(Week N)" qualifiers, broken
+  pointers to the moved-out 90-day plan, and Track A / Track B
+  internal-plan vocabulary that referenced the now-private velox-ops
+  repo. The blog post `docs/blog/2026-04-stripe-meter-api-ai-workloads.md`
+  got a 2026-04-28 update note at the top calling out that the
+  multi-dim implementation it describes is now live in `main` and the
+  endpoints in the post are the production contract — past-tensed the
+  "Velox is implementing this" line further down so the post reads as
+  shipped retrospective, not aspirational design.
+
 - **Public/private repo split for internal-only docs.** Twelve internal
   planning + marketing docs moved out of the public repo to a private
   `sagarsuperuser/velox-ops` repo so the public surface only carries

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ curl -X POST https://api.velox.dev/v1/meters/mtr_tokens/pricing-rules \
 
 A coarser rule (`{"model": "gpt-4"}`) plus a finer override (`{"model": "gpt-4", "cached": true}` at higher priority) compose cleanly — each event is claimed by the highest-priority matching rule, no double-count. The full design — schema, aggregation semantics, decimal quantities, all five aggregation modes (`sum`, `count`, `last_during_period`, `last_ever`, `max`) — lives in [`docs/design-multi-dim-meters.md`](docs/design-multi-dim-meters.md).
 
-> **Status:** multi-dim meters land in `v0.x` on **May 8, 2026** (Week 2 of the 90-day plan). The endpoints above are the published API contract; today's `POST /v1/usage-events` accepts integer `quantity` only and stays available for back-compat.
-
 ---
 
 ## What's in the box
@@ -95,7 +93,7 @@ End-to-end demo (creates a customer, ingests usage, runs billing, generates a PD
 ./scripts/demo.sh $VELOX_SECRET
 ```
 
-Five-minute self-host: see [`docs/self-host`](docs/) (Week 9 deliverable — under construction).
+Five-minute self-host (Helm chart + Terraform module): under construction. Postgres backup playbook is already in [`docs/self-host/postgres-backup.md`](docs/self-host/postgres-backup.md).
 
 ---
 
@@ -232,22 +230,26 @@ All keys are HMAC-rotated on a 72-hour overlap window, matching Stripe's webhook
 
 ---
 
-## Roadmap (next 90 days)
+## Roadmap
 
-| Week  | Ship                                                                            |
-|-------|---------------------------------------------------------------------------------|
-| 1     | Positioning, README, blog post, design-partner outreach list (this commit)      |
-| 2     | Multi-dim meters, decimal quantities, all five aggregation modes                |
-| 3     | Pricing recipes (`anthropic_style`, etc.) + recipe-picker UI                    |
-| 4     | Quickstart wizard — sign-up → first invoice in <5 minutes                       |
-| 5     | `create_preview`, billing thresholds, billing alerts, `<VeloxCostDashboard />`  |
-| 6–7   | Live event stream UI, plan-migration preview, bulk operations, invoice composer |
-| 8     | 50 cold emails, 10+ demo calls, 3 design partners with signed LOI               |
-| 9     | Helm chart, Docker Compose, Terraform — self-host in ≤1 hour                    |
-| 10    | Compliance posture — encryption-at-rest, SOC2 mapping, GDPR export              |
-| 11    | Migration FROM Stripe Billing (importer + cutover playbook)                     |
-| 12    | First design partner cuts over to Velox in production                           |
-| 13    | Stabilize + public retro                                                         |
+### Recently shipped
+
+- **Multi-dimensional meters** — one meter, N pricing rules, decimal quantities (`NUMERIC(38, 12)`), all five aggregation modes
+- **Pricing recipes** — `anthropic_style`, `openai_style`, `replicate_style`, `b2b_saas_pro`, `marketplace_gmv`; recipe-picker UI; one-click uninstall
+- **Quickstart wizard** — sign-up → first invoice in under five minutes
+- **`create_preview`, billing thresholds, billing alerts** — Stripe Tier-1 surfaces with multi-dim parity
+- **Embeddable cost dashboard** — `<VeloxCostDashboard customerId={…} />` plus token-authenticated public URL
+- **Plan-migration UI** — preview, batch apply, history; bulk operations on customers/subscriptions/invoices
+- **Live event stream + invoice composer** — operator UX for ingestion debugging and one-off invoice creation
+- **`velox-import`** — Stripe Billing → Velox cutover with idempotent reruns and reconciliation CSV; full operator playbook in [`docs/migration-from-stripe.md`](docs/migration-from-stripe.md)
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full ship log.
+
+### In flight
+
+- **Self-host packaging** — Helm chart + Terraform module (Postgres backup runbook already in [`docs/self-host/postgres-backup.md`](docs/self-host/postgres-backup.md))
+- **Compliance posture** — encryption-at-rest hardening, SOC 2 control mapping, GDPR export coverage
+- **First design-partner cutover** to Velox in production
 
 ---
 

--- a/docs/blog/2026-04-stripe-meter-api-ai-workloads.md
+++ b/docs/blog/2026-04-stripe-meter-api-ai-workloads.md
@@ -4,6 +4,8 @@
 > Code samples are real; the API contracts referenced are
 > Stripe's [Billing Meter](https://docs.stripe.com/api/billing/meter) and
 > Velox's [multi-dim meters RFC](../design-multi-dim-meters.md).
+>
+> *Updated 2026-04-28: Velox's multi-dimensional meter implementation is now live in `main`. The endpoints below are the production contract — schema, aggregation semantics, and per-rule pricing all round-trip end-to-end.*
 
 If you bill an AI product — inference, embeddings, agentic workflows, vector search — you've probably tried to model your pricing inside Stripe Billing and noticed something is wrong. You start with one Meter for "tokens." Then you add another for "output tokens" because input and output bill at different rates. Then "cached input" because Anthropic prompt caching is 90% cheaper. Then "batch" because batch pricing is half. Three models in your catalog, and you're suddenly at twenty-something Meters, each tied to its own Price and its own Subscription Item, before a single customer is on the system.
 
@@ -168,7 +170,7 @@ The decision point is the cardinality of your rate matrix. Below ~6 cells, Strip
 
 ## What we're building
 
-Velox's multi-dim meter implementation lands in `v0.x` on **May 8, 2026**. The schema, API surface, aggregation semantics, and test plan are public in the [design doc](../design-multi-dim-meters.md). The endpoints in this post are the published contract — you can scaffold against them today.
+Velox's multi-dim meter implementation is live in `v0.x` (shipped 2026-04-25). The schema, API surface, aggregation semantics, and test plan are public in the [design doc](../design-multi-dim-meters.md). The endpoints in this post are the production contract — `decimal` quantities round-trip without precision loss, pricing rules dispatch on `dimension_match`, and the cycle scan rates events through the same `usage.AggregateByPricingRules` path the dashboard reads.
 
 If you run an AI product where the rate matrix is starting to outgrow Stripe Billing, or where regulatory pressure (EU GDPR-strict, India RBI data localization, healthcare-adjacent SaaS) means you can't keep customer billing data on Stripe's servers in the first place — we're looking for design partners. Twelve months free hosted access in exchange for a weekly check-in and a co-branded case study. Email `partners@velox.dev` or open an issue on [the repo](https://github.com/sagarsuperuser/velox).
 

--- a/docs/design-billing-alerts.md
+++ b/docs/design-billing-alerts.md
@@ -1,9 +1,10 @@
 # Billing Alerts — Technical Design
 
-> **Status:** Draft v1
-> **Owner:** Track A
+> **Status:** Shipped — see [`CHANGELOG.md`](../CHANGELOG.md) for the merged commits and migration `0057_billing_alerts`.
 > **Last revised:** 2026-04-26
 > **Related:** `docs/design-create-preview.md` (sibling — same composition + always-array conventions), `docs/design-customer-usage.md` (the read surface alerts evaluate against), `docs/design-multi-dim-meters.md` (multi-dim dependency — `usage.AggregateByPricingRules` is the trigger evaluator's engine)
+>
+> The text below is preserved as the design-time RFC. The implementation is live in `main`; refer to `internal/billingalert/` and `web-v2/src/pages/BillingAlerts.tsx` for the current behaviour.
 
 ## Motivation
 
@@ -23,7 +24,7 @@ The dashboard consumer is the existing CostDashboard's notifications panel; it p
 - **Stripe Tier 1 parity** for the simple "alert me at $X" use case. Threshold is either dollar-cents (`amount_gte`) or raw quantity (`usage_gte`) — both are common ("alert at $50 spent" vs "alert at 1M tokens consumed").
 - **Customer-scoped first**. v1 alerts are always tied to a `customer_id`; tenant-wide ("alert me when ANY customer crosses $1000 this cycle") is a separate, more-complex surface — defer.
 - **Optional meter scope**. An alert can target one specific meter (`filter.meter_id`) or aggregate across all meters on the customer's plan (omit `filter.meter_id`). Single-meter alerts evaluate against that meter's rule resolution; cross-meter alerts evaluate against the customer's total amount across the cycle (same number `customer-usage` reports).
-- **Optional dimension filter**. Multi-dim meters (Week 2) let pricing rules carry `dimension_match` — alerts can narrow further: "alert me when GPT-4 input token spend on customer X exceeds $50". Implemented as a strict-superset match on rule `dimension_match`.
+- **Optional dimension filter**. Multi-dim meters let pricing rules carry `dimension_match` — alerts can narrow further: "alert me when GPT-4 input token spend on customer X exceeds $50". Implemented as a strict-superset match on rule `dimension_match`.
 - **Reliable emission via outbox**. Trigger evaluation reads, decides to fire, mutates state and enqueues the webhook all inside one tx. If the tx rolls back, no webhook fires; if it commits, the dispatcher will eventually deliver. Same atomicity contract every other event-emitting domain uses.
 - **Idempotent recurrence**. `per_period` alerts emit at most one event per (alert, cycle) — even across crashes / replica failovers / replays of the evaluator. The trigger row's UNIQUE constraint on `(alert_id, period_from)` is the source of truth.
 - **Always-array / always-object wire shape**. Same conventions as customer-usage and create_preview — `alerts[]` is a JSON array even when empty; `dimension_match` is a JSON object even when empty (the rule's "match anything" identity); decimals serialize as JSON strings.
@@ -397,26 +398,24 @@ The wire-shape regression test (`TestWireShape_SnakeCase`) marshals a fully-popu
 6. **Should we persist the trigger row's outbox `event_id` for cross-reference?** Useful for debugging "did this alert's webhook get delivered". **Proposal: defer.** The webhook outbox is queryable on its own; cross-referencing via `event_type='billing.alert.triggered'` and matching `data.alert_id` is sufficient. Add a column if a real ops use case emerges.
 7. **Should we expose a way to test-fire an alert without waiting for real usage?** Useful for the operator to verify their webhook receiver is wired correctly. **Proposal: defer to v2** behind a separate `POST /v1/billing/alerts/{id}/test_fire` route gated to test-mode keys only. v1 operators can verify via Stripe's standard webhook-event replay UI on the dashboard.
 
-## Implementation checklist (Week 5d)
+## Implementation checklist
 
-- [ ] `docs/design-billing-alerts.md` — this RFC.
-- [ ] `internal/domain/billing_alert.go` — domain types (`BillingAlert`, `BillingAlertStatus`, `BillingAlertRecurrence`, `BillingAlertTrigger`, threshold helpers).
-- [ ] `internal/platform/migrate/sql/0057_billing_alerts.up.sql` + `.down.sql` — schema.
-- [ ] `internal/billingalert/store.go` — `Store` interface + `ListFilter`.
-- [ ] `internal/billingalert/postgres.go` — Postgres implementation.
-- [ ] `internal/billingalert/service.go` — Create / Get / List / Archive.
-- [ ] `internal/billingalert/handler.go` — chi router for the four endpoints.
-- [ ] `internal/billingalert/evaluator.go` — background evaluator with advisory lock.
-- [ ] `internal/billingalert/wire_shape_test.go` — `TestWireShape_SnakeCase` merge gate.
-- [ ] `internal/billingalert/service_test.go` — unit tests with fakes.
-- [ ] `internal/billingalert/evaluator_test.go` — unit tests for evaluator helpers.
-- [ ] `internal/billingalert/integration_test.go` — full-stack integration with real Postgres + outbox.
-- [ ] Add `EventBillingAlertTriggered = "billing.alert.triggered"` to `internal/domain/webhook_outbound.go`.
-- [ ] Add `LockKeyBillingAlertEvaluator int64 = 76540005` to `internal/platform/postgres/advisory_lock.go`.
-- [ ] Wire routes + evaluator goroutine in `internal/api/router.go` and `cmd/velox/main.go`.
-- [ ] Update `web-v2/src/lib/api.ts` — `BillingAlert` types + endpoint methods.
-- [ ] Update `CHANGELOG.md` (Track A) + `web-v2/src/pages/Changelog.tsx` (Track B).
-- [ ] Track A → Track B handoff note (private velox-ops repo).
+- [x] `internal/domain/billing_alert.go` — domain types (`BillingAlert`, `BillingAlertStatus`, `BillingAlertRecurrence`, `BillingAlertTrigger`, threshold helpers).
+- [x] `internal/platform/migrate/sql/0057_billing_alerts.{up,down}.sql` — schema.
+- [x] `internal/billingalert/store.go` — `Store` interface + `ListFilter`.
+- [x] `internal/billingalert/postgres.go` — Postgres implementation.
+- [x] `internal/billingalert/service.go` — Create / Get / List / Archive.
+- [x] `internal/billingalert/handler.go` — chi router for the four endpoints.
+- [x] `internal/billingalert/evaluator.go` — background evaluator with advisory lock.
+- [x] `internal/billingalert/wire_shape_test.go` — `TestWireShape_SnakeCase` merge gate.
+- [x] `internal/billingalert/service_test.go` — unit tests with fakes.
+- [x] `internal/billingalert/evaluator_test.go` — unit tests for evaluator helpers.
+- [x] `internal/billingalert/integration_test.go` — full-stack integration with real Postgres + outbox.
+- [x] `EventBillingAlertTriggered = "billing.alert.triggered"` in `internal/domain/webhook_outbound.go`.
+- [x] `LockKeyBillingAlertEvaluator` in `internal/platform/postgres/advisory_lock.go`.
+- [x] Routes + evaluator goroutine wired in `internal/api/router.go` and `cmd/velox/main.go`.
+- [x] `web-v2/src/lib/api.ts` — `BillingAlert` types + endpoint methods.
+- [x] CHANGELOG entry + public changelog rollup.
 
 ## Track B unblock
 

--- a/docs/design-billing-thresholds.md
+++ b/docs/design-billing-thresholds.md
@@ -1,9 +1,10 @@
 # Billing Thresholds — Technical Design
 
-> **Status:** Draft v1
-> **Owner:** Track A
+> **Status:** Shipped — see [`CHANGELOG.md`](../CHANGELOG.md) for the merged commits and migration `0056_subscription_billing_thresholds`.
 > **Last revised:** 2026-04-26
 > **Related:** `docs/design-create-preview.md` (sibling — same composition, same wire conventions), `docs/design-multi-dim-meters.md` (multi-dim dependency — `usage.AggregateByPricingRules`)
+>
+> The text below is preserved as the design-time RFC. The implementation is live in `main`; refer to `internal/billing/threshold_scan.go` and `internal/subscription/` for the current behaviour.
 
 ## Motivation
 
@@ -12,7 +13,7 @@ Stripe ships **billing thresholds** as Tier 1 — a tenant configures a per-subs
 Velox already has every primitive to do this:
 
 - The cycle scan (`Engine.RunCycle` → `Engine.billSubscription` → `CreateInvoiceWithLineItems` → `advanceCycleOrCancel`) already builds line items from the partial-cycle window, prices them via `domain.ComputeAmountCents`, finalizes the invoice, and rolls the cycle forward.
-- `usage.AggregateByPricingRules` (Week 2) already computes the running total over an arbitrary window, including for multi-dim meters.
+- `usage.AggregateByPricingRules` already computes the running total over an arbitrary window, including for multi-dim meters.
 - The scheduler already runs a billing tick under an advisory lock (`s.billingLockKey`) that gates exactly-one finalize per (subscription, cycle).
 
 The slice is composition: **a mid-cycle scan tick** that, for every subscription with thresholds configured, computes the partial-cycle total via the same aggregation path the cycle scan uses, and when the threshold is crossed, **calls into the existing finalize-cycle code path early** with `billing_reason="threshold"`. We do **not** duplicate the build-line-items or advance-cycle code — same code path, different entry point.
@@ -323,25 +324,24 @@ The `item_thresholds` array is an aux table because per-item config doesn't comp
 6. **Should we emit `subscription.threshold_warning` at 80% of threshold?** That's Week 5d (billing alerts) — different feature. Linked, but not co-shipped.
 7. **Should `amount_gte` be denominated in the subscription's currency or platform-canonical USD?** **Proposal: subscription currency.** A multi-currency tenant configures different thresholds per currency (different subscriptions). Avoids FX conversion in the hot scan path.
 
-## Implementation checklist (Week 5c)
+## Implementation checklist
 
-- [ ] `internal/domain/subscription.go` — add `BillingThresholds` struct + `SubscriptionItemThreshold`, attach to `Subscription`.
-- [ ] `internal/domain/invoice.go` — add `InvoiceBillingReason` enum + `BillingReason` field on `Invoice`.
-- [ ] `internal/platform/migrate/sql/0056_subscription_billing_thresholds.{up,down}.sql` — schema.
-- [ ] `internal/subscription/store.go` — extend interface with `SetBillingThresholds`, `ClearBillingThresholds`, `ListWithThresholds`.
-- [ ] `internal/subscription/postgres.go` — implementations.
-- [ ] `internal/subscription/service.go` — validation + `SetBillingThresholds` method.
-- [ ] `internal/subscription/handler.go` — `PATCH /v1/subscriptions/{id}` route.
-- [ ] `internal/billing/threshold_scan.go` — `Engine.ScanThresholds` + `scanOneThreshold` + `fireThreshold`.
-- [ ] `internal/billing/scheduler.go` — wire `ScanThresholds` into `runBillingCycleForMode`.
-- [ ] `internal/billing/engine.go` — extend `billSubscription` with `billing_reason` parameter.
-- [ ] `internal/invoice/postgres.go` — extend `CreateInvoiceWithLineItems` to persist `billing_reason`.
-- [ ] `internal/domain/webhook_outbound.go` — add `EventSubscriptionThresholdCrossed`.
-- [ ] `internal/subscription/wire_shape_test.go` — `TestWireShape_SnakeCase` regression (the merge gate).
-- [ ] Unit tests for service validation + handler PATCH path + `evaluateThresholds`.
-- [ ] Integration tests covering the seven scenarios listed above.
-- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B) entries.
-- [ ] Track A → Track B handoff note (private velox-ops repo).
+- [x] `internal/domain/subscription.go` — `BillingThresholds` struct + `SubscriptionItemThreshold`.
+- [x] `internal/domain/invoice.go` — `InvoiceBillingReason` enum + `BillingReason` field on `Invoice`.
+- [x] `internal/platform/migrate/sql/0056_subscription_billing_thresholds.{up,down}.sql`.
+- [x] `internal/subscription/store.go` — `SetBillingThresholds`, `ClearBillingThresholds`, `ListWithThresholds`.
+- [x] `internal/subscription/postgres.go` — implementations.
+- [x] `internal/subscription/service.go` — validation + `SetBillingThresholds` method.
+- [x] `internal/subscription/handler.go` — `PATCH /v1/subscriptions/{id}` route.
+- [x] `internal/billing/threshold_scan.go` — `Engine.ScanThresholds` + `scanOneThreshold` + `fireThreshold`.
+- [x] `internal/billing/scheduler.go` — `ScanThresholds` wired into `runBillingCycleForMode`.
+- [x] `internal/billing/engine.go` — `billSubscription` accepts `billing_reason`.
+- [x] `internal/invoice/postgres.go` — `CreateInvoiceWithLineItems` persists `billing_reason`.
+- [x] `internal/domain/webhook_outbound.go` — `EventSubscriptionThresholdCrossed`.
+- [x] `internal/subscription/wire_shape_test.go` — `TestWireShape_SnakeCase` regression.
+- [x] Unit tests for service validation + handler PATCH path + `evaluateThresholds`.
+- [x] Integration tests covering the seven scenarios listed above.
+- [x] CHANGELOG entry + public changelog rollup.
 
 ## Track B unblock
 

--- a/docs/design-customer-usage.md
+++ b/docs/design-customer-usage.md
@@ -1,19 +1,20 @@
 # Customer Usage Endpoint — Technical Design
 
-> **Status:** Draft v1
-> **Owner:** Track A
+> **Status:** Shipped — see [`CHANGELOG.md`](../CHANGELOG.md) for the merged commits and the embeddable surface in `web-v2/src/components/CostDashboard.tsx`.
 > **Last revised:** 2026-04-26
 > **Related:** `docs/design-multi-dim-meters.md` (multi-dim dependency), `docs/design-recipes.md` (same wire-contract conventions)
+>
+> The text below is preserved as the design-time RFC. The implementation is live in `main`; refer to `internal/usage/customer_usage.go` and `internal/costdashboard/` for the current behaviour.
 
 ## Motivation
 
 A buyer evaluating Velox asks the same question on day one: "How do I show a customer their current usage and what they'll be charged?" Stripe Billing's answer is a hosted Customer Portal page — but that's locked to Stripe Billing, which Velox does not use (per ADR on PaymentIntent-only). Buyers self-hosting Velox today have no first-party answer; they hand-roll a SQL query against `usage_events` and pray the dimension-match logic stays in sync with their pricing rules.
 
-This is the second flagship developer-experience surface, alongside recipes. Where recipes collapse "set up billing" to one POST, **`GET /v1/customers/{id}/usage` collapses "show me what this customer used and owes" to one GET**. The Track B cost-dashboard scaffold (Week 5) is the in-product manifestation; the API itself unblocks every operator who needs the same data in their own portal, in Slack alerts, in CSV exports.
+This is the second flagship developer-experience surface, alongside recipes. Where recipes collapse "set up billing" to one POST, **`GET /v1/customers/{id}/usage` collapses "show me what this customer used and owes" to one GET**. The cost-dashboard component is the in-product manifestation; the API itself unblocks every operator who needs the same data in their own portal, in Slack alerts, in CSV exports.
 
 The dimension-match-aware aggregation is the part that can't be hand-rolled: the rules-ranked LATERAL JOIN in `internal/usage/postgres.go:236–279` is non-trivial, and any external SQL would silently drift from canonical pricing the moment a tenant adds a `meter_pricing_rule`. This endpoint is the supported way to get the right answer.
 
-This design ships in Week 5 and depends on Week 2 multi-dim meters (schema + aggregation already shipped) plus Week 4 invoice-line-item fan-out (so we can distinguish billed vs. not-yet-billed usage).
+This endpoint composes the multi-dim aggregation surface and the invoice-line-item fan-out so callers can distinguish billed from not-yet-billed usage in a single response.
 
 ## Goals
 
@@ -23,7 +24,7 @@ This design ships in Week 5 and depends on Week 2 multi-dim meters (schema + agg
 - **Subscription context co-emitted.** Response includes the plan(s) the customer is on plus the cycle boundaries, so a dashboard can render "Plan: AI API Pro · cycle Apr 1 → May 1 · 87% through" without follow-up calls.
 - **RLS-safe.** All queries scope through `BeginTx(ctx, postgres.TxTenant, tenantID)`; the response cannot leak across tenants even when an operator passes a customer ID from another tenant — the lookup just 404s.
 - **Cheap.** Constant-bounded SQL (one aggregate per meter on the customer's plans). No event-by-event scan in the hot path. Live dashboards refresh every few seconds without melting the DB.
-- **Documented contract Track B mocks against today.** This is the API Track B's cost-dashboard scaffold (Week 5) and the eventual portal surface call.
+- **Documented contract for downstream consumers.** This is the API the cost-dashboard component calls and the portal surface uses.
 
 ## Non-goals (deferred)
 
@@ -225,15 +226,15 @@ Quantity is `decimal.Decimal` (NUMERIC(38,12)) per ADR-005, marshaled as a strin
 7. **Should `total_amount_cents` come from a fresh `ComputeAmountCents` call or from the matching `invoice_line_items` if the cycle is closed?** **Proposal: always fresh compute.** If the customer's pricing was edited mid-cycle, the dashboard wants the live answer; the invoice has the historical answer. Cycle-closed parity test guards drift.
 8. **Should warnings include "subscription cycle has rolled over but `current_period_*` hasn't been refreshed yet"?** **Proposal: yes**, surfaces a real ops issue (cycle scanner stuck) without breaking the response. Format: `cycle_refresh_lagging` warning code + the offending subscription ID.
 
-## Implementation checklist (Week 5)
+## Implementation checklist
 
-- [ ] `internal/usage/service.go` — `GetCustomerUsage` + `RateForCustomer` (composes existing store calls, no new SQL)
-- [ ] `internal/usage/handler.go` — `GET /v1/customers/{id}/usage` route (mounted off the customer router or as its own sub-router; whichever matches the existing customer endpoint pattern)
-- [ ] `resolvePeriod` helper + unit tests
-- [ ] Integration tests: single-meter parity, multi-dim parity, cycle alignment, cross-tenant 404, no-sub + explicit window, plan transition, closed-cycle parity
-- [ ] `cmd/velox-customer-usage-e2e/main.go` (or extend recipes e2e) — assertion fixture
-- [ ] OpenAPI spec update (`docs/openapi.yaml`)
-- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B, after coordinating)
+- [x] `internal/usage/service.go` — `GetCustomerUsage` + `RateForCustomer` composing existing store calls.
+- [x] `internal/usage/handler.go` — `GET /v1/customers/{id}/usage` route.
+- [x] `resolvePeriod` helper + unit tests.
+- [x] Integration tests: single-meter parity, multi-dim parity, cycle alignment, cross-tenant 404, no-sub + explicit window, plan transition, closed-cycle parity.
+- [x] End-to-end assertion fixture against the running stack.
+- [x] OpenAPI spec update (`docs/openapi.yaml`).
+- [x] CHANGELOG entry + public changelog rollup.
 
 ## Track B unblock
 

--- a/docs/design-multi-dim-meters.md
+++ b/docs/design-multi-dim-meters.md
@@ -1,9 +1,10 @@
 # Multi-Dimensional Meters — Technical Design
 
-> **Status:** Draft v1
-> **Owner:** Track A
+> **Status:** Shipped 2026-04-25 — see [`CHANGELOG.md`](../CHANGELOG.md) for the merged commits.
 > **Last revised:** 2026-04-25
 > **Related:** ADR-002 (per-domain), ADR-003 (RLS), ADR-005 (integer cents)
+>
+> The text below is preserved as the design-time RFC. The implementation is live in `main`; refer to the package-level docs in `internal/usage/` and `internal/billing/` for the current behaviour.
 
 ## Motivation
 
@@ -307,26 +308,18 @@ Per memory `feedback_prefer_battle_tested_libs`: use `shopspring/decimal`, do no
 6. **Do existing `usage_events.quantity` BIGINT values need any migration data work?** Proposal: **no**. Widening cast is lossless; max BIGINT (≈9.2 × 10¹⁸) fits NUMERIC(38, 12) trivially.
 7. **Should we deprecate the existing `meters.aggregation` column?** Proposal: **not yet**. Keep it as the default-rule aggregation mode for back-compat; flag for removal in 6 months once all tenants migrate to `meter_pricing_rules`.
 
-## Implementation checklist (Week 2)
+## Implementation checklist
 
-Tracking via the 90-day plan; this is the canonical breakdown:
-
-- [ ] Migration `0054_multi_dim_meters.{up,down}.sql` (allocate number from `origin/main`)
-- [ ] `domain.UsageEvent.Quantity` → `decimal.Decimal` (one-time refactor; field name stays `Quantity`)
-- [ ] `domain.MeterPricingRule` struct
-- [ ] `usage.Store.UpsertPricingRule(...)`, `ListPricingRulesByMeter(...)`, `DeletePricingRule(...)`
-- [ ] `usage.Service.IngestEvent(...)` accepts decimal quantity + dimensions
-- [ ] `usage.Service.AggregateForBillingPeriod(...)` resolves rules with priority + dimension match
-- [ ] HTTP handlers: `POST /v1/usage-events`, `POST/GET/LIST/DELETE /v1/meters/{id}/pricing-rules`
-- [ ] `GET /v1/customers/{id}/usage` (powers Week 5 cost dashboard)
-- [ ] Unit tests: ingest, aggregation per mode, subset-match, priority-claim
-- [ ] Integration tests: real Postgres, RLS-isolated tenants, decimal precision, idempotency
-- [ ] `cmd/velox-bench/main.go` + 50k events/sec benchmark validation
-- [ ] OpenAPI spec update (`docs/openapi.yaml`)
-- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B, after coordinating)
-
-## Review status
-
-- **Track A author:** drafted 2026-04-25
-- **Track B review:** pending — Track B can build recipe-picker UI scaffold against this design without waiting for implementation
-- **Human review:** pending — please flag any open question to resolve before Week 2 starts
+- [x] Migration `0054_multi_dim_meters.{up,down}.sql`
+- [x] `domain.UsageEvent.Quantity` → `decimal.Decimal`
+- [x] `domain.MeterPricingRule` struct
+- [x] `usage.Store.UpsertPricingRule(...)`, `ListPricingRulesByMeter(...)`, `DeletePricingRule(...)`
+- [x] `usage.Service.IngestEvent(...)` accepts decimal quantity + dimensions
+- [x] `usage.Service.AggregateForBillingPeriod(...)` resolves rules with priority + dimension match
+- [x] HTTP handlers: `POST /v1/usage-events`, `POST/GET/LIST/DELETE /v1/meters/{id}/pricing-rules`
+- [x] `GET /v1/customers/{id}/usage` powering the cost dashboard
+- [x] Unit tests: ingest, aggregation per mode, subset-match, priority-claim
+- [x] Integration tests: real Postgres, RLS-isolated tenants, decimal precision, idempotency
+- [x] `cmd/velox-bench/main.go` + 50k events/sec benchmark validation
+- [x] OpenAPI spec update (`docs/openapi.yaml`)
+- [x] CHANGELOG entry + public changelog rollup

--- a/docs/design-recipes.md
+++ b/docs/design-recipes.md
@@ -1,9 +1,10 @@
 # Pricing Recipes — Technical Design
 
-> **Status:** Draft v1
-> **Owner:** Track A
+> **Status:** Shipped — see [`CHANGELOG.md`](../CHANGELOG.md) for the merged commits and the operator-facing surface in `web-v2/src/pages/Recipes.tsx`.
 > **Last revised:** 2026-04-25
 > **Related:** `docs/design-multi-dim-meters.md` (multi-dim meter dependency), ADR-002 (per-domain), ADR-003 (RLS)
+>
+> The text below is preserved as the design-time RFC. The implementation is live in `main`; refer to the package-level docs in `internal/recipe/` for the current behaviour.
 
 ## Motivation
 
@@ -39,7 +40,7 @@ This design depends on multi-dim meters being merged.
 - `internal/pricing.Service.CreateMeter`, `CreateRatingRule`, `CreatePlan` — narrow per-domain creates, no atomic-graph helper exists yet.
 - `internal/dunning.Service.UpsertPolicy` — per-tenant retry schedule.
 - `internal/webhook.Service.CreateEndpoint` — registers a webhook URL, returns the signing secret.
-- `internal/usage.Store.UpsertPricingRule` (Week 2) — multi-dim rule per meter.
+- `internal/usage.Store.UpsertPricingRule` — multi-dim rule per meter.
 - No coordinator. Today, building `anthropic_style` by hand is ~30 HTTP calls with manual ID-passing between them. Recipes collapse this to one.
 
 ## Proposed schema changes — migration `00XX_recipe_instances`
@@ -372,7 +373,7 @@ internal/recipe/
 - `pricing.Service` for plan + meter + rating rule creation
 - `dunning.Service` for policy upsert
 - `webhook.Service` for endpoint creation
-- `usage.Service` for `MeterPricingRule` upsert (Week 2 dependency)
+- `usage.Service` for `MeterPricingRule` upsert
 - `customer.Service` + `subscription.Service` for `seed_sample_data`
 
 The dependencies inject as narrow interfaces so the recipe package owns no cross-domain state. Same pattern as `internal/billing/engine`.
@@ -469,7 +470,7 @@ Each recipe gets a one-pager at `/docs/recipes/{key}.md` (Track B's `/docs/recip
 
 ## Decimal & numeric considerations
 
-Recipes inherit Week 2's `NUMERIC(38, 12)` quantity type; no recipe-specific changes. All amount fields are integer cents per ADR-005. Currency conversion is the operator's responsibility (Stripe handles the actual settlement).
+Recipes inherit the `NUMERIC(38, 12)` quantity type from `usage_events`; no recipe-specific changes. All amount fields are integer cents per ADR-005. Currency conversion is the operator's responsibility (Stripe handles the actual settlement).
 
 ## Performance
 
@@ -488,26 +489,24 @@ Recipes inherit Week 2's `NUMERIC(38, 12)` quantity type; no recipe-specific cha
 6. **Recipe ordering in `GET /v1/recipes` — is there a "featured" notion?** Proposal: **alphabetical, no featuring v1**. The picker UI (Track B) can apply its own ordering; backend doesn't pick favorites.
 7. **Should built-in recipes ship with `webhook.events` set or empty?** Proposal: **set per recipe**. `anthropic_style` and `openai_style` get the AI-relevant events (`invoice.finalized`, `usage.threshold_crossed` once Week 5 ships); `b2b_saas_pro` gets the SaaS-classic ones (`subscription.created`, `subscription.canceled`). Concrete defaults beat empty-and-let-the-tenant-figure-it-out.
 
-## Implementation checklist (Week 3)
+## Implementation checklist
 
-Tracking via the 90-day plan; this is the canonical breakdown:
-
-- [ ] Migration `00XX_recipe_instances.{up,down}.sql` (allocate number from `origin/main`)
-- [ ] `domain.RecipeInstance` struct, `domain.Recipe` (parsed YAML), `domain.CreatedObjects`
-- [ ] `internal/recipe/embed.go` — `embed.FS` and registry
-- [ ] `internal/recipe/parse.go` — YAML schema + validation
-- [ ] `internal/recipe/template.go` — override merge + `text/template` render
-- [ ] `internal/recipe/store.go` + `postgres.go` — `recipe_instances` CRUD
-- [ ] `internal/recipe/service.go` — `Preview`, `Instantiate`, `Uninstall`
-- [ ] HTTP handlers: `GET /v1/recipes`, `GET /v1/recipes/{key}`, `POST /v1/recipes/{key}/preview`, `POST /v1/recipes/instantiate`, `DELETE /v1/recipes/instances/{id}`
-- [ ] `*Tx` variants on `pricing.Service`, `dunning.Service`, `webhook.Service`, `usage.Service` for transactional graph creation
-- [ ] 5 built-in recipes in `internal/recipe/recipes/*.yaml`
-- [ ] Per-recipe one-pagers in `docs/recipes/*.md` (Track B owns rendering at `/docs/recipes`)
-- [ ] Unit tests: YAML parse, override validation, template render
-- [ ] Integration tests: instantiate / preview / force / RLS / atomicity rollback
-- [ ] `cmd/velox-recipes-e2e/main.go` + assertion against multi-dim meter pricing
-- [ ] OpenAPI spec update (`docs/openapi.yaml`)
-- [ ] CHANGELOG.md (Track A) + Changelog.tsx (Track B, after coordinating)
+- [x] Migration `0055_recipe_instances.{up,down}.sql`
+- [x] `domain.RecipeInstance` struct, `domain.Recipe` (parsed YAML), `domain.CreatedObjects`
+- [x] `internal/recipe/embed.go` — `embed.FS` and registry
+- [x] `internal/recipe/parse.go` — YAML schema + validation
+- [x] `internal/recipe/template.go` — override merge + `text/template` render
+- [x] `internal/recipe/store.go` + `postgres.go` — `recipe_instances` CRUD
+- [x] `internal/recipe/service.go` — `Preview`, `Instantiate`, `Uninstall`
+- [x] HTTP handlers: `GET /v1/recipes`, `GET /v1/recipes/{key}`, `POST /v1/recipes/{key}/preview`, `POST /v1/recipes/instantiate`, `DELETE /v1/recipes/instances/{id}`
+- [x] `*Tx` variants on `pricing.Service`, `dunning.Service`, `webhook.Service`, `usage.Service` for transactional graph creation
+- [x] 5 built-in recipes in `internal/recipe/recipes/*.yaml`
+- [x] Per-recipe one-pagers in `docs/recipes/*.md` rendered at `/docs/recipes`
+- [x] Unit tests: YAML parse, override validation, template render
+- [x] Integration tests: instantiate / preview / force / RLS / atomicity rollback
+- [x] `cmd/velox-recipes-e2e/main.go` + assertion against multi-dim meter pricing
+- [x] OpenAPI spec update (`docs/openapi.yaml`)
+- [x] CHANGELOG entry + public changelog rollup
 
 ## Track B unblock
 


### PR DESCRIPTION
## Summary

The README's "Status" blockquote — `multi-dim meters land in v0.x on May 8, 2026 (Week 2 of the 90-day plan)` and `POST /v1/usage-events accepts integer quantity only` — was stale. Multi-dim meters shipped 2026-04-25, the endpoint has taken decimal-string quantities (`NUMERIC(38, 12)`) since migration `0054`, and the 90-day-plan doc was moved to the private `velox-ops` repo. Five design RFCs still read as drafts. This PR truths-up the public surface in one shot.

## What changed

**README.md (3 edits)**
- Removed the stale "Status" blockquote outright.
- Softened the self-host one-liner from "five-minute self-host coming soon" → concrete pointer to `docs/self-host/postgres-backup.md` with Helm/Terraform called out as "under construction."
- Replaced the 13-week roadmap table (mixed shipped + not-yet-shipped under one heading) with a forward-looking `## Roadmap` split into:
  - `### Recently shipped` — multi-dim, recipes, quickstart wizard, `create_preview`, billing thresholds, billing alerts, cost dashboard, plan-migration UI, bulk ops, live event stream, `velox-import` CLI.
  - `### In flight` — Helm + Terraform self-host, compliance posture, first design-partner cutover.

**docs/blog/2026-04-stripe-meter-api-ai-workloads.md (2 edits)**
- Added a 2026-04-28 update note at the top: "multi-dim implementation is now live in `main`; endpoints below are the production contract."
- Past-tensed the future-tense "Velox is implementing this" line mid-post.

**5 design RFCs frozen as historical with shipped headers**
- `docs/design-multi-dim-meters.md`
- `docs/design-recipes.md`
- `docs/design-billing-thresholds.md`
- `docs/design-billing-alerts.md`
- `docs/design-customer-usage.md`

Each got: a `Status: Shipped <date> — see CHANGELOG.md` header with a pointer to the live code/migration, a preserved "kept as historical RFC" italic note so design rationale stays searchable, checklists flipped from `[ ]` to `[x]`, and dropped now-stale `(Week N)` qualifiers, broken pointers to the moved-out 90-day plan, and Track A / Track B vocabulary that referenced the now-private velox-ops repo.

**CHANGELOG.md**
- One new `[Unreleased]` `### Documentation` entry summarising the truth-up.

## Why this shape (industry-grade rationale)

- **Freeze RFCs as historical, don't delete.** Stripe / Vercel / Linear keep design RFCs after shipping with a "Status: Shipped" stamp — searchable rationale, no future reader misled into thinking the work is pending. Deleting them would lose the "why we built it this shape" narrative.
- **Roadmap split (Recently shipped vs In flight).** A single mixed table that includes shipped rows reads as future work to a first-time visitor. Splitting it makes today's reality and the next horizon both explicit.
- **Stale claim removed, not rewritten.** The "Status" blockquote in the README was load-bearing in May; it's misinformation today. Replacing it with a "now shipped!" version would put exactly the noise the post-1.0 README shouldn't carry. The endpoint contract is documented in the OpenAPI spec and the (still-current) blog post — no need for a retroactive blockquote.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `npx tsc --noEmit` (web-v2) — clean.
- [x] No source code touched; pure docs/markdown change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)