### PR TITLE
fix(api): reserve idempotency key before running the handler (close check-then-act race)

### DIFF
--- a/internal/api/middleware/idempotency.go
+++ b/internal/api/middleware/idempotency.go
@@ -23,6 +23,23 @@ import (
 // are rare and the risk of key reuse with different bodies is low.
 const maxIdempotentBodyBytes = 1 << 20 // 1 MiB
 
+// statusPending marks a reserved-but-not-yet-completed idempotency row. The
+// request that claims the key writes this sentinel before running the handler;
+// concurrent requests that find it poll until the owner overwrites it with the
+// real status_code (always > 0). status_code is NOT NULL, so a sentinel value
+// is how "in flight" is encoded without a separate column.
+const statusPending = 0
+
+// idempotencyPollInterval / idempotencyPollTimeout bound how long a losing
+// concurrent request waits for the winning request to store its response
+// before giving up with 409. The timeout is shorter than typical handler
+// budgets — a request that's still pending after this either died mid-flight
+// or is a genuinely slow operation the client should retry, not block on.
+const (
+	idempotencyPollInterval = 25 * time.Millisecond
+	idempotencyPollTimeout  = 5 * time.Second
+)
+
 // Idempotency returns middleware that caches responses for POST/PUT/PATCH
 // requests that include an Idempotency-Key header. If a request with the same
 // key has been processed before, the cached response is returned.
@@ -81,26 +98,28 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 
 			fingerprint := fingerprintRequest(r.Method, r.URL.Path, bodyBytes)
 
-			cached, found, err := getCachedResponse(r.Context(), db, tenantID, key)
+			// RESERVE the key before running the handler. A single INSERT ...
+			// ON CONFLICT DO NOTHING is the serialization point: exactly one
+			// concurrent request with the same (tenant, livemode, key) inserts
+			// the pending row, every other request conflicts. Without this
+			// reserve-before-act step, two simultaneous retries both passed the
+			// old check-then-act read (no row yet) and both ran the side effect
+			// — double credit-grant / double-charge.
+			claimed, err := reserveKey(r.Context(), db, tenantID, key,
+				r.Method, r.URL.Path, fingerprint)
 			if err != nil {
-				// DB error — fail open (don't block the write). An idempotency
-				// check failure shouldn't prevent the actual operation.
+				// DB error on the reserve — fail open (don't block the write).
+				// An idempotency-infra failure shouldn't prevent the actual
+				// operation; this matches the prior read-path fail-open.
 				next.ServeHTTP(w, r)
 				return
 			}
-			if found {
-				// Fingerprint mismatch → key reused with different parameters.
-				// Stripe returns 422 idempotency_error here.
-				if len(cached.Fingerprint) > 0 &&
-					subtle.ConstantTimeCompare(cached.Fingerprint, fingerprint) != 1 {
-					ErrorJSON(w, http.StatusUnprocessableEntity, "idempotency_error",
-						"Keys for idempotent requests can only be used with the same parameters they were first used with.")
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				w.Header().Set("Idempotent-Replayed", "true")
-				w.WriteHeader(cached.StatusCode)
-				_, _ = w.Write(cached.Body)
+			if !claimed {
+				// Someone else owns this key. It either already completed (or is
+				// in flight from a concurrent request). Resolve it the same way
+				// a serial retry would: replay the stored response, 422 on a
+				// fingerprint mismatch, or 409 if it never resolves.
+				replayExistingKey(w, r.Context(), db, tenantID, key, fingerprint)
 				return
 			}
 
@@ -110,6 +129,12 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 				body:           &bytes.Buffer{},
 			}
 			next.ServeHTTP(recorder, r)
+
+			// Finalize the reservation. Run against context.Background (with the
+			// captured livemode) so the write survives a client disconnect — a
+			// dropped connection after the side effect committed must still
+			// persist the response, or the retry re-runs it.
+			bgCtx := postgres.WithLivemode(context.Background(), livemode)
 
 			// Cache 2xx/3xx/4xx/5xx except 409 and 422. The core value of
 			// idempotency is that a transient 500 retry must not re-run side
@@ -124,14 +149,15 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 			// contention clears may legitimately succeed), 422 typically
 			// from input validation (the client usually fixes the body, and
 			// our fingerprint check will flag that as a key-reuse error).
-			// Pinning either would trap the caller.
-			if recorder.statusCode != http.StatusConflict &&
-				recorder.statusCode != http.StatusUnprocessableEntity {
-				bgCtx := postgres.WithLivemode(context.Background(), livemode)
-				storeCachedResponse(bgCtx, db, tenantID, key,
-					r.Method, r.URL.Path, fingerprint,
-					recorder.statusCode, recorder.body.Bytes())
+			// Pinning either would trap the caller — so we DELETE the pending
+			// reservation instead, freeing the key for a clean retry.
+			if recorder.statusCode == http.StatusConflict ||
+				recorder.statusCode == http.StatusUnprocessableEntity {
+				releaseKey(bgCtx, db, tenantID, key)
+				return
 			}
+			finalizeKey(bgCtx, db, tenantID, key,
+				recorder.statusCode, recorder.body.Bytes())
 		})
 	}
 }
