### PR TITLE
fix(usage): reject malformed ingest timestamps + aggregate summary server-side

### DIFF
--- a/internal/usage/handler.go
+++ b/internal/usage/handler.go
@@ -120,14 +120,23 @@ func (h *Handler) resolve(ctx context.Context, tenantID string, evt apiEvent) (I
 	}
 
 	if evt.Timestamp != nil {
-		var ts interface{}
-		if err := json.Unmarshal(*evt.Timestamp, &ts); err == nil {
-			if tsStr, ok := ts.(string); ok {
-				if parsed, err := parseTimestamp(tsStr); err == nil {
-					input.Timestamp = &parsed
-				}
-			}
+		// A caller that sends a timestamp means it. Silently discarding a
+		// malformed/non-string value and falling back to wall-clock now
+		// back-dates or future-dates usage into the wrong billing period —
+		// reject it instead, matching the Backfill and getSummary paths.
+		var ts any
+		if err := json.Unmarshal(*evt.Timestamp, &ts); err != nil {
+			return IngestInput{}, errs.Invalid("timestamp", "must be an RFC3339 string, e.g. 2026-05-31T12:00:00Z")
 		}
+		tsStr, ok := ts.(string)
+		if !ok {
+			return IngestInput{}, errs.Invalid("timestamp", "must be an RFC3339 string, e.g. 2026-05-31T12:00:00Z")
+		}
+		parsed, err := parseTimestamp(tsStr)
+		if err != nil {
+			return IngestInput{}, errs.Invalid("timestamp", "must be an RFC3339 string, e.g. 2026-05-31T12:00:00Z")
+		}
+		input.Timestamp = &parsed
 	}
 
 	return input, nil

--- a/internal/usage/resolve_timestamp_test.go
+++ b/internal/usage/resolve_timestamp_test.go
@@ -1,0 +1,91 @@
+package usage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+)
+
+type stubCustomer struct{}
+
+func (stubCustomer) GetByExternalID(_ context.Context, _, _ string) (domain.Customer, error) {
+	return domain.Customer{ID: "cus_1"}, nil
+}
+
+type stubMeter struct{}
+
+func (stubMeter) GetMeterByKey(_ context.Context, _, _ string) (domain.Meter, error) {
+	return domain.Meter{ID: "mtr_1"}, nil
+}
+
+func rawMsg(s string) *json.RawMessage {
+	m := json.RawMessage(s)
+	return &m
+}
+
+// TestResolve_MalformedTimestampRejected covers the medium-severity audit
+// finding: a non-nil but malformed/non-string timestamp was silently
+// discarded and the event stamped at wall-clock now — back-dating or
+// future-dating usage into the wrong billing period with no signal to the
+// caller. A sent timestamp must parse or the ingest is rejected, matching
+// the Backfill and getSummary paths.
+func TestResolve_MalformedTimestampRejected(t *testing.T) {
+	h := NewHandler(NewService(newMemStore()), stubCustomer{}, stubMeter{})
+	ctx := context.Background()
+
+	base := apiEvent{ExternalCustomerID: "cus_ext", EventName: "api_call", Quantity: decimal.NewFromInt(1)}
+
+	t.Run("valid RFC3339 honored", func(t *testing.T) {
+		evt := base
+		evt.Timestamp = rawMsg(`"2026-03-15T10:00:00Z"`)
+		in, err := h.resolve(ctx, "t1", evt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if in.Timestamp == nil || in.Timestamp.Year() != 2026 || in.Timestamp.Month() != 3 {
+			t.Errorf("timestamp not parsed: %v", in.Timestamp)
+		}
+	})
+
+	t.Run("rejected", func(t *testing.T) {
+		cases := map[string]*json.RawMessage{
+			"non-string number": rawMsg(`1716000000`),
+			"non-string object": rawMsg(`{"t":1}`),
+			"unparseable string": rawMsg(`"not-a-date"`),
+			"empty string":       rawMsg(`""`),
+		}
+		for name, ts := range cases {
+			t.Run(name, func(t *testing.T) {
+				evt := base
+				evt.Timestamp = ts
+				_, err := h.resolve(ctx, "t1", evt)
+				if err == nil {
+					t.Fatalf("expected rejection, got nil error")
+				}
+				if !errors.Is(err, errs.ErrValidation) {
+					t.Errorf("expected validation error, got %v", err)
+				}
+				if errs.Field(err) != "timestamp" {
+					t.Errorf("expected field=timestamp, got %q", errs.Field(err))
+				}
+			})
+		}
+	})
+
+	t.Run("absent timestamp ok", func(t *testing.T) {
+		evt := base // Timestamp nil
+		in, err := h.resolve(ctx, "t1", evt)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if in.Timestamp != nil {
+			t.Errorf("expected nil timestamp, got %v", in.Timestamp)
+		}
+	})
+}

--- a/internal/usage/resolve_timestamp_test.go
+++ b/internal/usage/resolve_timestamp_test.go
@@ -55,8 +55,8 @@ func TestResolve_MalformedTimestampRejected(t *testing.T) {
 
 	t.Run("rejected", func(t *testing.T) {
 		cases := map[string]*json.RawMessage{
-			"non-string number": rawMsg(`1716000000`),
-			"non-string object": rawMsg(`{"t":1}`),
+			"non-string number":  rawMsg(`1716000000`),
+			"non-string object":  rawMsg(`{"t":1}`),
 			"unparseable string": rawMsg(`"not-a-date"`),
 			"empty string":       rawMsg(`""`),
 		}

--- a/internal/usage/summary.go
+++ b/internal/usage/summary.go
@@ -24,21 +24,25 @@ type UsageSummary struct {
 }
 
 // GetSummary aggregates usage for a customer in the current billing period.
+//
+// Uses the server-side Aggregate (SUM ... GROUP BY meter_id, COUNT(*)) rather
+// than List-and-reduce: List clamps to 1000 rows, so a customer with more than
+// 1000 events in the window had their summary silently truncated to the newest
+// page — under-reporting both per-meter totals and TotalEvents.
 func (s *Service) GetSummary(ctx context.Context, tenantID, customerID string, from, to time.Time) (UsageSummary, error) {
-	events, _, err := s.store.List(ctx, ListFilter{
+	agg, err := s.store.Aggregate(ctx, ListFilter{
 		TenantID:   tenantID,
 		CustomerID: customerID,
 		From:       &from,
 		To:         &to,
-		Limit:      10000,
 	})
 	if err != nil {
 		return UsageSummary{}, err
 	}
 
-	meters := make(map[string]decimal.Decimal)
-	for _, e := range events {
-		meters[e.MeterID] = meters[e.MeterID].Add(e.Quantity)
+	meters := make(map[string]decimal.Decimal, len(agg.ByMeter))
+	for _, m := range agg.ByMeter {
+		meters[m.MeterID] = m.Total
 	}
 
 	return UsageSummary{
@@ -46,7 +50,7 @@ func (s *Service) GetSummary(ctx context.Context, tenantID, customerID string, f
 		PeriodFrom:  from,
 		PeriodTo:    to,
 		Meters:      meters,
-		TotalEvents: len(events),
+		TotalEvents: agg.TotalEvents,
 	}, nil
 }
 


### PR DESCRIPTION
Two medium-severity backend-audit findings in the usage domain.

## 1. Ingest swallowed malformed timestamps (`handler.go:122`)

A non-nil but malformed or non-string `timestamp` was silently discarded and the event stamped at **wall-clock now** — back-dating or future-dating usage into the wrong billing period with no signal to the caller. Now any unmarshal / type-assertion / parse failure on a *sent* timestamp returns `errs.Invalid("timestamp", "must be an RFC3339 string …")`, matching the Backfill and getSummary paths. Absent timestamp still falls back to now (unchanged).

## 2. GetSummary under-reported usage (`summary.go:33`)

`GetSummary` requested 10000 events but `List` clamps to 1000 rows, so a customer with **>1000 events** in the window had per-meter totals and `TotalEvents` silently truncated to the newest page. Replaced the List-and-reduce with the existing server-side `Aggregate` (`SUM(quantity) GROUP BY meter_id`, `COUNT(*)`) — unbounded, decimal-precision.

## Test

`TestResolve_MalformedTimestampRejected`: valid RFC3339 honored; non-string number / object, unparseable string, and empty string all rejected with a `timestamp` validation error; absent timestamp ok. Full usage suite (incl. integration) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)