### PR TITLE
docs(readme): fix marketplace/Connect positioning line precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Stating these loudly so the wrong customers self-select out:
 
 - **Not for vanilla card-first SaaS** with simple per-seat pricing — Stripe Billing is fine for them.
 - **Not multi-PSP yet** — Stripe is the only payment processor. Razorpay/Adyen come when a paying tenant asks.
-- **Not for marketplaces or Connect** — single-tenant per Velox deployment.
+- **Not for marketplaces or Stripe Connect** — Velox bills the tenant's customers directly; it doesn't split payouts across sub-merchants. (Velox itself is multi-tenant via RLS — many billing tenants per deployment — but each tenant collects on its own behalf, not on behalf of others.)
 - **No Revenue Recognition / Sigma** — bring your own warehouse + dbt.
 - **No Quotes or Subscription Schedules** — sales-led contract billing should pick Recurly or Maxio.
 - **No 50+ payment-method types** — cards via Stripe + send-invoice. ACH/SEPA expand from there.


### PR DESCRIPTION
## Summary

The README's "What Velox is **not**" section had a technically-wrong line:

> Not for marketplaces or Connect — single-tenant per Velox deployment.

Velox **is** multi-tenant (RLS via `tenant_id` is core architecture; per `CLAUDE.md`, every authed request runs in `db.BeginTx(ctx, postgres.TxTenant, tenantID)`). A reader familiar with the codebase trips on the claim; a new reader may walk away thinking one deployment = one company.

The actual constraint being communicated is about Stripe Connect-style **payout splitting** to third-party sub-merchants — that's not supported. Deployment-level multi-tenancy is supported and core.

## Change

```diff
-- **Not for marketplaces or Connect** — single-tenant per Velox deployment.
++ **Not for marketplaces or Stripe Connect** — Velox bills the tenant's customers directly; it doesn't split payouts across sub-merchants. (Velox itself is multi-tenant via RLS — many billing tenants per deployment — but each tenant collects on its own behalf, not on behalf of others.)
```

One line, README only, no behaviour change.

## Test plan

- [x] No source code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)