### PR TITLE
fix(payment): record Stripe webhook dedup after the side effect; 5xx on transient failure

### DIFF
--- a/internal/payment/handler.go
+++ b/internal/payment/handler.go
@@ -210,10 +210,16 @@ func (h *Handler) handleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 			"tenant_id", lookup.TenantID,
 			"error", err,
 		)
-		// Return 200 anyway — Stripe will retry on 5xx and we don't want infinite retries
-		// for events we can't process (e.g., missing invoice). Log the error server-side;
-		// don't echo raw error text to the caller (may leak internal details).
-		respond.JSON(w, r, http.StatusOK, map[string]string{"status": "error_logged"})
+		// A returned error is transient by construction: HandleWebhook
+		// already ack's (returns nil) any event it can't ever process —
+		// e.g. one referencing an invoice not in our DB — after recording
+		// it for audit. So the only errors that reach here are retryable
+		// (DB write failure, contention, downstream timeout), and crucially
+		// NO dedup row was persisted for them. Respond 5xx so Stripe
+		// redelivers and the handler re-runs; returning 200 here would let
+		// a transient blip silently drop the event forever. Don't echo the
+		// raw error to Stripe (may leak internal details).
+		respond.InternalError(w, r)
 		return
 	}
 

--- a/internal/payment/handler_test.go
+++ b/internal/payment/handler_test.go
@@ -240,6 +240,89 @@ func TestWebhookHandler_TenantMismatchRejects(t *testing.T) {
 	}
 }
 
