### PR TITLE
fix(credit): make invoice-void credit reversal idempotent

### DIFF
--- a/internal/credit/postgres.go
+++ b/internal/credit/postgres.go
@@ -93,8 +93,8 @@ func (s *PostgresStore) appendEntryInTx(ctx context.Context, tx *sql.Tx, tenantI
 		INSERT INTO customer_credit_ledger (id, tenant_id, customer_id, entry_type,
 			amount_cents, balance_after, description, invoice_id, expires_at, metadata, created_at,
 			source_subscription_id, source_subscription_item_id, source_plan_changed_at, source_change_type,
-			source_credit_note_id)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+			source_credit_note_id, source_invoice_reversal_id)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
 		RETURNING id, tenant_id, customer_id, entry_type, amount_cents, balance_after,
 			description, COALESCE(invoice_id,''), expires_at, metadata, created_at,
 			COALESCE(source_subscription_id,''), COALESCE(source_subscription_item_id,''),
@@ -109,6 +109,7 @@ func (s *PostgresStore) appendEntryInTx(ctx context.Context, tx *sql.Tx, tenantI
 		postgres.NullableTime(entry.SourcePlanChangedAt),
 		postgres.NullableString(string(entry.SourceChangeType)),
 		postgres.NullableString(entry.SourceCreditNoteID),
+		postgres.NullableString(entry.SourceInvoiceReversalID),
 	).Scan(&entry.ID, &entry.TenantID, &entry.CustomerID, &entry.EntryType,
 		&entry.AmountCents, &entry.BalanceAfter, &entry.Description,
 		&entry.InvoiceID, &entry.ExpiresAt, &metaJSON, &entry.CreatedAt,
@@ -134,6 +135,9 @@ func (s *PostgresStore) appendEntryInTx(ctx context.Context, tx *sql.Tx, tenantI
 			case "idx_credit_ledger_credit_note_dedup":
 				return domain.CreditLedgerEntry{}, errs.AlreadyExists("credit_note_source",
 					"credit ledger entry already exists for this credit note").WithCode("credit_note_source_taken")
+			case "idx_credit_ledger_reversal_dedup":
+				return domain.CreditLedgerEntry{}, errs.AlreadyExists("invoice_reversal_source",
+					"credit ledger reversal already exists for this invoice").WithCode("credit_reversal_source_taken")
 			}
 			return domain.CreditLedgerEntry{}, errs.AlreadyExists("",
 				fmt.Sprintf("unique constraint %q violated on credit ledger insert",

--- a/internal/credit/postgres_reverse_test.go
+++ b/internal/credit/postgres_reverse_test.go
@@ -1,0 +1,138 @@
+package credit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/credit"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestReverseForInvoice_IdempotentNoDoubleCredit reproduces the
+// double-credit bug caught in the 2026-06 backend audit: voiding an
+// invoice and then manual-resolving the same invoice's dunning run (or
+// any retry of the void) re-summed the untouched usage rows and
+// re-granted the full applied amount, crediting the customer twice.
+//
+// The fix stamps each reversal grant with source_invoice_reversal_id
+// and enforces one-reversal-per-invoice via the partial unique index
+// idx_credit_ledger_reversal_dedup (migration 0106). A second
+// ReverseForInvoice hits the constraint and is an idempotent no-op.
+func TestReverseForInvoice_IdempotentNoDoubleCredit(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	creditStore := credit.NewPostgresStore(db)
+	svc := credit.NewService(creditStore)
+	invoiceStore := invoice.NewPostgresStore(db)
+	tenantID := testutil.CreateTestTenant(t, db, "Reverse Idempotent")
+
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_reverse_idem", DisplayName: "Reverse Idem",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	// Grant $100, then apply $40 to an invoice — leaves $60 balance and a
+	// usage entry of -$40 linked to the invoice.
+	if _, err := svc.Grant(ctx, tenantID, credit.GrantInput{
+		CustomerID: cust.ID, AmountCents: 10000, Description: "seed",
+	}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	now := time.Now().UTC()
+	dueAt := now.Add(7 * 24 * time.Hour)
+	issuedAt := now
+	inv, err := invoiceStore.Create(ctx, tenantID, domain.Invoice{
+		CustomerID:         cust.ID,
+		Status:             domain.InvoiceDraft,
+		PaymentStatus:      domain.PaymentPending,
+		Currency:           "USD",
+		SubtotalCents:      4000,
+		TotalAmountCents:   4000,
+		AmountDueCents:     4000,
+		BillingPeriodStart: now,
+		BillingPeriodEnd:   now.Add(30 * 24 * time.Hour),
+		IssuedAt:           &issuedAt,
+		DueAt:              &dueAt,
+	})
+	if err != nil {
+		t.Fatalf("create invoice: %v", err)
+	}
+
+	applied, err := svc.ApplyToInvoice(ctx, tenantID, cust.ID, inv.ID, 4000)
+	if err != nil {
+		t.Fatalf("ApplyToInvoice: %v", err)
+	}
+	if applied != 4000 {
+		t.Fatalf("applied: got %d, want 4000", applied)
+	}
+
+	balAfterApply, err := svc.GetBalance(ctx, tenantID, cust.ID)
+	if err != nil {
+		t.Fatalf("get balance after apply: %v", err)
+	}
+	if balAfterApply.BalanceCents != 6000 {
+		t.Fatalf("balance after apply: got %d, want 6000 ($100 - $40)", balAfterApply.BalanceCents)
+	}
+
+	// First reversal: invoice voided. Credits the $40 back → balance $100.
+	reversed, err := svc.ReverseForInvoice(ctx, tenantID, cust.ID, inv.ID, "INV-001")
+	if err != nil {
+		t.Fatalf("first ReverseForInvoice: %v", err)
+	}
+	if reversed != 4000 {
+		t.Errorf("first reversal: got %d, want 4000", reversed)
+	}
+
+	balAfterFirst, err := svc.GetBalance(ctx, tenantID, cust.ID)
+	if err != nil {
+		t.Fatalf("get balance after first reversal: %v", err)
+	}
+	if balAfterFirst.BalanceCents != 10000 {
+		t.Fatalf("balance after first reversal: got %d, want 10000 ($60 + $40 reversed)", balAfterFirst.BalanceCents)
+	}
+
+	// Second reversal: dunning manual-resolve / retry of the same void.
+	// Pre-fix this re-granted another $40 → balance $140. Post-fix it's an
+	// idempotent no-op returning 0 with balance unchanged.
+	reversedAgain, err := svc.ReverseForInvoice(ctx, tenantID, cust.ID, inv.ID, "INV-001")
+	if err != nil {
+		t.Fatalf("second ReverseForInvoice: %v", err)
+	}
+	if reversedAgain != 0 {
+		t.Errorf("second reversal: got %d, want 0 (idempotent no-op)", reversedAgain)
+	}
+
+	balAfterSecond, err := svc.GetBalance(ctx, tenantID, cust.ID)
+	if err != nil {
+		t.Fatalf("get balance after second reversal: %v", err)
+	}
+	if balAfterSecond.BalanceCents != 10000 {
+		t.Errorf("balance after second reversal: got %d, want 10000 (no double-credit)", balAfterSecond.BalanceCents)
+	}
+
+	// Exactly one reversal grant exists for this invoice.
+	tx, err := db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		t.Fatalf("begin bypass tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var reversalGrants int
+	if err := tx.QueryRow(`
+		SELECT count(*) FROM customer_credit_ledger
+		WHERE source_invoice_reversal_id = $1
+	`, inv.ID).Scan(&reversalGrants); err != nil {
+		t.Fatalf("count reversal grants: %v", err)
+	}
+	if reversalGrants != 1 {
+		t.Errorf("reversal grants for invoice: got %d, want 1", reversalGrants)
+	}
+}

--- a/internal/credit/service.go
+++ b/internal/credit/service.go
@@ -256,13 +256,21 @@ func (s *Service) ReverseForInvoice(ctx context.Context, tenantID, customerID, i
 	}
 
 	_, err = s.store.AppendEntry(ctx, tenantID, domain.CreditLedgerEntry{
-		CustomerID:  customerID,
-		EntryType:   domain.CreditGrant,
-		AmountCents: totalUsed,
-		Description: desc,
-		InvoiceID:   invoiceID,
+		CustomerID:              customerID,
+		EntryType:               domain.CreditGrant,
+		AmountCents:             totalUsed,
+		Description:             desc,
+		InvoiceID:               invoiceID,
+		SourceInvoiceReversalID: invoiceID,
 	})
 	if err != nil {
+		// A second void / dunning manual-resolve of the same invoice hits the
+		// partial unique index (migration 0106) and the store returns
+		// ErrAlreadyExists with this code — the reversal already happened, so
+		// this is an idempotent no-op rather than a double-credit.
+		if errs.Code(err) == "credit_reversal_source_taken" {
+			return 0, nil
+		}
 		return 0, err
 	}
 

--- a/internal/domain/credit.go
+++ b/internal/domain/credit.go
@@ -51,6 +51,15 @@ type CreditLedgerEntry struct {
 	// after partial-failure of CN Issue() hits the index, store
 	// returns ErrAlreadyExists, service fetches the existing grant.
 	SourceCreditNoteID string `json:"source_credit_note_id,omitempty"`
+
+	// SourceInvoiceReversalID dedups invoice-void credit reversals. credit.
+	// ReverseForInvoice (invoice void / dunning manual-resolve) stamps the
+	// voided invoice's id here; the partial unique index
+	// idx_credit_ledger_reversal_dedup (migration 0106) enforces one reversal
+	// grant per (tenant, invoice). A second void/resolve of the same invoice
+	// hits the index, the store returns ErrAlreadyExists, and ReverseForInvoice
+	// treats it as an idempotent no-op instead of double-crediting.
+	SourceInvoiceReversalID string `json:"source_invoice_reversal_id,omitempty"`
 }
 
 type CreditBalance struct {

--- a/internal/platform/migrate/sql/0106_credit_reversal_dedup.down.sql
+++ b/internal/platform/migrate/sql/0106_credit_reversal_dedup.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_credit_ledger_reversal_dedup;
+ALTER TABLE customer_credit_ledger DROP COLUMN IF EXISTS source_invoice_reversal_id;

--- a/internal/platform/migrate/sql/0106_credit_reversal_dedup.up.sql
+++ b/internal/platform/migrate/sql/0106_credit_reversal_dedup.up.sql
@@ -1,0 +1,15 @@
+-- 0106: idempotent invoice-void credit reversals.
+--
+-- credit.ReverseForInvoice (invoice void / dunning manual-resolve) summed the
+-- invoice's applied-credit `usage` entries and appended a reversal `grant`
+-- with no dedup. Voiding an invoice and then manual-resolving the same
+-- invoice's dunning run (or any retry of the void) re-summed the untouched
+-- usage rows and re-granted the full amount — double-crediting the customer's
+-- balance. Stamp each reversal grant with the source invoice and enforce
+-- one-reversal-per-invoice with a partial unique index, so a second reversal
+-- hits the constraint and no-ops instead of double-crediting.
+ALTER TABLE customer_credit_ledger ADD COLUMN source_invoice_reversal_id text;
+
+CREATE UNIQUE INDEX idx_credit_ledger_reversal_dedup
+    ON customer_credit_ledger (tenant_id, source_invoice_reversal_id)
+    WHERE source_invoice_reversal_id IS NOT NULL;


### PR DESCRIPTION
## Problem

`credit.ReverseForInvoice` (invoice void / dunning manual-resolve) summed an invoice's applied-credit `usage` entries and appended a reversal `grant` with no dedup key. Voiding an invoice and then manual-resolving the same invoice's dunning run — or any retry of the void — re-summed the untouched usage rows and re-granted the full amount, **double-crediting the customer's balance**.

## Fix

- **Migration 0106** adds `source_invoice_reversal_id` to `customer_credit_ledger` + a partial unique index `idx_credit_ledger_reversal_dedup` on `(tenant_id, source_invoice_reversal_id)`.
- `ReverseForInvoice` stamps the voided invoice's id on the reversal grant.
- The store routes the unique violation to a `credit_reversal_source_taken` code; `ReverseForInvoice` treats it as an idempotent no-op returning `0`.
- Both callers (invoice void handler, dunning manual-resolve) already no-op on a `0` return.

This mirrors the existing proration-dedup and credit-note-dedup patterns (migrations 0026/0027, 0093) — same source-key + partial-unique-index shape.

## Test

`TestReverseForInvoice_IdempotentNoDoubleCredit`: grant $100, apply $40 to an invoice, then call `ReverseForInvoice` twice. First call credits $40 back (balance → $100); second returns `0` with balance unchanged and exactly one reversal grant in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)