### PR TITLE
fix(subscription): correct negative proration rounding + defer zero-tax to draft

### DIFF
--- a/internal/platform/money/round.go
+++ b/internal/platform/money/round.go
@@ -16,20 +16,30 @@ package money
 // out to zero bias. IEEE 754 default, Python 3's round(), .NET decimal, and
 // most financial/GAAP-adjacent systems use this rule.
 //
-// Requires num >= 0 and denom > 0; billing amounts are always non-negative.
+// Requires denom > 0. num may be negative — downgrade/quantity-reduction
+// proration passes a negative numerator. The rounding operates on the
+// magnitude and reapplies the sign so negatives round symmetrically (half to
+// even on the absolute value). Without this, Go's truncate-toward-zero integer
+// division rounded every negative result toward zero, understating proration
+// credits by up to 1 cent. Positive numerators are unaffected.
 func RoundHalfToEven(num, denom int64) int64 {
+	sign := int64(1)
+	if num < 0 {
+		sign = -1
+		num = -num
+	}
 	quotient := num / denom
 	remainder := num % denom
 	doubled := remainder * 2
 	switch {
 	case doubled < denom:
-		return quotient
+		return sign * quotient
 	case doubled > denom:
-		return quotient + 1
+		return sign * (quotient + 1)
 	default:
 		if quotient%2 == 0 {
-			return quotient
+			return sign * quotient
 		}
-		return quotient + 1
+		return sign * (quotient + 1)
 	}
 }