+// TestWebhookHandler_TransientFailureRedelivers is the regression test for the
+// silent-drop bug: a transient processing failure used to commit the dedup row
+// FIRST and then return HTTP 200, so Stripe never redelivered and the dedup row
+// short-circuited any retry — the event was lost forever.
+//
+// The fix: on a transient failure the handler writes NO dedup row and returns
+// 5xx, so Stripe redelivers and the (now healthy) handler re-processes.
+func TestWebhookHandler_TransientFailureRedelivers(t *testing.T) {
+	invoices := newMockInvoiceUpdaterH()
+	invoices.invoices["inv_1"] = mockInvoice{
+		id: "inv_1", tenantID: "t1", status: "finalized",
+		paymentStatus: "processing", stripePI: "pi_test_abc",
+	}
+	invoices.byPI["pi_test_abc"] = "inv_1"
+	// First delivery hits a transient DB blip on MarkPaid.
+	invoices.markPaidErr = fmt.Errorf("connection reset by peer")
+
+	webhooks := newMockWebhookStoreHandler()
+	stripeAdapter := NewStripe(nil, invoices, webhooks, nil)
+	secret := "whsec_transient_test"
+	resolver := &stubResolver{rows: map[string]tenantstripe.EndpointLookup{
+		"vlx_spc_abc": {ID: "vlx_spc_abc", TenantID: "t1", Livemode: true, WebhookSecret: secret},
+	}}
+	handler := NewHandler(stripeAdapter, resolver)
+
+	event := map[string]any{
+		"id":       "evt_transient_1",
+		"type":     "payment_intent.succeeded",
+		"created":  time.Now().Unix(),
+		"livemode": true,
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":       "pi_test_abc",
+				"object":   "payment_intent",
+				"status":   "succeeded",
+				"amount":   19900,
+				"currency": "usd",
+				"metadata": map[string]string{
+					"velox_tenant_id":  "t1",
+					"velox_invoice_id": "inv_1",
+				},
+			},
+		},
+	}
+	body, _ := json.Marshal(event)
+
+	send := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest("POST", "/stripe/vlx_spc_abc", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Stripe-Signature", signStripePayload(body, secret))
+		rec := httptest.NewRecorder()
+		handler.Routes().ServeHTTP(rec, req)
+		return rec
+	}
+
+	// First delivery: transient failure must surface as 5xx so Stripe retries.
+	rec := send()
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("transient failure: got status %d, want 500. body: %s", rec.Code, rec.Body.String())
+	}
+	// And it must NOT have been recorded as seen — otherwise the redelivery
+	// is short-circuited as a duplicate and the event is dropped forever.
+	if webhooks.seen["evt_transient_1"] {
+		t.Fatalf("transient failure must not mark the event consumed (would block Stripe redelivery)")
+	}
+	if invoices.invoices["inv_1"].paymentStatus == "succeeded" {
+		t.Fatalf("invoice should not be paid after a failed MarkPaid")
+	}
+
+	// Stripe redelivers the SAME event_id; the blip has cleared.
+	invoices.markPaidErr = nil
+	rec = send()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("redelivery: got status %d, want 200. body: %s", rec.Code, rec.Body.String())
+	}
+	if !webhooks.seen["evt_transient_1"] {
+		t.Fatalf("successful redelivery must record the dedup row")
+	}
+	if got := invoices.invoices["inv_1"].paymentStatus; got != "succeeded" {
+		t.Fatalf("redelivery should settle the invoice: payment_status got %q, want succeeded", got)
+	}
+}
+
 // signStripePayload produces a valid Stripe-Signature header for payload+secret.
 func signStripePayload(payload []byte, secret string) string {
 	ts := fmt.Sprintf("%d", time.Now().Unix())
@@ -256,8 +339,9 @@ type mockInvoice struct {
 }
 
 type mockInvoiceUpdaterHandler struct {
-	invoices map[string]mockInvoice
-	byPI     map[string]string
+	invoices    map[string]mockInvoice
+	byPI        map[string]string
+	markPaidErr error // when set, MarkPaid returns this (simulates a transient DB failure)
 }
 
 func newMockInvoiceUpdaterH() *mockInvoiceUpdaterHandler {
@@ -311,6 +395,9 @@ func (m *mockInvoiceUpdaterHandler) Get(_ context.Context, _, id string) (domain
 }
 
 func (m *mockInvoiceUpdaterHandler) MarkPaid(_ context.Context, _, id string, piID string, paidAt time.Time) (domain.Invoice, error) {
+	if m.markPaidErr != nil {
+		return domain.Invoice{}, m.markPaidErr
+	}
 	inv, ok := m.invoices[id]
 	if !ok {
 		return domain.Invoice{}, fmt.Errorf("not found")
@@ -343,6 +430,10 @@ type mockWebhookStoreH struct {
 
 func newMockWebhookStoreHandler() *mockWebhookStoreH {
 	return &mockWebhookStoreH{seen: make(map[string]bool)}
+}
+
+func (m *mockWebhookStoreH) WasProcessed(_ context.Context, _, stripeEventID string) (bool, error) {
+	return m.seen[stripeEventID], nil
 }
 
 func (m *mockWebhookStoreH) IngestEvent(_ context.Context, _ string, event domain.StripeWebhookEvent) (domain.StripeWebhookEvent, bool, error) {

--- a/internal/payment/stripe.go
+++ b/internal/payment/stripe.go
@@ -148,7 +148,20 @@ type InvoiceUpdater interface {
 }
 
 // WebhookStore persists and queries Stripe webhook events.
+//
+// Dedup is split across two calls so the dedup marker can be written
+// AFTER the business side-effect commits, not before. WasProcessed is
+// the read-only pre-check; IngestEvent is the write that both records
+// the audit row and claims the dedup slot (ON CONFLICT DO NOTHING).
+// HandleWebhook calls IngestEvent only once processing has succeeded
+// (or failed permanently) — a transient processing failure persists no
+// row, so Stripe's redelivery re-runs the handler instead of being
+// short-circuited as a duplicate.
 type WebhookStore interface {
+	// WasProcessed reports whether an event with this stripe_event_id has
+	// already been ingested for the tenant+livemode. Read-only; used as the
+	// idempotency pre-check before running side-effects.
+	WasProcessed(ctx context.Context, tenantID, stripeEventID string) (bool, error)
 	IngestEvent(ctx context.Context, tenantID string, event domain.StripeWebhookEvent) (domain.StripeWebhookEvent, bool, error)
 	ListByInvoice(ctx context.Context, tenantID, invoiceID string) ([]domain.StripeWebhookEvent, error)
 }
@@ -521,18 +534,71 @@ func simulatedFailureAt(inv domain.Invoice) time.Time {
 	return failureAt
 }
 
-// HandleWebhook processes a Stripe webhook event and updates the corresponding invoice.
+// HandleWebhook processes a Stripe webhook event and updates the
+// corresponding invoice.
+//
+// Dedup ordering (the fix): the dedup marker is written AFTER the
+// business side-effect commits, not before. The pre-2026-06 flow
+// committed the dedup row first (IngestEvent's own tx) and then ran the
+// handler — so a transient handler failure left a committed dedup row,
+// the HTTP layer ack'd 200, and Stripe's redelivery short-circuited as
+// a duplicate. The event was silently and permanently dropped.
+//
+// Now:
+//  1. WasProcessed is a read-only idempotency pre-check.
+//  2. processEvent runs the side-effect (MarkPaid / dunning / etc.).
+//  3. On a TRANSIENT failure we persist NO row and return the error —
+//     the HTTP handler turns that into a 5xx so Stripe redelivers and
+//     the handler re-runs. "dedup row exists" now strictly implies
+//     "side-effect committed."
+//  4. On success OR a PERMANENT failure (the event references an entity
+//     that isn't in our DB and never will be — errs.ErrNotFound) we
+//     IngestEvent to persist the audit row + claim the dedup slot, then
+//     ack. Acking a permanent failure is deliberate: redelivering it
+//     forever achieves nothing.
+//
+// Business side-effects on these paths are idempotent (MarkPaid is a
+// no-op on an already-paid invoice; StartDunning is UNIQUE per invoice),
+// so a redelivery that races a slow first delivery and double-processes
+// converges to the same state — the ON CONFLICT DO NOTHING in
+// IngestEvent collapses the duplicate audit row.
 func (s *Stripe) HandleWebhook(ctx context.Context, tenantID string, event domain.StripeWebhookEvent) error {
-	// Persist the event for audit trail (idempotent — returns false if already seen)
-	_, isNew, err := s.webhooks.IngestEvent(ctx, tenantID, event)
+	seen, err := s.webhooks.WasProcessed(ctx, tenantID, event.StripeEventID)
 	if err != nil {
-		return fmt.Errorf("ingest webhook event: %w", err)
+		return fmt.Errorf("webhook dedup pre-check: %w", err)
 	}
-	if !isNew {
+	if seen {
 		slog.Info("duplicate webhook event, skipping", "stripe_event_id", event.StripeEventID)
 		return nil
 	}
 
+	if procErr := s.processEvent(ctx, tenantID, event); procErr != nil {
+		if isTransientWebhookError(procErr) {
+			// No dedup row written — return the error so the HTTP layer
+			// responds 5xx and Stripe redelivers the event.
+			return procErr
+		}
+		// Permanent: record the audit row (and claim the dedup slot) so the
+		// event shows up in history with its outcome, then ack.
+		slog.Warn("webhook permanently unprocessable — acking without retry",
+			"stripe_event_id", event.StripeEventID,
+			"event_type", event.EventType,
+			"error", procErr)
+	}
+
+	// Side-effect committed (or permanently un-processable) — claim the
+	// dedup slot + persist the audit row.
+	if _, _, err := s.webhooks.IngestEvent(ctx, tenantID, event); err != nil {
+		return fmt.Errorf("ingest webhook event: %w", err)
+	}
+	return nil
+}
+
+// processEvent runs the side-effect for one webhook event. Returns nil on
+// success (including no-op event types). A non-nil error is classified by
+// HandleWebhook as transient (redeliver) or permanent (ack) via
+// isTransientWebhookError.
+func (s *Stripe) processEvent(ctx context.Context, tenantID string, event domain.StripeWebhookEvent) error {
 	switch event.EventType {
 	case "payment_intent.succeeded":
 		return s.handlePaymentSucceeded(ctx, tenantID, event)
@@ -554,6 +620,16 @@ func (s *Stripe) HandleWebhook(ctx context.Context, tenantID string, event domai
 		slog.Debug("unhandled webhook event type", "type", event.EventType)
 		return nil
 	}
+}
+
+// isTransientWebhookError reports whether a webhook processing error is
+// worth a Stripe redelivery. A missing target entity (errs.ErrNotFound)
+// is permanent — the event references an invoice/customer that isn't in
+// our DB, and redelivering won't conjure it — so we ack it. Everything
+// else (DB write failure, contention, a downstream timeout) is treated
+// as transient: return it, respond 5xx, let Stripe redeliver.
+func isTransientWebhookError(err error) bool {
+	return !errors.Is(err, errs.ErrNotFound)
 }
 
 // handleSetupIntentSucceeded re-parses the raw payload to pull out the

--- a/internal/payment/stripe_test.go
+++ b/internal/payment/stripe_test.go
@@ -143,14 +143,28 @@ func (m *mockInvoiceUpdater) ApplyCreditNote(_ context.Context, _, id string, am
 }
 
 type mockWebhookStore struct {
-	events map[string]bool
+	events      map[string]bool // stripe_event_id -> ingested (dedup row present)
+	ingestCalls int             // number of IngestEvent invocations
+	ingestErr   error           // when set, IngestEvent returns this error
+	wasProcErr  error           // when set, WasProcessed returns this error
 }
 
 func newMockWebhookStore() *mockWebhookStore {
 	return &mockWebhookStore{events: make(map[string]bool)}
 }
 
+func (m *mockWebhookStore) WasProcessed(_ context.Context, _, stripeEventID string) (bool, error) {
+	if m.wasProcErr != nil {
+		return false, m.wasProcErr
+	}
+	return m.events[stripeEventID], nil
+}
+
 func (m *mockWebhookStore) IngestEvent(_ context.Context, _ string, event domain.StripeWebhookEvent) (domain.StripeWebhookEvent, bool, error) {
+	m.ingestCalls++
+	if m.ingestErr != nil {
+		return domain.StripeWebhookEvent{}, false, m.ingestErr
+	}
 	if m.events[event.StripeEventID] {
 		return event, false, nil
 	}
@@ -523,6 +537,97 @@ func TestHandleWebhook_UnhandledEvent(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unhandled events should not error: %v", err)
+	}
+}
+
+// TestHandleWebhook_TransientFailureNotConsumed is the unit-level regression
+// guard for the silent-drop bug. A transient processing failure (here: a DB
+// blip on MarkPaid surfaced via a missing-then-present invoice) must:
+//   - return the error to the caller (so the HTTP layer responds 5xx), and
+//   - NOT write the dedup row (so Stripe's redelivery re-processes).
+//
+// Before the fix the dedup row was committed BEFORE the business write, so a
+// failed write left the event marked consumed and the redelivery was dropped.
+func TestHandleWebhook_TransientFailureNotConsumed(t *testing.T) {
+	invoices := newMockInvoiceUpdater()
+	invoices.invoices["inv_1"] = domain.Invoice{
+		ID: "inv_1", TenantID: "t1", Status: domain.InvoiceFinalized,
+		PaymentStatus:         domain.PaymentProcessing,
+		StripePaymentIntentID: "pi_transient",
+	}
+	invoices.byPI["pi_transient"] = "inv_1"
+
+	webhooks := newMockWebhookStore()
+	// Force the audit/dedup insert to fail transiently — stands in for any
+	// retryable error on the persistence path.
+	stripe := NewStripe(&mockStripeClient{}, &transientMarkPaidInvoices{mockInvoiceUpdater: invoices}, webhooks, nil)
+
+	event := domain.StripeWebhookEvent{
+		StripeEventID:   "evt_transient",
+		EventType:       "payment_intent.succeeded",
+		PaymentIntentID: "pi_transient",
+	}
+
+	err := stripe.HandleWebhook(context.Background(), "t1", event)
+	if err == nil {
+		t.Fatal("expected transient processing error to surface, got nil")
+	}
+	if webhooks.events["evt_transient"] {
+		t.Fatal("transient failure must not mark the event consumed")
+	}
+	if webhooks.ingestCalls != 0 {
+		t.Fatalf("transient failure must not write a dedup row, got %d IngestEvent calls", webhooks.ingestCalls)
+	}
+
+	// Stripe redelivers; the blip has cleared. The event must re-process.
+	invoices.invoices["inv_1"] = domain.Invoice{
+		ID: "inv_1", TenantID: "t1", Status: domain.InvoiceFinalized,
+		PaymentStatus:         domain.PaymentProcessing,
+		StripePaymentIntentID: "pi_transient",
+	}
+	invoices.byPI["pi_transient"] = "inv_1"
+	stripe = NewStripe(&mockStripeClient{}, invoices, webhooks, nil)
+	if err := stripe.HandleWebhook(context.Background(), "t1", event); err != nil {
+		t.Fatalf("redelivery should succeed: %v", err)
+	}
+	if !webhooks.events["evt_transient"] {
+		t.Fatal("successful redelivery must record the dedup row")
+	}
+	if got := invoices.invoices["inv_1"].PaymentStatus; got != domain.PaymentSucceeded {
+		t.Fatalf("redelivery should settle the invoice: got %q, want succeeded", got)
+	}
+}
+
+// transientMarkPaidInvoices wraps the mock to make MarkPaid fail with a
+// transient (non-ErrNotFound) error.
+type transientMarkPaidInvoices struct {
+	*mockInvoiceUpdater
+}
+
+func (t *transientMarkPaidInvoices) MarkPaid(_ context.Context, _, _ string, _ string, _ time.Time) (domain.Invoice, error) {
+	return domain.Invoice{}, fmt.Errorf("connection reset by peer")
+}
+
+// TestHandleWebhook_PermanentFailureAcked verifies the other half of the
+// classification: an event referencing an invoice that isn't in our DB
+// (errs.ErrNotFound) is permanent — redelivering it forever is pointless — so
+// HandleWebhook acks (returns nil) and records the audit/dedup row.
+func TestHandleWebhook_PermanentFailureAcked(t *testing.T) {
+	invoices := newMockInvoiceUpdater() // empty — no such invoice
+	webhooks := newMockWebhookStore()
+	stripe := NewStripe(&mockStripeClient{}, invoices, webhooks, nil)
+
+	event := domain.StripeWebhookEvent{
+		StripeEventID:   "evt_orphan",
+		EventType:       "payment_intent.succeeded",
+		PaymentIntentID: "pi_orphan",
+	}
+
+	if err := stripe.HandleWebhook(context.Background(), "t1", event); err != nil {
+		t.Fatalf("permanent failure should be ack'd (nil), got: %v", err)
+	}
+	if !webhooks.events["evt_orphan"] {
+		t.Fatal("permanently-unprocessable event should still be recorded for audit + dedup")
 	}
 }
 

--- a/internal/payment/webhook_store.go
+++ b/internal/payment/webhook_store.go
@@ -21,6 +21,41 @@ func NewPostgresWebhookStore(db *postgres.DB) *PostgresWebhookStore {
 	return &PostgresWebhookStore{db: db}
 }
 
+// WasProcessed reports whether an event with this stripe_event_id has
+// already been ingested for the tenant+livemode. Read-only idempotency
+// pre-check used by HandleWebhook before running side-effects; the dedup
+// row itself is written by IngestEvent only after processing succeeds, so
+// "row present" implies "side-effect committed."
+//
+// The (tenant_id, livemode, stripe_event_id) tuple matches IngestEvent's
+// ON CONFLICT target, so this check sees exactly the rows that would block
+// an insert. A concurrent redelivery that passes this read and races into
+// IngestEvent is still de-duplicated by the ON CONFLICT DO NOTHING there;
+// double-processing is safe because the side-effects are idempotent.
+func (s *PostgresWebhookStore) WasProcessed(ctx context.Context, tenantID, stripeEventID string) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return false, err
+	}
+	defer postgres.Rollback(tx)
+
+	livemode := auth.Livemode(ctx)
+
+	var exists bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM stripe_webhook_events
+			WHERE tenant_id = $1 AND livemode = $2 AND stripe_event_id = $3
+		)
+	`, tenantID, livemode, stripeEventID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check webhook event processed: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
 func (s *PostgresWebhookStore) IngestEvent(ctx context.Context, tenantID string, event domain.StripeWebhookEvent) (domain.StripeWebhookEvent, bool, error) {
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {


### PR DESCRIPTION
Inbound Stripe webhook dedup was committed before the business write and returned 200 on a processing error, so a transient failure permanently dropped the event. Now the handler returns 5xx on transient processing failure (Stripe redelivers) and only marks the event processed after the business write. Regression test for the redelivery path.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)