### PR TITLE
fix(auth): require a platform principal to issue platform keys

### DIFF
--- a/internal/api/respond/errors.go
+++ b/internal/api/respond/errors.go
@@ -80,6 +80,13 @@ func FromError(w http.ResponseWriter, r *http.Request, err error, resource strin
 		}
 		errorField(w, r, http.StatusConflict, "invalid_request_error", c, field, err.Error())
 
+	case errors.Is(err, errs.ErrForbidden):
+		// Authenticated but not permitted → 403. The request is well-formed
+		// and the resource state is fine; the caller's principal simply lacks
+		// authority for this action (e.g. minting a platform key without being
+		// a platform principal).
+		Forbidden(w, r, err.Error())
+
 	case errors.Is(err, errs.ErrValidation):
 		ValidationCoded(w, r, field, code, err.Error())
 

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -226,7 +226,8 @@ func TestLivemodeFromRequest(t *testing.T) {
 
 func TestRequire_PlatformKeyOnlyTenants(t *testing.T) {
 	svc := NewService(newMemStore())
-	result, _ := svc.CreateKey(t.Context(), "t1", CreateKeyInput{Name: "Platform", KeyType: KeyTypePlatform})
+	// Platform keys can only be minted by an existing platform principal.
+	result, _ := svc.CreateKey(WithKeyType(t.Context(), KeyTypePlatform), "t1", CreateKeyInput{Name: "Platform", KeyType: KeyTypePlatform})
 
 	// Should have tenant access
 	handler := Middleware(svc)(Require(PermTenantWrite)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -54,6 +54,21 @@ func (s *Service) CreateKey(ctx context.Context, tenantID string, input CreateKe
 		return CreateKeyResult{}, errs.Invalid("key_type", "must be one of: platform, secret, publishable")
 	}
 
+	// Platform keys are a privileged credential: they carry tenant-management
+	// permissions (PermTenantRead/Write) that reach ACROSS tenants, and the
+	// `tenants` surface they unlock is not RLS-protected. `key_type` arrives
+	// from the request body, and the /v1/api-keys route is reachable by any
+	// secret key or dashboard session (both hold PermAPIKeyWrite, both scoped
+	// to a single tenant). Without this gate a single-tenant principal could
+	// self-mint a platform key and escalate to read/create every tenant.
+	// Treat key_type as privileged: a platform key may only be issued by an
+	// existing platform principal. (The first platform key, if a deployment
+	// ever needs one, is provisioned out-of-band, not over this route.)
+	if keyType == KeyTypePlatform && GetKeyType(ctx) != KeyTypePlatform {
+		return CreateKeyResult{}, errs.Forbidden(
+			"platform keys can only be issued by an existing platform key")
+	}
+
 	// Reject past expires_at — a key that's already expired at creation
 	// is DOA (any auth attempt fails with `api key expired`). Industry
 	// parity (Stripe rejects past expiry on credentials). API keys are

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -166,7 +167,10 @@ func TestCreateKey_Publishable(t *testing.T) {
 func TestCreateKey_Platform(t *testing.T) {
 	svc := NewService(newMemStore())
 
-	result, err := svc.CreateKey(context.Background(), "tenant1", CreateKeyInput{
+	// Platform keys may only be minted by an existing platform principal, so
+	// the caller ctx must carry KeyTypePlatform.
+	ctx := WithKeyType(context.Background(), KeyTypePlatform)
+	result, err := svc.CreateKey(ctx, "tenant1", CreateKeyInput{
 		Name:    "Platform Key",
 		KeyType: KeyTypePlatform,
 	})
@@ -178,6 +182,36 @@ func TestCreateKey_Platform(t *testing.T) {
 	}
 	if result.Key.KeyType != "platform" {
 		t.Errorf("key_type: got %q, want platform", result.Key.KeyType)
+	}
+}
+
+// Regression for the audit critical (velox-ops #1): a non-platform principal
+// (secret key, dashboard session, or no key-type in ctx) must NOT be able to
+// mint a platform key by passing key_type=platform in the request body. Before
+// the fix, any single-tenant secret/session could self-escalate to a platform
+// key and read/create every tenant.
+func TestCreateKey_Platform_RejectedForNonPlatformCaller(t *testing.T) {
+	svc := NewService(newMemStore())
+
+	callers := map[string]context.Context{
+		"no key-type (raw ctx)": context.Background(),
+		"secret key":            WithKeyType(context.Background(), KeyTypeSecret),
+		"dashboard session":     WithKeyType(context.Background(), KeyTypeSession),
+		"publishable key":       WithKeyType(context.Background(), KeyTypePublishable),
+	}
+	for name, ctx := range callers {
+		t.Run(name, func(t *testing.T) {
+			_, err := svc.CreateKey(ctx, "tenant1", CreateKeyInput{
+				Name:    "Escalation attempt",
+				KeyType: KeyTypePlatform,
+			})
+			if err == nil {
+				t.Fatal("expected platform-key creation to be rejected, got nil error")
+			}
+			if !errors.Is(err, errs.ErrForbidden) {
+				t.Errorf("want ErrForbidden (HTTP 403), got %T: %v", err, err)
+			}
+		})
 	}
 }
 
@@ -265,10 +299,14 @@ func TestValidateKey_AllTypes(t *testing.T) {
 	svc := NewService(newMemStore())
 	ctx := context.Background()
 
+	// A platform principal may mint any key type; use it so the platform
+	// iteration passes the privileged-mint guard (secret/publishable are
+	// unrestricted either way).
+	mintCtx := WithKeyType(ctx, KeyTypePlatform)
 	types := []KeyType{KeyTypeSecret, KeyTypePublishable, KeyTypePlatform}
 	for _, kt := range types {
 		t.Run(string(kt), func(t *testing.T) {
-			result, _ := svc.CreateKey(ctx, "tenant1", CreateKeyInput{
+			result, _ := svc.CreateKey(mintCtx, "tenant1", CreateKeyInput{
 				Name:    "Test " + string(kt),
 				KeyType: kt,
 			})

--- a/internal/errs/domain.go
+++ b/internal/errs/domain.go
@@ -145,6 +145,20 @@ func PreconditionFailed(message string) *DomainError {
 	}
 }
 
+// Forbidden marks an authorization denial — the caller is authenticated but
+// not permitted to perform this action (distinct from Invalid, which is bad
+// input, and from a missing-auth 401). Maps to HTTP 403. Use at the service
+// layer when an authz rule must hold regardless of which handler/route the
+// call arrived through, so the rule cannot be bypassed by a future caller.
+//
+//	return errs.Forbidden("platform keys can only be issued by an existing platform key")
+func Forbidden(message string) *DomainError {
+	return &DomainError{
+		Kind:    ErrForbidden,
+		Message: message,
+	}
+}
+
 // Sentinel errors for store and service layers.
 var (
 	ErrNotFound           = errors.New("not found")
@@ -152,6 +166,9 @@ var (
 	ErrDuplicateKey       = errors.New("duplicate key")
 	ErrInvalidState       = errors.New("invalid state")
 	ErrPreconditionFailed = errors.New("precondition failed")
+	// ErrForbidden marks an authorization denial (authenticated but not
+	// permitted). Maps to HTTP 403 via respond.FromError. Prefer errs.Forbidden.
+	ErrForbidden = errors.New("forbidden")
 	// ErrValidation marks an error caused by bad caller input (missing field,
 	// malformed value). New code should prefer errs.Required / errs.Invalid /
 	// errs.AlreadyExists which set Field metadata for the UI. The legacy


### PR DESCRIPTION
## What

Authorization hardening on `POST /v1/api-keys`: a **platform** key may now only be issued by a caller that is already a platform principal.

## Why

Platform keys carry cross-tenant management permissions (`PermTenantRead/Write`), and the `tenants` surface they unlock is intentionally not RLS-scoped. `key_type` is read from the request body, and the api-keys route is reachable by any secret key or dashboard session — both of which are scoped to a single tenant. `CreateKey` did not check the caller's principal before honoring `key_type=platform`, leaving an authorization gap where a single-tenant credential could obtain a platform-scoped key.

## Change

- `auth.CreateKey`: reject `key_type=platform` unless `GetKeyType(ctx) == KeyTypePlatform`. `secret`/`publishable` issuance is unchanged. `PermTenantWrite` is already platform-only, so blocking the self-mint fully closes the path — no redundant route gate added.
- New reusable `errs.Forbidden` → HTTP 403 (the codebase had no *authenticated-but-not-permitted* error kind), wired through `respond.FromError`.
- Regression test: rejection asserted for secret / session / publishable / no-key-type callers.

## Verification

- `go build ./...` ✓ · `go vet` ✓ · `go test ./... -short` ✓ (42 pkgs)
- New `TestCreateKey_Platform_RejectedForNonPlatformCaller` passes; existing platform-key tests updated to mint under a platform principal.

Addresses a finding from the backend security audit (tracked privately per `SECURITY.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)