### PR TITLE
fix(usage): stop under-billing — propagate agg errors, fix last_ever double-count, server-side summary

### DIFF
--- a/internal/usage/aggregation_integration_test.go
+++ b/internal/usage/aggregation_integration_test.go
@@ -170,6 +170,45 @@ func TestAggregateByPricingRules(t *testing.T) {
 		})
 	})
 
+	t.Run("last_ever winner excluded from period buckets (no double-count)", func(t *testing.T) {
+		// Regression: an event whose top-priority matching rule is
+		// last_ever must NOT also be aggregated by a lower-priority
+		// period rule (or the unclaimed default). Before the fix, the
+		// period-bounded query filtered last_ever out of the LATERAL
+		// candidate set, so such events fell through to the next rule
+		// AND were claimed again by the last_ever pass — double-counting.
+		tenantID := testutil.CreateTestTenant(t, db, "Agg LE NoDouble")
+		customerID := insertTestCustomer(t, db, tenantID, "cus_le_dbl")
+		meterID := insertTestMeter(t, db, tenantID, "mtr_le_dbl", "tokens_le_dbl")
+		leverRRV := insertTestRatingRule(t, db, tenantID, "rate_le_dbl")
+		sumRRV := insertTestRatingRule(t, db, tenantID, "rate_sum_dbl")
+
+		// High-priority last_ever rule + lower-priority sum rule, both
+		// matching {model: gpt-4}. The events match BOTH; last_ever wins.
+		insertTestPricingRule(t, db, tenantID, meterID, leverRRV,
+			map[string]any{"model": "gpt-4"}, domain.AggLastEver, 100)
+		insertTestPricingRule(t, db, tenantID, meterID, sumRRV,
+			map[string]any{"model": "gpt-4"}, domain.AggSum, 50)
+
+		now := time.Now()
+		from := now.Add(-2 * time.Hour)
+		to := now.Add(1 * time.Hour)
+
+		ingestAt(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(10), map[string]any{"model": "gpt-4"}, now.Add(-90*time.Minute))
+		ingestAt(t, ctx, store, tenantID, customerID, meterID, decimal.NewFromInt(42), map[string]any{"model": "gpt-4"}, now.Add(-5*time.Minute))
+
+		got, err := store.AggregateByPricingRules(ctx, tenantID, customerID, meterID, domain.AggSum, from, to)
+		if err != nil {
+			t.Fatalf("aggregate: %v", err)
+		}
+		// Only the last_ever bucket should exist (latest event qty=42).
+		// The sum rule and the unclaimed default must be absent — the
+		// events belong solely to last_ever.
+		assertRuleAggregations(t, got, map[string]decimal.Decimal{
+			leverRRV: decimal.NewFromInt(42),
+		})
+	})
+
 	t.Run("priority claim prevents double-count when rules overlap", func(t *testing.T) {
 		tenantID := testutil.CreateTestTenant(t, db, "Agg Priority")
 		customerID := insertTestCustomer(t, db, tenantID, "cus_prio")

--- a/internal/usage/postgres.go
+++ b/internal/usage/postgres.go
@@ -241,7 +241,13 @@ func (s *PostgresStore) AggregateForBillingPeriodByAgg(ctx context.Context, tena
 				WHERE customer_id = $1 AND meter_id = $2 AND timestamp >= $3 AND timestamp < $4
 				ORDER BY timestamp DESC LIMIT 1
 			`, customerID, meterID, from, to).Scan(&val)
-			if err == nil && val.IsPositive() {
+			// Propagate query errors — swallowing them here silently
+			// drops the meter from the billing total (under-billing at
+			// finalize). Only a positive aggregate is a billable line.
+			if err != nil {
+				return nil, fmt.Errorf("aggregate meter %s (%s): %w", meterID, agg, err)
+			}
+			if val.IsPositive() {
 				result[meterID] = val
 			}
 			continue
@@ -253,7 +259,12 @@ func (s *PostgresStore) AggregateForBillingPeriodByAgg(ctx context.Context, tena
 				WHERE customer_id = $1 AND meter_id = $2 AND timestamp >= $3 AND timestamp < $4`,
 				aggFunc),
 			customerID, meterID, from, to).Scan(&val)
-		if err == nil && val.IsPositive() {
+		// Propagate query errors — see the 'last' branch above. A swallowed
+		// error here under-bills the meter at finalize.
+		if err != nil {
+			return nil, fmt.Errorf("aggregate meter %s (%s): %w", meterID, agg, err)
+		}
+		if val.IsPositive() {
 			result[meterID] = val
 		}
 	}
@@ -410,10 +421,17 @@ func (s *PostgresStore) AggregateByPricingRules(
 				rr.rating_rule_version_id AS rating_rule_version_id
 			FROM usage_events e
 			LEFT JOIN LATERAL (
+				-- ALL rules (last_ever included) compete to claim the event,
+				-- so rule_rank picks the true top-priority match. last_ever
+				-- must NOT be filtered out of the candidate set here: if it
+				-- were, an event whose real winner is a last_ever rule would
+				-- fall through to a lower-priority period rule (or the
+				-- unclaimed bucket) AND get claimed again by the last_ever
+				-- pass below — double-counting it. We exclude such events
+				-- from the period buckets after the claim instead.
 				SELECT id, aggregation_mode, rating_rule_version_id, rule_rank
 				FROM ranked_rules
 				WHERE e.properties @> ranked_rules.dimension_match
-				  AND ranked_rules.aggregation_mode <> 'last_ever'
 				ORDER BY rule_rank ASC
 				LIMIT 1
 			) rr ON TRUE
@@ -422,6 +440,10 @@ func (s *PostgresStore) AggregateByPricingRules(
 			  AND e.customer_id = $3
 			  AND e.timestamp >= $4
 			  AND e.timestamp <  $5
+			  -- Events whose winning rule is last_ever belong solely to the
+			  -- last_ever pass; drop them from the period-bounded set so they
+			  -- neither double-count nor leak into the unclaimed default.
+			  AND COALESCE(rr.aggregation_mode, '') <> 'last_ever'
 		)
 		SELECT
 			COALESCE(rule_id, '')                AS rule_id,

--- a/internal/usage/service_test.go
+++ b/internal/usage/service_test.go
@@ -36,7 +36,14 @@ func (m *memStore) Ingest(_ context.Context, tenantID string, e domain.UsageEven
 	return e, nil
 }
 
-func (m *memStore) List(_ context.Context, filter ListFilter) ([]domain.UsageEvent, int, error) {
+// listClamp mirrors the PostgresStore.List cap (it silently clamps the
+// requested limit to 1000). GetSummary must NOT read its totals from
+// List, or any customer with more events than this in the window is
+// under-counted. Keeping the fake honest about the clamp is what makes
+// the GetSummary regression test meaningful.
+const listClamp = 1000
+
+func (m *memStore) matching(filter ListFilter) []domain.UsageEvent {
 	var result []domain.UsageEvent
 	for _, e := range m.events {
 		if e.TenantID != filter.TenantID {
@@ -47,11 +54,35 @@ func (m *memStore) List(_ context.Context, filter ListFilter) ([]domain.UsageEve
 		}
 		result = append(result, e)
 	}
-	return result, len(result), nil
+	return result
 }
 
-func (m *memStore) Aggregate(_ context.Context, _ ListFilter) (Aggregate, error) {
-	return Aggregate{ByMeter: []MeterTotal{}}, nil
+func (m *memStore) List(_ context.Context, filter ListFilter) ([]domain.UsageEvent, int, error) {
+	result := m.matching(filter)
+	total := len(result)
+	if len(result) > listClamp {
+		result = result[:listClamp]
+	}
+	return result, total, nil
+}
+
+// Aggregate reduces the full filtered set server-side (no clamp) — the
+// shape PostgresStore.Aggregate produces via COUNT(*) + GROUP BY SUM.
+func (m *memStore) Aggregate(_ context.Context, filter ListFilter) (Aggregate, error) {
+	events := m.matching(filter)
+	byMeter := make(map[string]decimal.Decimal)
+	order := []string{}
+	for _, e := range events {
+		if _, seen := byMeter[e.MeterID]; !seen {
+			order = append(order, e.MeterID)
+		}
+		byMeter[e.MeterID] = byMeter[e.MeterID].Add(e.Quantity)
+	}
+	agg := Aggregate{TotalEvents: len(events), ByMeter: []MeterTotal{}}
+	for _, id := range order {
+		agg.ByMeter = append(agg.ByMeter, MeterTotal{MeterID: id, Total: byMeter[id]})
+	}
+	return agg, nil
 }
 
 func (m *memStore) AggregateForBillingPeriod(_ context.Context, _, _ string, _ []string, _, _ time.Time) (map[string]decimal.Decimal, error) {
@@ -213,6 +244,42 @@ func TestAggregateByPricingRules_DefaultModeValidation(t *testing.T) {
 			t.Fatalf("empty mode should default to sum: %v", err)
 		}
 	})
+}
+
+// TestGetSummaryServerSideAggregate is the regression guard for the
+// under-count bug: GetSummary used List(Limit:10000), but List clamps to
+// 1000, so a customer with >1000 events in the window reported a truncated
+// total_events AND truncated per-meter quantities. The fix reads from
+// store.Aggregate (full COUNT(*) + GROUP BY SUM). This test ingests more
+// than the clamp and asserts the summary reflects the full set.
+func TestGetSummaryServerSideAggregate(t *testing.T) {
+	store := newMemStore()
+	svc := NewService(store)
+	ctx := context.Background()
+
+	const n = listClamp + 250 // 1250 events, over the List clamp
+	for i := 0; i < n; i++ {
+		if _, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "cus_big", MeterID: "mtr_tokens", Quantity: dec(1),
+		}); err != nil {
+			t.Fatalf("ingest %d: %v", i, err)
+		}
+	}
+
+	from := time.Now().Add(-1 * time.Hour)
+	to := time.Now().Add(1 * time.Hour)
+	summary, err := svc.GetSummary(ctx, "t1", "cus_big", from, to)
+	if err != nil {
+		t.Fatalf("GetSummary: %v", err)
+	}
+
+	if summary.TotalEvents != n {
+		t.Errorf("total_events: got %d, want %d (List-clamped under-count regressed)", summary.TotalEvents, n)
+	}
+	got := summary.Meters["mtr_tokens"]
+	if !got.Equal(dec(int64(n))) {
+		t.Errorf("meter total: got %s, want %d (per-meter quantity truncated)", got.String(), n)
+	}
 }
 
 // TestBackfill exercises the audit-path contract: past timestamp required,

--- a/internal/usage/summary.go
+++ b/internal/usage/summary.go
@@ -24,21 +24,27 @@ type UsageSummary struct {
 }
 
 // GetSummary aggregates usage for a customer in the current billing period.
+//
+// Aggregation is done server-side via store.Aggregate (COUNT(*) +
+// GROUP BY meter_id SUM) over the full filtered set. The previous
+// List(Limit:10000)+Go-reduce undercounted: List clamps the limit to
+// 1000, so any customer with >1000 events in the window reported a
+// truncated total — wrong on both the per-meter quantities and the
+// event count.
 func (s *Service) GetSummary(ctx context.Context, tenantID, customerID string, from, to time.Time) (UsageSummary, error) {
-	events, _, err := s.store.List(ctx, ListFilter{
+	agg, err := s.store.Aggregate(ctx, ListFilter{
 		TenantID:   tenantID,
 		CustomerID: customerID,
 		From:       &from,
 		To:         &to,
-		Limit:      10000,
 	})
 	if err != nil {
 		return UsageSummary{}, err
 	}
 
-	meters := make(map[string]decimal.Decimal)
-	for _, e := range events {
-		meters[e.MeterID] = meters[e.MeterID].Add(e.Quantity)
+	meters := make(map[string]decimal.Decimal, len(agg.ByMeter))
+	for _, m := range agg.ByMeter {
+		meters[m.MeterID] = m.Total
 	}
 
 	return UsageSummary{
@@ -46,7 +52,7 @@ func (s *Service) GetSummary(ctx context.Context, tenantID, customerID string, f
 		PeriodFrom:  from,
 		PeriodTo:    to,
 		Meters:      meters,
-		TotalEvents: len(events),
+		TotalEvents: agg.TotalEvents,
 	}, nil
 }
 


### PR DESCRIPTION
- `AggregateForBillingPeriodByAgg` swallowed per-meter query errors (`err == nil &&`), silently dropping meters from the finalize total → now propagates.
- `last_ever` rules double-counted against period-bounded rules; the candidate set now keeps last_ever for correct rule-ranking and excludes last_ever-won events from the period buckets post-claim.
- `GetSummary` used List(10000)+reduce but List clamps to 1000 (undercount >1000 events); now a server-side COUNT + GROUP BY SUM aggregate.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)