### PR TITLE
fix(auth): stop deriving password-reset link origin from request headers

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -893,7 +893,7 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	// hits a 404 when clicking the email.
 	dashboardBaseURL := strings.TrimSpace(os.Getenv("DASHBOARD_BASE_URL"))
 	if dashboardBaseURL == "" {
-		slog.Warn("DASHBOARD_BASE_URL NOT SET — password-reset links will use the API server's Host header. Fine for single-origin prod (api + dashboard share a domain), but for split-origin dev set this to the dashboard SPA URL (e.g. http://localhost:5173).")
+		slog.Warn("DASHBOARD_BASE_URL NOT SET — password-reset emails will NOT be sent (the reset link origin is never derived from request headers, to prevent host-header poisoning / token theft). Set this to your canonical dashboard URL (e.g. http://localhost:5173 in dev) to enable password-reset emails.")
 	}
 	dashboardAuthH := user.NewHandler(
 		userSvc, sessionSvc, session.DefaultCookieConfig(),

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -231,8 +231,15 @@ func (h *Handler) requestPasswordReset(w http.ResponseWriter, r *http.Request) {
 		// email is on file, you'll get a link" to avoid email
 		// enumeration. SMTP misconfiguration shows up as a logged
 		// SendPasswordReset error.
-		resetLink := h.buildResetLink(r, plaintext)
-		if sendErr := h.email.SendPasswordReset(r.Context(), tenantID, req.Email, resetLink); sendErr != nil {
+		resetLink, ok := h.buildResetLink(plaintext)
+		if !ok {
+			// DASHBOARD_BASE_URL is unset. Refuse to derive the link origin
+			// from the request Host header — a poisoned Host would email the
+			// victim a reset link pointing at an attacker domain, leaking the
+			// token. Fail safe: don't send a poisonable link. Operator must
+			// set DASHBOARD_BASE_URL to enable password-reset emails.
+			slog.Error("password reset email not sent: DASHBOARD_BASE_URL is unset; refusing to build a reset link from request headers", "tenant_id", tenantID)
+		} else if sendErr := h.email.SendPasswordReset(r.Context(), tenantID, req.Email, resetLink); sendErr != nil {
 			slog.Error("password reset email send failed", "err", sendErr)
 		}
 	}
@@ -300,25 +307,17 @@ func (h *Handler) confirmPasswordReset(w http.ResponseWriter, r *http.Request) {
 }
 
 // buildResetLink constructs the operator-facing URL for the reset
-// confirmation page. When DASHBOARD_BASE_URL is set (split-origin
-// deployments — typical local dev where the SPA on :5173 and the
-// API on :8080 are different origins) it's used as the base. Otherwise
-// falls back to the request's Host header — correct for single-origin
-// prod deployments where the API and SPA share a domain.
-func (h *Handler) buildResetLink(r *http.Request, token string) string {
-	if h.dashboardBaseURL != "" {
-		return h.dashboardBaseURL + "/reset-password?token=" + token
+// confirmation page from the configured DASHBOARD_BASE_URL. It never
+// derives the origin from the request (Host header, X-Forwarded-Proto):
+// a password-reset link is a security-token carrier, and a poisoned Host
+// header would let an attacker email the victim a link pointing at their
+// own domain to capture the token. Returns ok=false when
+// DASHBOARD_BASE_URL is unset so the caller can fail safe rather than
+// send a poisonable link. Single-origin prod deployments still set
+// DASHBOARD_BASE_URL to their canonical dashboard URL.
+func (h *Handler) buildResetLink(token string) (string, bool) {
+	if h.dashboardBaseURL == "" {
+		return "", false
 	}
-	scheme := "https"
-	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
-		scheme = "http"
-	}
-	return scheme + "://" + r.Host + "/reset-password?token=" + token
+	return h.dashboardBaseURL + "/reset-password?token=" + token, true
 }
-
-// (Email integration deferred — internal/email's surface is built
-// for tenant-scoped invoice/dunning email delivery via outbox+
-// dispatcher and doesn't yet expose a simple SendRaw call. v1
-// password-reset emits the reset link to server logs; operators
-// retrieve it from there. Production deployments will wire a real
-// EmailSender once internal/email exposes the right surface.)

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -27,7 +27,7 @@ type Handler struct {
 	sessions         *session.Service
 	cookie           session.CookieConfig
 	email            EmailSender // required — production always wires the adapter
-	dashboardBaseURL string      // optional; overrides r.Host for reset links (split-origin dev)
+	dashboardBaseURL string      // canonical dashboard origin for reset links; never from request headers. empty => reset emails disabled
 }
 
 // EmailSender is the narrow surface this handler uses to dispatch
@@ -40,11 +40,12 @@ type EmailSender interface {
 }
 
 // NewHandler wires the dependencies. emailSender is required —
-// password-reset requests will nil-panic if it's nil. dashboardBaseURL
-// is optional; when empty, reset-link URLs are built from the request's
-// Host header (works for single-origin prod deployments where the API
-// and SPA share a domain). For split-origin dev (Vite on :5173 vs API
-// on :8080) set DASHBOARD_BASE_URL so the link points at the SPA.
+// password-reset requests will nil-panic if it's nil. dashboardBaseURL is
+// the canonical dashboard origin used to build password-reset links; it is
+// never derived from the request (Host header) to prevent host-header
+// poisoning / token theft. When empty, password-reset emails are not sent
+// (requestPasswordReset fails safe). Set it to your dashboard URL — in
+// split-origin dev (Vite on :5173 vs API on :8080) that's the SPA URL.
 func NewHandler(users *Service, sessions *session.Service, cookie session.CookieConfig, emailSender EmailSender, dashboardBaseURL string) *Handler {
 	return &Handler{
 		users:            users,

--- a/internal/user/reset_link_test.go
+++ b/internal/user/reset_link_test.go
@@ -1,0 +1,33 @@
+package user
+
+import "testing"
+
+// TestBuildResetLink covers the medium-severity [security] audit finding:
+// the password-reset link origin was derived from the request Host header,
+// so a poisoned Host would email the victim a link pointing at an attacker
+// domain, leaking the single-use reset token. The fix removes the request
+// parameter entirely — the link can only come from the configured
+// DASHBOARD_BASE_URL — so header poisoning is structurally impossible.
+func TestBuildResetLink(t *testing.T) {
+	t.Run("uses configured base url", func(t *testing.T) {
+		h := &Handler{dashboardBaseURL: "https://app.velox.dev"}
+		link, ok := h.buildResetLink("tok_abc")
+		if !ok {
+			t.Fatal("expected ok=true when base url is set")
+		}
+		if link != "https://app.velox.dev/reset-password?token=tok_abc" {
+			t.Errorf("unexpected link: %q", link)
+		}
+	})
+
+	t.Run("fails safe when base url unset", func(t *testing.T) {
+		h := &Handler{dashboardBaseURL: ""}
+		link, ok := h.buildResetLink("tok_abc")
+		if ok {
+			t.Error("expected ok=false when base url is unset (no header fallback)")
+		}
+		if link != "" {
+			t.Errorf("expected empty link, got %q", link)
+		}
+	})
+}


### PR DESCRIPTION
Medium-severity **[security]** backend-audit finding (`user/handler.go:316`).

## Problem

`buildResetLink` fell back to the request **Host header** (and `X-Forwarded-Proto`) when `DASHBOARD_BASE_URL` was unset. Password-reset emails are now wired (`SendPasswordReset` is called), so a poisoned `Host` header would email the victim a reset link pointing at an **attacker domain** — capturing the single-use reset token and enabling account takeover. (The "email integration deferred / link goes to logs" comment was stale.)

## Fix

`buildResetLink` no longer accepts the request at all — the link can only be built from the configured `DASHBOARD_BASE_URL`, so header poisoning is **structurally impossible**. When the env is unset it returns `ok=false` and `requestPasswordReset` **fails safe**: logs an error and sends nothing, rather than a poisonable link — while still returning the generic `200` that prevents account enumeration.

Updated the boot warning to match the new behavior (reset emails disabled, not Host-derived) and removed the stale comment.

## Test

`TestBuildResetLink`: configured base URL produces the canonical link; unset base URL returns `ok=false` with an empty link (no header fallback path exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)