@@ -155,55 +181,183 @@ type cachedResponse struct {
 	Fingerprint []byte
 }
 
-func getCachedResponse(ctx context.Context, db *postgres.DB, tenantID, key string) (cachedResponse, bool, error) {
+// reserveKey atomically claims the idempotency key by inserting a pending row
+// (status_code = statusPending) with ON CONFLICT DO NOTHING. It reports whether
+// THIS request won the claim: RowsAffected == 1 → claimed (proceed to handler),
+// 0 → another request already owns the key (replay its outcome). This single
+// statement is the serialization point that prevents two concurrent requests
+// from both executing the side effect.
+//
+// livemode is omitted from the INSERT column list on purpose — the BEFORE
+// INSERT trigger (set_livemode_from_session) stamps it from the tx session, so
+// the row lands in the same mode partition the request runs under. The
+// (tenant_id, livemode, key) primary key is the unique constraint the conflict
+// resolves against.
+func reserveKey(ctx context.Context, db *postgres.DB, tenantID, key, method, path string, fingerprint []byte) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {
-		return cachedResponse{}, false, err
+		return false, err
 	}
 	defer postgres.Rollback(tx)
 
-	var c cachedResponse
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO idempotency_keys (key, tenant_id, http_method, http_path, request_fingerprint, status_code, response_body)
+		VALUES ($1, $2, $3, $4, $5, $6, ''::bytea)
+		ON CONFLICT (tenant_id, livemode, key) DO NOTHING`,
+		key, tenantID, method, path, fingerprint, statusPending,
+	)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		// Conflict: another request holds the key. Nothing to commit.
+		return false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// finalizeKey writes the captured response onto the pending reservation. The
+// owning request always overwrites its own pending row, so an unconditional
+// UPDATE on (tenant_id, key) is correct.
+func finalizeKey(ctx context.Context, db *postgres.DB, tenantID, key string, statusCode int, body []byte) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE idempotency_keys SET status_code = $3, response_body = $4
+		WHERE tenant_id = $1 AND key = $2`,
+		tenantID, key, statusCode, body,
+	); err != nil {
+		return
+	}
+	_ = tx.Commit()
+}
+
+// releaseKey deletes the pending reservation so a key whose handler returned a
+// non-cacheable status (409/422) can be retried cleanly. Without this, the
+// pending row would linger until expiry and every retry would 409.
+func releaseKey(ctx context.Context, db *postgres.DB, tenantID, key string) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM idempotency_keys WHERE tenant_id = $1 AND key = $2 AND status_code = $3`,
+		tenantID, key, statusPending,
+	); err != nil {
+		return
+	}
+	_ = tx.Commit()
+}
+
+// readKey loads the current state of a reserved/completed idempotency row.
+// pending reports whether the owning request hasn't finalized yet
+// (status_code == statusPending). found is false when no live row exists.
+func readKey(ctx context.Context, db *postgres.DB, tenantID, key string) (c cachedResponse, found, pending bool, err error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return cachedResponse{}, false, false, err
+	}
+	defer postgres.Rollback(tx)
+
 	err = tx.QueryRowContext(ctx,
 		`SELECT status_code, response_body, request_fingerprint FROM idempotency_keys
 		WHERE tenant_id = $1 AND key = $2 AND expires_at > now()`,
 		tenantID, key,
 	).Scan(&c.StatusCode, &c.Body, &c.Fingerprint)
 	if errors.Is(err, sql.ErrNoRows) {
-		return c, false, nil
+		return cachedResponse{}, false, false, nil
 	}
 	if err != nil {
-		return c, false, err
+		return cachedResponse{}, false, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return c, false, err
+		return cachedResponse{}, false, false, err
 	}
-	return c, true, nil
+	return c, true, c.StatusCode == statusPending, nil
 }
 
-func storeCachedResponse(ctx context.Context, db *postgres.DB, tenantID, key, method, path string, fingerprint []byte, statusCode int, body []byte) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
-	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
-	if err != nil {
-		return
+// replayExistingKey resolves a request that lost the reserve race. It enforces
+// the fingerprint contract (422 on parameter mismatch), replays the stored
+// response once the owner finalizes, and polls briefly while the owner is still
+// in flight. If the owner never finalizes within the poll window — it died, or
+// the operation is too slow to block on — it returns 409 conflict_idempotency,
+// signaling the client to retry.
+func replayExistingKey(w http.ResponseWriter, ctx context.Context, db *postgres.DB, tenantID, key string, fingerprint []byte) {
+	deadline := time.Now().Add(idempotencyPollTimeout)
+	for {
+		c, found, pending, err := readKey(ctx, db, tenantID, key)
+		if err != nil {
+			// DB error resolving the conflict — fail open is unsafe here
+			// (the side effect may already be running), so surface a 409 the
+			// client retries rather than re-executing the operation.
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A request with this idempotency key is being processed. Please retry.")
+			return
+		}
+		if found && !pending {
+			// Fingerprint mismatch → key reused with different parameters.
+			// Stripe returns 422 idempotency_error here.
+			if len(c.Fingerprint) > 0 &&
+				subtle.ConstantTimeCompare(c.Fingerprint, fingerprint) != 1 {
+				ErrorJSON(w, http.StatusUnprocessableEntity, "idempotency_error",
+					"Keys for idempotent requests can only be used with the same parameters they were first used with.")
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Idempotent-Replayed", "true")
+			w.WriteHeader(c.StatusCode)
+			_, _ = w.Write(c.Body)
+			return
+		}
+		// Not found means the owner released the key (409/422 handler) — the
+		// key is free again, but this request already lost the race; treat it
+		// as a conflict so the client retries into a clean slot rather than
+		// re-running concurrently.
+		if !found {
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A concurrent request with this idempotency key did not complete. Please retry.")
+			return
+		}
+		// Still pending. Wait for the owner to finalize, bounded by the poll
+		// timeout and the request context.
+		if time.Now().After(deadline) {
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A request with this idempotency key is still being processed. Please retry.")
+			return
+		}
+		select {
+		case <-ctx.Done():
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A request with this idempotency key is being processed. Please retry.")
+			return
+		case <-time.After(idempotencyPollInterval):
+		}
 	}
-	defer postgres.Rollback(tx)
-
-	livemode := auth.Livemode(ctx)
-
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO idempotency_keys (key, tenant_id, livemode, http_method, http_path, request_fingerprint, status_code, response_body)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		ON CONFLICT (tenant_id, livemode, key) DO NOTHING`,
-		key, tenantID, livemode, method, path, fingerprint, statusCode, body,
-	); err != nil {
-		return
-	}
-	_ = tx.Commit()
 }
 
 // responseRecorder captures the response for caching while writing to the client.

