### PR TITLE
fix(billing): propagate tax errors (cycle-close + threshold) and stop in_advance threshold double-bill

### DIFF
--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -2160,7 +2160,14 @@ func (e *Engine) billOnePeriod(ctx context.Context, sub domain.Subscription) (bo
 	// Coupons removed 2026-05-29 (Phase A1). Discount stays at zero;
 	// AI-native discount intent flows through the credit ledger.
 	var discountCents int64
-	taxApp, _ := e.ApplyTaxToLineItems(ctx, sub.TenantID, sub.CustomerID, invoiceCurrency, subtotal, discountCents, lineItems)
+	taxApp, err := e.ApplyTaxToLineItems(ctx, sub.TenantID, sub.CustomerID, invoiceCurrency, subtotal, discountCents, lineItems)
+	if err != nil {
+		// A tax failure must abort before invoice create/finalize and
+		// before the cycle advances — otherwise a transient DB blip would
+		// finalize a $0 invoice and burn the period. Returning the error
+		// leaves the sub untouched so the next tick retries.
+		return false, fmt.Errorf("apply tax: %w", err)
+	}
 	// In tax-inclusive mode the engine back-calculates net subtotal/discount
 	// from the gross inputs; in exclusive mode these pass through unchanged,
 	// so the caller always reads the authoritative values off the result.

--- a/internal/billing/engine_tax_apply_test.go
+++ b/internal/billing/engine_tax_apply_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/clock"
 	"github.com/sagarsuperuser/velox/internal/tax"
 )
 
@@ -396,5 +398,91 @@ func TestApplyTaxToLineItems_NoProvidersFailsLoudly(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "tax provider resolver not wired") {
 		t.Errorf("error should reference unwired resolver, got: %v", err)
+	}
+}
+
+// TestRunCycle_TaxErrorAbortsBeforeInvoiceAndCycleAdvance is the regression
+// test for the discarded ApplyTaxToLineItems error in billOnePeriod. A tax
+// failure (here: an unwired resolver, the same surface as a transient DB blip
+// resolving provider credentials) MUST abort the cycle close before any
+// invoice is created/finalized and before the billing cycle advances — so the
+// next tick retries against an untouched sub.
+//
+// Pre-fix billOnePeriod read `taxApp, _ :=` and dropped the error, then went
+// on to finalize a $0-tax invoice AND advance the cycle, silently swallowing
+// the failure. With the error captured and propagated, RunCycle surfaces it,
+// no invoice is stored, and the cycle is left untouched.
+func TestRunCycle_TaxErrorAbortsBeforeInvoiceAndCycleAdvance(t *testing.T) {
+	periodStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	nextBilling := periodEnd
+
+	subs := &mockSubs{
+		subs: map[string]domain.Subscription{
+			"sub_1": {
+				ID: "sub_1", TenantID: "t1", CustomerID: "cus_1",
+				Items:  []domain.SubscriptionItem{{PlanID: "pln_1", Quantity: 1}},
+				Status: domain.SubscriptionActive, BillingTime: domain.BillingTimeCalendar,
+				CurrentBillingPeriodStart: &periodStart, CurrentBillingPeriodEnd: &periodEnd,
+				NextBillingAt: &nextBilling,
+			},
+		},
+		cycleUpdated: make(map[string]bool),
+	}
+
+	usage := &mockUsage{totals: map[string]int64{"mtr_api": 1000}}
+
+	pricing := &mockPricing{
+		plans: map[string]domain.Plan{
+			"pln_1": {
+				ID: "pln_1", Name: "Pro Plan", Currency: "USD",
+				BillingInterval: domain.BillingMonthly,
+				BaseAmountCents: 4900,
+				MeterIDs:        []string{"mtr_api"},
+			},
+		},
+		meters: map[string]domain.Meter{
+			"mtr_api": {ID: "mtr_api", Name: "API Calls", Unit: "calls", RatingRuleVersionID: "rrv_api"},
+		},
+		rules: map[string]domain.RatingRuleVersion{
+			"rrv_api": {
+				ID: "rrv_api", RuleKey: "api_calls", Version: 1, Mode: domain.PricingFlat,
+				FlatAmountCents: 100,
+			},
+		},
+	}
+
+	invoices := &mockInvoices{}
+
+	fakeClk := clock.NewFake(periodEnd.Add(time.Nanosecond))
+	// Deliberately do NOT call wireBaseTax — the tax provider resolver is
+	// left unwired so ApplyTaxToLineItems returns an error.
+	engine := NewEngine(subs, usage, pricing, invoices, nil, &mockSettings{}, nil, nil, fakeClk)
+
+	count, errs := engine.RunCycle(context.Background(), 50)
+
+	if len(errs) == 0 {
+		t.Fatal("expected a billing error when tax application fails, got none")
+	}
+	var sawTaxErr bool
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "apply tax") {
+			sawTaxErr = true
+		}
+	}
+	if !sawTaxErr {
+		t.Errorf("expected an 'apply tax' error to surface, got: %v", errs)
+	}
+	if count != 0 {
+		t.Errorf("no invoice should be generated when tax fails, got count=%d", count)
+	}
+	if len(invoices.invoices) != 0 {
+		t.Errorf("no invoice should be stored when tax fails, got %d", len(invoices.invoices))
+	}
+	if len(invoices.lineItems) != 0 {
+		t.Errorf("no line items should be stored when tax fails, got %d", len(invoices.lineItems))
+	}
+	if subs.cycleUpdated["sub_1"] {
+		t.Error("billing cycle must NOT advance when tax fails — the sub must be retried untouched next tick")
 	}
 }

