### PR TITLE
fix(auth): revoke all sessions on password reset

### DIFF
--- a/internal/session/service.go
+++ b/internal/session/service.go
@@ -84,6 +84,17 @@ func (s *Service) Revoke(ctx context.Context, rawID string) error {
 	return s.store.Revoke(ctx, HashID(rawID))
 }
 
+// RevokeAllForUser revokes every active session belonging to a user.
+// The password-reset flow calls this after the new password is set so
+// a session minted from a stolen cookie can't outlive the credential
+// change. Idempotent — no active sessions is a no-op.
+func (s *Service) RevokeAllForUser(ctx context.Context, userID string) error {
+	if userID == "" {
+		return nil
+	}
+	return s.store.RevokeAllForUser(ctx, userID)
+}
+
 // SetLivemode flips the active mode (test/live) on the cookie session.
 // Same operator switches between modes without re-authenticating; every
 // downstream request inherits the new mode via session.Resolve.

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -22,6 +22,7 @@ type Store interface {
 	Insert(ctx context.Context, s Session) error
 	GetByIDHash(ctx context.Context, idHash string) (Session, error)
 	Revoke(ctx context.Context, idHash string) error
+	RevokeAllForUser(ctx context.Context, userID string) error
 	UpdateLivemode(ctx context.Context, idHash string, livemode bool) error
 }
 
@@ -106,6 +107,29 @@ func (s *postgresStore) Revoke(ctx context.Context, idHash string) error {
 		SET revoked_at = $1
 		WHERE id_hash = $2 AND revoked_at IS NULL
 	`, time.Now().UTC(), idHash); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// RevokeAllForUser revokes every active session for a user in one
+// statement. Backs the password-reset flow: changing the password
+// must invalidate any session a thief minted from a stolen cookie,
+// not let it ride out the 7-day TTL. Uses idx_dashboard_sessions_user
+// (migration 0070). Idempotent — already-revoked rows are skipped by
+// the revoked_at IS NULL guard.
+func (s *postgresStore) RevokeAllForUser(ctx context.Context, userID string) error {
+	tx, err := s.db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		return err
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE dashboard_sessions
+		SET revoked_at = $1
+		WHERE user_id = $2 AND revoked_at IS NULL
+	`, time.Now().UTC(), userID); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -266,10 +266,14 @@ func (h *Handler) checkPasswordResetToken(w http.ResponseWriter, r *http.Request
 }
 
 // confirmPasswordReset validates the reset token, applies the new