--- a/internal/api/middleware/idempotency_cache_test.go
+++ b/internal/api/middleware/idempotency_cache_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sagarsuperuser/velox/internal/auth"
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
@@ -136,6 +138,78 @@ func TestIdempotency_FingerprintMismatchStill422(t *testing.T) {
 	}
 	if !strings.Contains(rec2.Body.String(), "idempotency_error") {
 		t.Errorf("mismatch: expected idempotency_error in body, got: %s", rec2.Body.String())
+	}
+}
+
+// TestIdempotency_ConcurrentSameKey_RunsOnce is the regression test for the
+// check-then-act race: two concurrent requests with the same idempotency key
+// must execute the side effect exactly once. Before the reserve-before-act
+// fix, both requests passed the read (no row yet) and both invoked the handler
+// — a double credit-grant / double-charge. With the fix, exactly one request
+// claims the key and runs the handler; the other either replays the stored
+// response or gets a 409 conflict_idempotency, but never re-executes.
+func TestIdempotency_ConcurrentSameKey_RunsOnce(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	tenantID := testutil.CreateTestTenant(t, db, "Idempotency Concurrent")
+
+	var calls atomic.Int64
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Count the side effect (the "credit grant"). Sleep briefly while
+		// holding the claim so the racing request reliably reaches the
+		// conflict path and starts polling — exercising the serialization.
+		calls.Add(1)
+		time.Sleep(150 * time.Millisecond)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"granted"}`))
+	})
+	handler := Idempotency(db)(inner)
+
+	const n = 2
+	var (
+		wg      sync.WaitGroup
+		start   = make(chan struct{})
+		codes   [n]int
+		replays [n]string
+	)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release both goroutines as close to simultaneously as possible
+			rec := invokeWithKey(t, handler, tenantID, "idem-concurrent", `{"amount":100}`)
+			codes[i] = rec.Code
+			replays[i] = rec.Header().Get("Idempotent-Replayed")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// The side effect must have run exactly once.
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent same-key: handler must run exactly once, got %d", got)
+	}
+
+	// Exactly one request executed (201, no replay header). The other must be
+	// either a replay of that 201, or a 409 conflict_idempotency — never a
+	// second fresh execution.
+	executed, replayed, conflicted := 0, 0, 0
+	for i := 0; i < n; i++ {
+		switch {
+		case codes[i] == http.StatusCreated && replays[i] == "":
+			executed++
+		case codes[i] == http.StatusCreated && replays[i] == "true":
+			replayed++
+		case codes[i] == http.StatusConflict:
+			conflicted++
+		default:
+			t.Errorf("request %d: unexpected outcome code=%d replayed=%q", i, codes[i], replays[i])
+		}
+	}
+	if executed != 1 {
+		t.Errorf("exactly one request should have executed fresh, got %d (codes=%v replays=%v)", executed, codes, replays)
+	}
+	if replayed+conflicted != 1 {
+		t.Errorf("the other request should replay or 409, got replayed=%d conflicted=%d (codes=%v)", replayed, conflicted, codes)
 	}
 }
 


### PR DESCRIPTION
The idempotency middleware did check-then-act, so two concurrent same-key requests both executed the side effect. It now reserves the key with a single `INSERT … ON CONFLICT DO NOTHING` (the serialization point) before running the handler; losers replay the stored response (409 if unresolved), and the reservation is released on 409/422 so the key isn't trapped. Concurrency regression test.

Addresses a finding from the backend audit (tracked privately per `SECURITY.md`). Verified: `go build` + `go vet` + package tests (`-short=false`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)