--- a/internal/billing/threshold_scan.go
+++ b/internal/billing/threshold_scan.go
@@ -368,7 +368,15 @@ func (e *Engine) fireThreshold(ctx context.Context, sub domain.Subscription, eva
 	subtotal := eval.RunningSubtotal
 	var discountCents int64
 
-	taxApp, _ := e.ApplyTaxToLineItems(ctx, sub.TenantID, sub.CustomerID, invoiceCurrency, subtotal, discountCents, eval.LineItems)
+	// Propagate tax errors rather than discarding them: a swallowed error
+	// yields a zero-value TaxApplication (TaxStatus="") that finalizes a $0
+	// threshold invoice and permanently consumes the cycle idempotency slot,
+	// leaving the over-threshold usage unbilled. Mirrors the cycle-close and
+	// proration call sites. (audit: velox-ops threshold tax-discard finding)
+	taxApp, err := e.ApplyTaxToLineItems(ctx, sub.TenantID, sub.CustomerID, invoiceCurrency, subtotal, discountCents, eval.LineItems)
+	if err != nil {
+		return false, fmt.Errorf("apply tax: %w", err)
+	}
 	totalWithTax := taxApp.SubtotalCents - taxApp.DiscountCents + taxApp.TaxAmountCents
 
 	netDays := 30

--- a/internal/billing/threshold_scan.go
+++ b/internal/billing/threshold_scan.go
@@ -185,13 +185,42 @@ func (e *Engine) evaluateThresholds(ctx context.Context, sub domain.Subscription
 		return thresholdEval{}, err
 	}
 
+	// in_advance base fees are billed up front by BillOnCreate / cycle close,
+	// so they must NOT count toward the threshold running total or ride along
+	// on the early-finalize invoice — doing so double-bills the prepaid base.
+	// previewWithWindow emits one base_fee line per item (in sub.Items order)
+	// whose plan has BaseAmountCents > 0; mirror that ordering to know each
+	// base_fee preview line's timing. Predicate matches billOnePeriod's base
+	// loop (engine.go base-segment skip). in_arrears base fees and all usage
+	// lines pass through unchanged.
+	inAdvanceBaseTiming := make([]bool, 0, len(sub.Items))
+	for _, it := range sub.Items {
+		plan, err := e.pricing.GetPlan(ctx, sub.TenantID, it.PlanID)
+		if err != nil {
+			return thresholdEval{}, fmt.Errorf("get plan %s: %w", it.PlanID, err)
+		}
+		if plan.BaseAmountCents <= 0 {
+			continue
+		}
+		inAdvanceBaseTiming = append(inAdvanceBaseTiming, plan.BaseBillTiming == domain.BillInAdvance)
+	}
+
 	// Roll up the running subtotal across the previewed lines. Multi-currency
 	// sub already filtered upstream at PATCH time, so we sum across all lines
 	// regardless of per-line currency — there's only one.
 	var running int64
 	currency := ""
+	baseFeeIdx := 0
 	lineItems := make([]domain.InvoiceLineItem, 0, len(preview.Lines))
 	for _, pl := range preview.Lines {
+		if pl.LineType == "base_fee" {
+			isInAdvance := baseFeeIdx < len(inAdvanceBaseTiming) && inAdvanceBaseTiming[baseFeeIdx]
+			baseFeeIdx++
+			if isInAdvance {
+				// Already prepaid — skip from running total and line items.
+				continue
+			}
+		}
 		running += pl.AmountCents
 		if currency == "" {
 			currency = pl.Currency

--- a/internal/billing/threshold_scan_test.go
+++ b/internal/billing/threshold_scan_test.go
@@ -225,6 +225,96 @@ func TestEvaluateThresholds_BelowItemQuantity(t *testing.T) {
 	}
 }
 
+// setupThresholdEngineWithTiming mirrors setupThresholdEngine but lets the
+// caller set the plan's BaseBillTiming so the in_advance double-bill guard
+// can be exercised directly.
+func setupThresholdEngineWithTiming(thresholds *domain.BillingThresholds, usageQty int64, baseTiming domain.BillTiming) (*Engine, *thresholdMockSubs, *mockInvoices) {
+	engine, subs, invoices := setupThresholdEngine(thresholds, usageQty)
+	mp, ok := engine.pricing.(*mockPricing)
+	if !ok {
+		panic("expected *mockPricing")
+	}
+	pln := mp.plans["pln_1"]
+	pln.BaseBillTiming = baseTiming
+	mp.plans["pln_1"] = pln
+	return engine, subs, invoices
+}
+
+// TestEvaluateThresholds_InAdvanceBaseExcluded is the regression test for the
+// double-bill: an in_advance base fee is already billed up front by
+// BillOnCreate / cycle close, so it must NOT count toward the threshold
+// running total or ride along on the early-finalize invoice's line items.
+// Without the guard, running would include the 4900-cent prepaid base and the
+// line items would carry a duplicate base_fee row.
+func TestEvaluateThresholds_InAdvanceBaseExcluded(t *testing.T) {
+	thresholds := &domain.BillingThresholds{
+		AmountGTE:         100000,
+		ResetBillingCycle: true,
+	}
+	// $49 base is in_advance (prepaid); 1000 calls × 100 cents = 100000 usage.
+	engine, _, _ := setupThresholdEngineWithTiming(thresholds, 1000, domain.BillInAdvance)
+
+	sub, _ := engine.subs.Get(context.Background(), "t1", "sub_1")
+	periodStart := *sub.CurrentBillingPeriodStart
+	now := periodStart.AddDate(0, 0, 5)
+
+	eval, err := engine.evaluateThresholds(context.Background(), sub, periodStart, now)
+	if err != nil {
+		t.Fatalf("evaluateThresholds: %v", err)
+	}
+
+	// Running must be usage-only: the prepaid in_advance base is excluded.
+	wantSubtotal := int64(1000 * 100)
+	if eval.RunningSubtotal != wantSubtotal {
+		t.Errorf("running subtotal: got %d, want %d (in_advance base must be excluded)", eval.RunningSubtotal, wantSubtotal)
+	}
+	// No base_fee line should survive — only usage lines.
+	for _, li := range eval.LineItems {
+		if li.LineType == domain.LineTypeBaseFee {
+			t.Errorf("unexpected base_fee line item in threshold eval (in_advance base double-bills): %+v", li)
+		}
+	}
+	// Usage still crosses the cap on its own, so the fire decision is unchanged.
+	if !eval.CrossedAny {
+		t.Error("expected CrossedAny to be true (usage alone crosses the cap)")
+	}
+}
+
+// TestEvaluateThresholds_InArrearsBaseIncluded is the control: an in_arrears
+// base fee is NOT prepaid, so it must still count toward the running total and
+// appear on the early-finalize line items.
+func TestEvaluateThresholds_InArrearsBaseIncluded(t *testing.T) {
+	thresholds := &domain.BillingThresholds{
+		AmountGTE:         100000,
+		ResetBillingCycle: true,
+	}
+	engine, _, _ := setupThresholdEngineWithTiming(thresholds, 1000, domain.BillInArrears)
+
+	sub, _ := engine.subs.Get(context.Background(), "t1", "sub_1")
+	periodStart := *sub.CurrentBillingPeriodStart
+	now := periodStart.AddDate(0, 0, 5)
+
+	eval, err := engine.evaluateThresholds(context.Background(), sub, periodStart, now)
+	if err != nil {
+		t.Fatalf("evaluateThresholds: %v", err)
+	}
+
+	// $49 base (4900) + 1000 calls × 100 cents (100000) = 104900.
+	wantSubtotal := int64(4900 + 1000*100)
+	if eval.RunningSubtotal != wantSubtotal {
+		t.Errorf("running subtotal: got %d, want %d (in_arrears base must be included)", eval.RunningSubtotal, wantSubtotal)
+	}
+	var baseFeeLines int
+	for _, li := range eval.LineItems {
+		if li.LineType == domain.LineTypeBaseFee {
+			baseFeeLines++
+		}
+	}
+	if baseFeeLines != 1 {
+		t.Errorf("base_fee line items: got %d, want 1", baseFeeLines)
+	}
+}
+
 // TestScanThresholds_SkipsTerminalSubs covers the gate that prevents
 // firing on canceled/archived subs. The candidate query in postgres
 // already restricts to active+trialing — this test guards the second-line


### PR DESCRIPTION
Three fixes in the billing engine:
- **Tax-error propagation** — `billOnePeriod` (engine.go) and `fireThreshold` (threshold_scan.go) discarded the `ApplyTaxToLineItems` error, so a tax-calc failure finalized a $0 invoice and advanced the cycle past the period (permanent under-billing). Both now propagate, matching the proration call site.
- **Threshold double-bill** — `evaluateThresholds` summed in_advance base fees already charged by BillOnCreate/cycle-close; now skips `BaseBillTiming == BillInAdvance` base lines.
- Regression tests for both.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)