### PR TITLE
fix(customer): pin customer livemode on the public cost-dashboard route

### DIFF
--- a/internal/customer/postgres.go
+++ b/internal/customer/postgres.go
@@ -270,6 +270,7 @@ func (s *PostgresStore) GetByCostDashboardToken(ctx context.Context, token strin
 			COALESCE(cost_dashboard_token, ''),
 			COALESCE(test_clock_id, ''),
 			COALESCE(dunning_policy_id, ''),
+			livemode,
 			created_at, updated_at
 		FROM customers WHERE cost_dashboard_token = $1
 	`, token).Scan(&c.ID, &c.TenantID, &c.ExternalID, &c.DisplayName, &c.Email, &c.Status,
@@ -277,6 +278,7 @@ func (s *PostgresStore) GetByCostDashboardToken(ctx context.Context, token strin
 		&c.CostDashboardToken,
 		&c.TestClockID,
 		&c.DunningPolicyID,
+		&c.Livemode,
 		&c.CreatedAt, &c.UpdatedAt)
 
 	if err == sql.ErrNoRows {

--- a/internal/domain/customer.go
+++ b/internal/domain/customer.go
@@ -81,9 +81,16 @@ type Customer struct {
 	// for customers who never went through any PM flow. Single source
 	// of truth for the mapping since migration 0096; previously lived
 	// on customer_payment_setups (now deprecated).
-	StripeCustomerID string    `json:"stripe_customer_id,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	StripeCustomerID string `json:"stripe_customer_id,omitempty"`
+	// Livemode is the mode the customer row lives in (live vs test).
+	// Hydrated by lookups that resolve a customer outside of any tenant
+	// context (e.g. GetByCostDashboardToken on the public cost-dashboard
+	// route): the caller must pin this onto ctx via postgres.WithLivemode
+	// before any TxTenant read, otherwise the RLS livemode predicate
+	// defaults to live and a test-mode customer's reads return nothing.
+	Livemode  bool      `json:"livemode,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 type BillingProfileStatus string

--- a/internal/usage/cost_dashboard.go
+++ b/internal/usage/cost_dashboard.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
 	"github.com/sagarsuperuser/velox/internal/subscription"
 )
 
@@ -130,6 +131,14 @@ func (a *CostDashboardAssembler) GetByToken(ctx context.Context, token string) (
 	if err != nil {
 		return nil, err
 	}
+
+	// Pin the resolved customer's mode onto ctx before any TxTenant read.
+	// The public cost-dashboard route arrives with no mode set, so the
+	// downstream RLS livemode predicate would default to live — and every
+	// read for a test-mode customer would return nothing (500 in prod).
+	// The token lookup runs under TxBypass and is the only place we learn
+	// the customer's mode, so we propagate it here.
+	ctx = postgres.WithLivemode(ctx, cust.Livemode)
 
 	// Empty-state short-circuit. Without an active sub the usage path
 	// requires an explicit window; we don't have one here so we return

--- a/internal/usage/cost_dashboard_livemode_test.go
+++ b/internal/usage/cost_dashboard_livemode_test.go
@@ -1,0 +1,87 @@
+package usage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/subscription"
+)
+
+// fakeTokenLookup resolves the cost-dashboard token to a fixed customer.
+// It runs under TxBypass in production, so it intentionally does NOT read
+// livemode from ctx — it returns the customer's stored mode instead.
+type fakeTokenLookup struct {
+	cust domain.Customer
+}
+
+func (f fakeTokenLookup) GetByCostDashboardToken(_ context.Context, _ string) (domain.Customer, error) {
+	return f.cust, nil
+}
+
+// recordingLister captures the livemode it was scoped to via ctx, mirroring
+// how a real TxTenant read derives its RLS mode from postgres.Livemode(ctx).
+type recordingLister struct {
+	gotLivemode bool
+	called      bool
+}
+
+func (r *recordingLister) List(ctx context.Context, _ subscription.ListFilter) ([]domain.Subscription, int, error) {
+	r.called = true
+	r.gotLivemode = postgres.Livemode(ctx)
+	return nil, 0, nil
+}
+
+// TestCostDashboard_PinsCustomerLivemode is the regression test for the
+// public cost-dashboard route 500ing for test-mode customers. The route
+// arrives with no livemode on ctx; the assembler must pin the resolved
+// customer's mode before any TxTenant read. Without the pin,
+// postgres.Livemode(ctx) defaults to true (live) and every read for a
+// test-mode customer mismatches the RLS livemode predicate.
+func TestCostDashboard_PinsCustomerLivemode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		custLivemode bool
+	}{
+		{name: "test-mode customer pins livemode=false", custLivemode: false},
+		{name: "live-mode customer pins livemode=true", custLivemode: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lookup := fakeTokenLookup{cust: domain.Customer{
+				ID:       "vlx_cus_test",
+				TenantID: "vlx_ten_test",
+				Livemode: tt.custLivemode,
+			}}
+			lister := &recordingLister{}
+
+			// usageService is never reached: with no active subscriptions
+			// the assembler short-circuits on the no_subscription branch
+			// after pinning livemode, which is exactly the path we assert.
+			a := NewCostDashboardAssembler(lookup, nil, lister)
+
+			// ctx deliberately carries NO livemode — the public route is
+			// unauthenticated and never set one. The fix must pin it from
+			// the resolved customer.
+			_, err := a.GetByToken(context.Background(), "vlx_pcd_whatever")
+			if err != nil {
+				t.Fatalf("GetByToken returned error: %v", err)
+			}
+
+			if !lister.called {
+				t.Fatal("subscription lister was never called; assembler short-circuited before the pinned-ctx read")
+			}
+			if lister.gotLivemode != tt.custLivemode {
+				t.Fatalf("downstream read scoped to livemode=%v, want %v (livemode not pinned from customer)",
+					lister.gotLivemode, tt.custLivemode)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The public cost-dashboard route never pinned livemode, so RLS reads 500'd. The token lookup now surfaces the customer's livemode and pins it on ctx before any tenant-scoped read.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)