--- a/internal/platform/money/round_test.go
+++ b/internal/platform/money/round_test.go
@@ -21,6 +21,18 @@ func TestRoundHalfToEven(t *testing.T) {
 		// 2 under banker's. Guards against regression to math.Round-equivalent.
 		{"banker's diverges from half-up at 2.5", 25, 10, 2},
 		{"banker's diverges from half-up at 4.5", 45, 10, 4},
+
+		// Negative numerators (downgrade / quantity-reduction proration credits).
+		// Pre-fix these truncated toward zero, understating the credit by up to
+		// 1 cent. Must mirror the positive cases by magnitude with the sign
+		// reapplied (half to even on the absolute value).
+		{"negative clean division", -100, 10, -10},
+		{"negative round down below half", -19, 10, -2},
+		{"negative round up above half", -21, 10, -2},
+		{"negative tie → even (-2.5 stays -2)", -25, 10, -2},
+		{"negative tie → even (-3.5 bumps to -4)", -35, 10, -4},
+		{"negative tie → even (-4.5 stays -4)", -45, 10, -4},
+		{"negative identity", -42, 1, -42},
 	}
 
 	for _, tc := range cases {

--- a/internal/subscription/handler.go
+++ b/internal/subscription/handler.go
@@ -1604,8 +1604,14 @@ func (h *Handler) handleItemProration(ctx context.Context, tenantID string, sub 
 		if h.tax != nil {
 			r, err := h.tax.ApplyTaxToLineItems(ctx, tenantID, sub.CustomerID, effectivePlan.Currency, proratedCents, discountCents, lineItems)
 			if err != nil {
-				slog.WarnContext(ctx, "tax apply failed on proration, proceeding with zero tax",
+				// Transient tax-infra failure. Do NOT finalize with zero tax —
+				// that ships an invoice lying about authoritative amounts.
+				// Mark pending so InvoiceFinalizationStatus stamps Draft and the
+				// tax retry worker re-runs calculation (same contract as the
+				// engine's billOnePeriod / BillOnCreate paths).
+				slog.WarnContext(ctx, "tax apply failed on proration, deferring invoice to draft for retry",
 					"error", err, "subscription_id", sub.ID)
+				taxResult.TaxStatus = domain.InvoiceTaxPending
 			} else {
 				taxResult = r
 			}

--- a/internal/subscription/handler_test.go
+++ b/internal/subscription/handler_test.go
@@ -473,6 +473,60 @@ func TestUpdateItem_ProrationAppliesTax(t *testing.T) {
 	}
 }
 
+// TestUpdateItem_ProrationTaxErrorDefersToDraft covers the medium-severity
+// audit finding: when ApplyTaxToLineItems returns a non-nil (transient infra)
+// error, the proration invoice must NOT finalize with zero tax — it would ship
+// an invoice lying about authoritative amounts. Instead the invoice is stamped
+// Draft with tax_status=pending so the tax retry worker re-runs calculation.
+func TestUpdateItem_ProrationTaxErrorDefersToDraft(t *testing.T) {
+	ctx := context.Background()
+	tenantID := "t1"
+
+	store := newMemStore()
+	subID, itemID := seedSubWithItem(t, store, tenantID, "cus_1", "plan_old")
+	svc := NewService(store, nil)
+
+	plans := &plansMock{plans: map[string]domain.Plan{
+		"plan_old": {ID: "plan_old", Name: "Basic", BaseAmountCents: 1000, Currency: "USD", BaseBillTiming: domain.BillInAdvance},
+		"plan_new": {ID: "plan_new", Name: "Pro", BaseAmountCents: 3000, Currency: "USD", BaseBillTiming: domain.BillInAdvance},
+	}}
+	invoices := &invoicesMock{
+		sourceInvoice: domain.Invoice{ID: "src_inv", PaymentStatus: domain.PaymentSucceeded},
+	}
+	credits := &creditsMock{}
+	taxMock := &prorationTaxApplierMock{err: errors.New("stripe tax: 503 service unavailable")}
+
+	h := NewHandler(svc)
+	h.SetProrationDeps(plans, invoices, credits)
+	h.SetProrationTaxApplier(taxMock)
+
+	body, _ := json.Marshal(UpdateItemInput{NewPlanID: "plan_new", Immediate: true})
+	req := updateItemURL(context.WithValue(ctx, auth.TestTenantIDKey(), tenantID), subID, itemID, body)
+
+	rr := httptest.NewRecorder()
+	h.updateItem(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200. body=%s", rr.Code, rr.Body.String())
+	}
+	if taxMock.calls != 1 {
+		t.Errorf("tax applier called %d times, want 1", taxMock.calls)
+	}
+	if len(invoices.createdInvoices) != 1 {
+		t.Fatalf("got %d invoices, want 1", len(invoices.createdInvoices))
+	}
+	inv := invoices.createdInvoices[0]
+	if inv.TaxStatus != domain.InvoiceTaxPending {
+		t.Errorf("invoice TaxStatus = %q, want %q (defer for retry)", inv.TaxStatus, domain.InvoiceTaxPending)
+	}
+	if inv.Status != domain.InvoiceDraft {
+		t.Errorf("invoice Status = %q, want %q (not finalized with zero tax)", inv.Status, domain.InvoiceDraft)
+	}
+	if inv.TaxAmountCents != 0 {
+		t.Errorf("invoice TaxAmountCents = %d, want 0 (no tax computed yet)", inv.TaxAmountCents)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Event dispatch tests — P0 #2. Design partners building on Velox need a
 // webhook stream for subscription lifecycle the same way Stripe customers


### PR DESCRIPTION
Two medium-severity backend-audit findings in the proration path.

## 1. Negative proration rounding understated credits by 1 cent (`handler.go:1541`)

`money.RoundHalfToEven` assumed a non-negative numerator. Go's integer division truncates toward zero, so for the **negative** numerator a downgrade / quantity-reduction proration produces, the `doubled < denom` branch always fired → the result rounded toward zero, understating the credit by up to 1 cent. Made the helper **sign-symmetric**: round half-to-even on the magnitude, reapply the sign. Every other caller (tax, billing base fees) passes a positive numerator and is unaffected.

## 2. Proration invoice finalized with zero tax on infra error (`handler.go:1606`)

When `ApplyTaxToLineItems` returned a transient (non-nil) error, `taxResult.TaxStatus` stayed `""`, so `InvoiceFinalizationStatus` stamped **Finalized** — shipping an invoice that lies about authoritative amounts. The error branch now sets `TaxStatus = pending`, so the invoice is created **Draft** and the tax retry worker re-runs calculation — the same no-silent-zero-tax contract the engine's `billOnePeriod` / `BillOnCreate` paths already enforce.

## Tests

- `TestRoundHalfToEven`: seven negative-numerator cases mirroring the positive ones by magnitude.
- `TestUpdateItem_ProrationTaxErrorDefersToDraft`: applier error → invoice `Draft` + `tax_status=pending` + zero tax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)