### PR TITLE
fix(creditnote): re-derive allocation at Issue + refuse void of a refunded credit note

### DIFF
--- a/internal/creditnote/postgres.go
+++ b/internal/creditnote/postgres.go
@@ -244,6 +244,30 @@ func (s *PostgresStore) UpdateRefundStatus(ctx context.Context, tenantID, id str
 	return tx.Commit()
 }
 
+// UpdateAllocation persists the three-channel allocation. Issue() calls
+// this when a CN created against a then-unpaid invoice is issued after
+// the invoice became paid — the allocation frozen at Create was all
+// zeros, so Issue re-derives it (default: full credit to balance) and
+// persists the result here so the dashboard and any retry observe the
+// same split Issue acted on.
+func (s *PostgresStore) UpdateAllocation(ctx context.Context, tenantID, id string, refundCents, creditCents, outOfBandCents int64) error {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return err
+	}
+	defer postgres.Rollback(tx)
+
+	_, err = tx.ExecContext(ctx, `
+		UPDATE credit_notes SET refund_amount_cents=$1, credit_amount_cents=$2,
+			out_of_band_amount_cents=$3, updated_at=$4
+		WHERE id=$5`,
+		refundCents, creditCents, outOfBandCents, clock.Now(ctx), id)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *PostgresStore) CreateLineItem(ctx context.Context, tenantID string, item domain.CreditNoteLineItem) (domain.CreditNoteLineItem, error) {
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {

--- a/internal/creditnote/service.go
+++ b/internal/creditnote/service.go
@@ -437,8 +437,10 @@ func (s *Service) CreateRefund(ctx context.Context, tenantID string, input Refun
 	issued, err := s.Issue(ctx, tenantID, cn.ID)
 	if err != nil {
 		// Issue failed after Create succeeded — void the draft so we don't
-		// leave an unusable record. Best-effort: if void itself fails,
-		// surface the original issue error (it's the actionable one).
+		// leave an unusable record. Best-effort: Void deliberately refuses
+		// when the Stripe refund leg already executed (that cash must stay
+		// counted in the over-refund cap), and any other void failure is
+		// non-actionable here. Either way, surface the original issue error.
 		_, _ = s.Void(ctx, tenantID, cn.ID)
 		return domain.CreditNote{}, err
 	}
@@ -482,6 +484,29 @@ func (s *Service) Issue(ctx context.Context, tenantID, id string) (domain.Credit
 	}
 
 	if inv.PaymentStatus == domain.PaymentSucceeded {
+		// Re-derive the three-channel allocation from the CURRENT invoice
+		// state. The allocation persisted at Create is frozen against the
+		// invoice status AT THAT TIME: a CN created while the invoice was
+		// still unpaid (InvoiceFinalized) skips Create's paid-invoice
+		// block entirely, so all three channels land at zero. If that
+		// invoice is then paid BEFORE the CN is issued, this Issue path
+		// sees a paid invoice but a CN with zero allocations — neither the
+		// refund leg nor the credit-grant leg below fires, and the
+		// refund/credit silently vanishes (the CN issues as a no-op).
+		//
+		// Mirror Create's documented paid-invoice default: when the
+		// invoice is now paid and the CN carries zero across all three
+		// channels, grant the full CN total to the customer's credit
+		// balance — the safest fallback (no cash movement, restorable
+		// later). Persist it so the dashboard and any retry see the same
+		// allocation the Issue path acts on.
+		if cn.RefundAmountCents == 0 && cn.CreditAmountCents == 0 && cn.OutOfBandAmountCents == 0 && cn.TotalCents > 0 {
+			cn.CreditAmountCents = cn.TotalCents
+			if err := s.store.UpdateAllocation(ctx, tenantID, id, cn.RefundAmountCents, cn.CreditAmountCents, cn.OutOfBandAmountCents); err != nil {
+				return domain.CreditNote{}, fmt.Errorf("re-derive credit-note allocation at issue: %w", err)
+			}
+		}
+
 		// Invoice already paid — handle based on refund type.
 		//
 		// Idempotency contract (added 2026-05-22 after audit):
@@ -697,6 +722,20 @@ func (s *Service) Void(ctx context.Context, tenantID, id string) (domain.CreditN
 	// To correct a mistake on an issued CN, create a new invoice or adjustment.
 	if cn.Status == domain.CreditNoteIssued {
 		return domain.CreditNote{}, errs.InvalidState("cannot void an issued credit note — issued credit notes are final financial documents")
+	}
+	// Refuse to void a draft CN whose Stripe refund leg already executed.
+	// CreateRefund() voids the draft as a best-effort rollback when Issue()
+	// returns an error — but Issue() persists the Stripe refund_id BEFORE
+	// the credit-grant / tax-reversal steps, so an error after the refund
+	// leg succeeded leaves a draft CN that ALREADY pushed cash back to the
+	// payment method. The over-refund cap in Create()/CreateRefund() sums
+	// RefundAmountCents only over non-voided CNs, so voiding this CN would
+	// drop its executed refund from that ceiling — a later CN could then
+	// refund the same money again (double refund). Keep the CN un-voided so
+	// it stays counted; the operator reconciles the partially-issued CN
+	// (e.g. RetryRefund / re-Issue) instead.
+	if cn.StripeRefundID != "" || cn.RefundStatus == domain.RefundSucceeded {
+		return domain.CreditNote{}, errs.InvalidState("cannot void a credit note whose refund has already been processed — voiding would drop the executed refund from the over-refund cap and allow a duplicate refund. Reconcile the existing refund instead.")
 	}
 	return s.store.UpdateStatus(ctx, tenantID, id, domain.CreditNoteVoided)
 }

--- a/internal/creditnote/service_audit_test.go
+++ b/internal/creditnote/service_audit_test.go
@@ -1,0 +1,199 @@
+package creditnote
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// TestIssue_ReDerivesAllocationWhenInvoicePaidAfterCreate is the regression
+// test for the frozen-allocation bug: a CN created against a still-unpaid
+// (finalized) invoice skips Create's paid-invoice block, so all three
+// allocation channels persist as zero. If that invoice is then PAID before
+// the CN is issued, Issue sees a paid invoice but a CN with zero
+// allocations — pre-fix, neither the refund leg nor the credit-grant leg
+// fired and the CN issued as a silent no-op (the customer's refund/credit
+// vanished). Post-fix, Issue re-derives the allocation from the current
+// invoice state and defaults to a full credit-balance grant (Create's
+// documented paid-invoice default).
+func TestIssue_ReDerivesAllocationWhenInvoicePaidAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	store := newMemStore()
+	invoices := &memInvoiceReader{
+		invoices: map[string]domain.Invoice{
+			"inv_1": {
+				ID:               "inv_1",
+				TenantID:         "t1",
+				CustomerID:       "cus_1",
+				Status:           domain.InvoiceFinalized,
+				PaymentStatus:    domain.PaymentPending,
+				Currency:         "USD",
+				TotalAmountCents: 10000,
+				AmountDueCents:   10000,
+			},
+		},
+	}
+	granter := &fakeCreditGranter{}
+	svc := NewService(store, invoices, nil, granter)
+	ctx := context.Background()
+
+	// Create the CN while the invoice is still unpaid → allocation frozen
+	// at all-zero (the paid-invoice allocation block is skipped).
+	cn, err := svc.Create(ctx, "t1", CreateInput{
+		InvoiceID: "inv_1",
+		Reason:    "Service credit",
+		Lines:     []CreditLineInput{{Description: "adj", Quantity: 1, UnitAmountCents: 4000}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if cn.RefundAmountCents != 0 || cn.CreditAmountCents != 0 || cn.OutOfBandAmountCents != 0 {
+		t.Fatalf("precondition: expected frozen-zero allocation on unpaid-invoice CN, got (%d,%d,%d)",
+			cn.RefundAmountCents, cn.CreditAmountCents, cn.OutOfBandAmountCents)
+	}
+
+	// Invoice gets paid out-of-band before the CN is issued.
+	inv := invoices.invoices["inv_1"]
+	inv.Status = domain.InvoicePaid
+	inv.PaymentStatus = domain.PaymentSucceeded
+	inv.AmountPaidCents = 10000
+	inv.AmountDueCents = 0
+	invoices.invoices["inv_1"] = inv
+
+	issued, err := svc.Issue(ctx, "t1", cn.ID)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if issued.Status != domain.CreditNoteIssued {
+		t.Fatalf("status: got %q, want issued", issued.Status)
+	}
+
+	// The credit-grant leg must have fired for the full CN total. Pre-fix
+	// it did not (allocation was frozen zero) and the refund/credit was
+	// silently dropped.
+	if len(granter.cnCalls) != 1 {
+		t.Fatalf("credit-grant calls: got %d, want 1 (allocation should have been re-derived to a credit grant)", len(granter.cnCalls))
+	}
+	if got := granter.cnCalls[0].input.AmountCents; got != cn.TotalCents {
+		t.Errorf("granted amount: got %d, want %d (full CN total)", got, cn.TotalCents)
+	}
+
+	// The persisted allocation must reflect the re-derived split so the
+	// dashboard and any retry observe what Issue acted on.
+	persisted, err := store.Get(ctx, "t1", cn.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if persisted.CreditAmountCents != cn.TotalCents {
+		t.Errorf("persisted credit_amount_cents: got %d, want %d", persisted.CreditAmountCents, cn.TotalCents)
+	}
+	if persisted.RefundAmountCents != 0 || persisted.OutOfBandAmountCents != 0 {
+		t.Errorf("persisted refund/oob should stay 0; got refund=%d oob=%d",
+			persisted.RefundAmountCents, persisted.OutOfBandAmountCents)
+	}
+}
+
+// TestVoid_RefusesCreditNoteWithExecutedRefund is the regression test for the
+// double-refund bug: Void on a draft CN whose Stripe refund leg already
+// executed would drop that refund from the over-refund cap (Create/CreateRefund
+// sum RefundAmountCents over non-voided CNs only), letting a later CN refund the
+// same money again. Void must refuse when the refund has been processed.
+func TestVoid_RefusesCreditNoteWithExecutedRefund(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("refuses when StripeRefundID present", func(t *testing.T) {
+		store := newMemStore()
+		invoices := &memInvoiceReader{invoices: map[string]domain.Invoice{}}
+		svc := NewService(store, invoices, nil)
+
+		// Draft CN that already carries an executed Stripe refund.
+		cn, err := store.Create(ctx, "t1", domain.CreditNote{
+			InvoiceID:         "inv_1",
+			CustomerID:        "cus_1",
+			Status:            domain.CreditNoteDraft,
+			Reason:            "partial issue",
+			TotalCents:        5000,
+			RefundAmountCents: 5000,
+			RefundStatus:      domain.RefundSucceeded,
+			StripeRefundID:    "re_already_done",
+			Currency:          "USD",
+		})
+		if err != nil {
+			t.Fatalf("seed CN: %v", err)
+		}
+
+		_, err = svc.Void(ctx, "t1", cn.ID)
+		if err == nil {
+			t.Fatal("expected Void to refuse a CN with an executed refund")
+		}
+		if !strings.Contains(err.Error(), "refund") {
+			t.Errorf("error should explain the refund conflict: %q", err.Error())
+		}
+
+		// CN must stay un-voided so its refund keeps counting toward the cap.
+		after, err := store.Get(ctx, "t1", cn.ID)
+		if err != nil {
+			t.Fatalf("Get after refused void: %v", err)
+		}
+		if after.Status == domain.CreditNoteVoided {
+			t.Error("CN was voided despite carrying an executed refund — over-refund cap now under-counts")
+		}
+	})
+
+	t.Run("refuses when RefundStatus succeeded without explicit id", func(t *testing.T) {
+		store := newMemStore()
+		invoices := &memInvoiceReader{invoices: map[string]domain.Invoice{}}
+		svc := NewService(store, invoices, nil)
+
+		cn, err := store.Create(ctx, "t1", domain.CreditNote{
+			InvoiceID:         "inv_2",
+			CustomerID:        "cus_1",
+			Status:            domain.CreditNoteDraft,
+			Reason:            "partial issue",
+			TotalCents:        5000,
+			RefundAmountCents: 5000,
+			RefundStatus:      domain.RefundSucceeded,
+			Currency:          "USD",
+		})
+		if err != nil {
+			t.Fatalf("seed CN: %v", err)
+		}
+
+		if _, err := svc.Void(ctx, "t1", cn.ID); err == nil {
+			t.Fatal("expected Void to refuse a CN whose refund_status is succeeded")
+		}
+	})
+
+	t.Run("still voids a draft with no executed refund", func(t *testing.T) {
+		store := newMemStore()
+		invoices := &memInvoiceReader{invoices: map[string]domain.Invoice{}}
+		svc := NewService(store, invoices, nil)
+
+		cn, err := store.Create(ctx, "t1", domain.CreditNote{
+			InvoiceID:         "inv_3",
+			CustomerID:        "cus_1",
+			Status:            domain.CreditNoteDraft,
+			Reason:            "mistake",
+			TotalCents:        5000,
+			RefundAmountCents: 5000,
+			RefundStatus:      domain.RefundNone,
+			Currency:          "USD",
+		})
+		if err != nil {
+			t.Fatalf("seed CN: %v", err)
+		}
+
+		voided, err := svc.Void(ctx, "t1", cn.ID)
+		if err != nil {
+			t.Fatalf("Void of un-refunded draft should succeed: %v", err)
+		}
+		if voided.Status != domain.CreditNoteVoided {
+			t.Errorf("status: got %q, want voided", voided.Status)
+		}
+	})
+}

--- a/internal/creditnote/service_test.go
+++ b/internal/creditnote/service_test.go
@@ -82,6 +82,18 @@ func (m *memStore) UpdateRefundStatus(_ context.Context, tenantID, id string, st
 	return nil
 }
 
+func (m *memStore) UpdateAllocation(_ context.Context, tenantID, id string, refundCents, creditCents, outOfBandCents int64) error {
+	cn, ok := m.notes[id]
+	if !ok || cn.TenantID != tenantID {
+		return errs.ErrNotFound
+	}
+	cn.RefundAmountCents = refundCents
+	cn.CreditAmountCents = creditCents
+	cn.OutOfBandAmountCents = outOfBandCents
+	m.notes[id] = cn
+	return nil
+}
+
 func (m *memStore) SetTaxTransaction(_ context.Context, tenantID, id, taxTransactionID string) error {
 	cn, ok := m.notes[id]
 	if !ok || cn.TenantID != tenantID {

--- a/internal/creditnote/store.go
+++ b/internal/creditnote/store.go
@@ -12,6 +12,11 @@ type Store interface {
 	List(ctx context.Context, filter ListFilter) ([]domain.CreditNote, error)
 	UpdateStatus(ctx context.Context, tenantID, id string, status domain.CreditNoteStatus) (domain.CreditNote, error)
 	UpdateRefundStatus(ctx context.Context, tenantID, id string, status domain.RefundStatus, stripeRefundID string) error
+	// UpdateAllocation persists the three-channel allocation
+	// (refund / credit / out-of-band). Used by Issue() to re-derive the
+	// allocation from the current invoice state when a CN created against
+	// a then-unpaid invoice is issued after that invoice became paid.
+	UpdateAllocation(ctx context.Context, tenantID, id string, refundCents, creditCents, outOfBandCents int64) error
 	// SetTaxTransaction persists the reversal transaction id returned by
 	// the tax provider at Issue time.
 	SetTaxTransaction(ctx context.Context, tenantID, id string, taxTransactionID string) error


### PR DESCRIPTION
- A credit note created while its invoice was unpaid froze zero allocations; if the invoice was paid before Issue, the refund/credit silently vanished. Issue now re-derives the allocation from the current invoice state (full credit-balance grant when paid + zero-allocated).
- Voiding a draft CN whose Stripe refund already executed dropped it from the over-refund cap (double refund); Void now refuses a CN carrying an executed refund. Regression tests for both.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)