-// password, and revokes any active sessions for the user (forces a
-// fresh login). Surface the password-validation error inline (e.g.
-// "must be at least 12 characters") so the dashboard can highlight
-// the field; collapse token failures into a single 422.
+// password, and revokes every active session for the user (forces a
+// fresh login). Revoking matters for the threat the reset is most
+// often run against: a thief who already has a live velox_session
+// cookie. Without the fan-out revoke the stolen cookie would ride out
+// its 7-day TTL even after the operator resets. Surface the
+// password-validation error inline (e.g. "must be at least 12
+// characters") so the dashboard can highlight the field; collapse
+// token failures into a single 422.
 func (h *Handler) confirmPasswordReset(w http.ResponseWriter, r *http.Request) {
 	var req confirmResetReq
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -285,13 +289,24 @@ func (h *Handler) confirmPasswordReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err := h.users.ConsumeResetToken(r.Context(), req.Token, req.Password)
+	u, err := h.users.ConsumeResetToken(r.Context(), req.Token, req.Password)
 	if err != nil {
 		// errs.Invalid (password validation) and errs.NotFound (token
 		// invalid/expired/used) both map cleanly; let respond.FromError
 		// do the routing.
 		respond.FromError(w, r, err, "password_reset")
 		return
+	}
+
+	// Revoke any sessions minted before the reset — including one a
+	// thief opened from a stolen cookie, which is exactly the case the
+	// operator is resetting to shut down. Failure here is logged but
+	// not surfaced: the password is already changed, so the reset
+	// succeeded; we don't want a transient session-store error to make
+	// the operator think it didn't.
+	if revokeErr := h.sessions.RevokeAllForUser(r.Context(), u.ID); revokeErr != nil {
+		slog.Error("session: revoke-all-for-user after password reset failed",
+			"user_id", u.ID, "err", revokeErr)
 	}
 
 	respond.JSON(w, r, http.StatusOK, map[string]string{

--- a/internal/user/passwordreset_revoke_test.go
+++ b/internal/user/passwordreset_revoke_test.go
@@ -1,0 +1,143 @@
+package user
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/platform/clock"
+	"github.com/sagarsuperuser/velox/internal/session"
+)
+
+// fakeUserStore is a minimal in-memory Store that lets the reset flow
+// run end-to-end through user.Service.ConsumeResetToken without a DB.
+// Only the methods the reset path touches are non-trivial; the rest
+// satisfy the interface.
+type fakeUserStore struct {
+	user            domain.User
+	resetTokenHash  string // the single valid token hash
+	consumed        bool
+	setPasswordHash string
+}
+
+func (f *fakeUserStore) Create(ctx context.Context, email, passwordHash string) (domain.User, error) {
+	return domain.User{}, errs.ErrNotFound
+}
+func (f *fakeUserStore) GetByEmail(ctx context.Context, email string) (domain.User, error) {
+	return domain.User{}, errs.ErrNotFound
+}
+func (f *fakeUserStore) GetByID(ctx context.Context, id string) (domain.User, error) {
+	if id == f.user.ID {
+		return f.user, nil
+	}
+	return domain.User{}, errs.ErrNotFound
+}
+func (f *fakeUserStore) TouchLastLogin(ctx context.Context, id string, at time.Time) error {
+	return nil
+}
+func (f *fakeUserStore) Lock(ctx context.Context, id string, until time.Time) error { return nil }
+func (f *fakeUserStore) SetPassword(ctx context.Context, id, passwordHash string) error {
+	f.setPasswordHash = passwordHash
+	return nil
+}
+func (f *fakeUserStore) AttachTenant(ctx context.Context, userID, tenantID, role string) error {
+	return nil
+}
+func (f *fakeUserStore) TenantsForUser(ctx context.Context, userID string) ([]domain.UserTenant, error) {
+	return nil, nil
+}
+func (f *fakeUserStore) CreateResetToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) (domain.PasswordResetToken, error) {
+	return domain.PasswordResetToken{}, nil
+}
+func (f *fakeUserStore) ConsumeResetToken(ctx context.Context, tokenHash string) (string, error) {
+	if f.consumed || tokenHash != f.resetTokenHash {
+		return "", errs.ErrNotFound
+	}
+	f.consumed = true
+	return f.user.ID, nil
+}
+func (f *fakeUserStore) LookupResetToken(ctx context.Context, tokenHash string) (string, error) {
+	if f.consumed || tokenHash != f.resetTokenHash {
+		return "", errs.ErrNotFound
+	}
+	return f.user.ID, nil
+}
+
+// recordingSessionStore satisfies session.Store and records the
+// argument passed to RevokeAllForUser so the test can assert the
+// reset flow actually fans out the revoke.
+type recordingSessionStore struct {
+	revokeAllForUser []string
+}
+
+func (r *recordingSessionStore) Insert(ctx context.Context, s session.Session) error { return nil }
+func (r *recordingSessionStore) GetByIDHash(ctx context.Context, idHash string) (session.Session, error) {
+	return session.Session{}, session.ErrNotFound
+}
+func (r *recordingSessionStore) Revoke(ctx context.Context, idHash string) error { return nil }
+func (r *recordingSessionStore) RevokeAllForUser(ctx context.Context, userID string) error {
+	r.revokeAllForUser = append(r.revokeAllForUser, userID)
+	return nil
+}
+func (r *recordingSessionStore) UpdateLivemode(ctx context.Context, idHash string, livemode bool) error {
+	return nil
+}
+
+// stubEmailSender satisfies the handler's EmailSender dependency; the
+// reset-confirm path under test never calls it.
+type stubEmailSender struct{}
+
+func (stubEmailSender) SendPasswordReset(ctx context.Context, tenantID, email, resetLink string) error {
+	return nil
+}
+
+// TestConfirmPasswordResetRevokesSessions is the regression guard for
+// the defect where a successful password reset left existing sessions
+// (including one minted from a stolen cookie) alive for the full TTL.
+// Without the RevokeAllForUser fan-out wired into confirmPasswordReset
+// this test fails: the session store records zero revoke-all calls.
+func TestConfirmPasswordResetRevokesSessions(t *testing.T) {
+	const (
+		userID    = "usr_reset_target"
+		plaintext = "reset-token-plaintext-0123456789abcdef"
+	)
+
+	userStore := &fakeUserStore{
+		user:           domain.User{ID: userID, Email: "op@example.com"},
+		resetTokenHash: hashResetToken(plaintext),
+	}
+	userSvc := NewService(userStore, clock.Real())
+
+	sessStore := &recordingSessionStore{}
+	sessSvc := session.NewService(sessStore)
+
+	h := NewHandler(userSvc, sessSvc, session.DefaultCookieConfig(), stubEmailSender{}, "")
+
+	body, _ := json.Marshal(confirmResetReq{
+		Token:    plaintext,
+		Password: "a-sufficiently-long-password",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/password-reset/confirm", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 from confirmPasswordReset, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !userStore.consumed {
+		t.Fatal("expected reset token to be consumed")
+	}
+	if got := len(sessStore.revokeAllForUser); got != 1 {
+		t.Fatalf("expected RevokeAllForUser to be called exactly once, got %d call(s)", got)
+	}
+	if sessStore.revokeAllForUser[0] != userID {
+		t.Fatalf("expected RevokeAllForUser(%q), got %q", userID, sessStore.revokeAllForUser[0])
+	}
+}


### PR DESCRIPTION
Password reset never revoked existing sessions, so a previously-stolen session cookie survived the reset until its TTL — and the handler docstring falsely claimed revocation. Adds `RevokeAllForUser` (single UPDATE under the existing index) invoked from the reset-confirm path, and corrects the docstring.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)