### PR TITLE
fix(dunning): dispatch dunning.resolved + resume cadence after downtime

### DIFF
--- a/internal/dunning/cadence_recovery_test.go
+++ b/internal/dunning/cadence_recovery_test.go
@@ -1,0 +1,61 @@
+package dunning
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/platform/clock"
+)
+
+// TestProcessDueRuns_WallClockCadenceAfterDowntime covers the medium-severity
+// audit finding: on the pure wall-clock cron path, a retry anchored on a stale
+// run.NextActionAt. After the scheduler was down for several intervals,
+// NextActionAt is far in the past, so the next retry was scheduled at
+// staleNextActionAt + interval — still in the past — and the whole backlog
+// fired back-to-back in one tick, collapsing the configured cadence.
+//
+// The fix clamps the anchor to max(now, NextActionAt) on the non-catchup,
+// non-clock-pinned path, so a recovered scheduler resumes the cadence from the
+// recovery instant.
+func TestProcessDueRuns_WallClockCadenceAfterDowntime(t *testing.T) {
+	recoveryNow := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	store := newMemStore()
+	// No resolver wired → pinned=false; pure wall-clock path.
+	svc := NewService(store, &failingRetrier{}, clock.NewFake(recoveryNow))
+	ctx := context.Background()
+
+	run, _ := svc.StartDunning(ctx, "t1", "inv_1", "cus_1", recoveryNow.Add(-30*24*time.Hour))
+	// Simulate multi-interval scheduler downtime: this run was due 10 days ago
+	// and never fired.
+	stalePast := recoveryNow.Add(-10 * 24 * time.Hour)
+	run.AttemptCount = 0
+	run.NextActionAt = &stalePast
+	store.runs[run.ID] = run
+
+	if _, errs := svc.ProcessDueRuns(ctx, "t1", 20); len(errs) > 0 {
+		t.Fatalf("ProcessDueRuns errors: %v", errs)
+	}
+
+	updated := store.runs[run.ID]
+	if updated.LastAttemptAt == nil {
+		t.Fatal("last_attempt_at should be stamped")
+	}
+	// Anchored on the recovery instant, NOT the stale scheduled time.
+	if !updated.LastAttemptAt.Equal(recoveryNow) {
+		t.Errorf("last_attempt_at: got %v, want %v (clamped to recovery now, not stale past %v)",
+			*updated.LastAttemptAt, recoveryNow, stalePast)
+	}
+	if updated.NextActionAt == nil {
+		t.Fatal("next_action_at should be re-stamped")
+	}
+	// Next retry scheduled forward from recovery, not back-dated into the past.
+	wantNext := recoveryNow.Add(72 * time.Hour) // schedule[0]
+	if !updated.NextActionAt.Equal(wantNext) {
+		t.Errorf("next_action_at: got %v, want %v (recovery now + 72h interval)", *updated.NextActionAt, wantNext)
+	}
+	if !updated.NextActionAt.After(recoveryNow) {
+		t.Errorf("next_action_at %v is not in the future — cadence collapsed", *updated.NextActionAt)
+	}
+}

--- a/internal/dunning/resolved_event_test.go
+++ b/internal/dunning/resolved_event_test.go
@@ -1,0 +1,96 @@
+package dunning
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// captureDispatcher records every dispatched event for assertion.
+type captureDispatcher struct {
+	events []capturedDunningEvent
+}
+
+type capturedDunningEvent struct {
+	eventType string
+	payload   map[string]any
+}
+
+func (c *captureDispatcher) Dispatch(_ context.Context, _, eventType string, payload map[string]any) error {
+	c.events = append(c.events, capturedDunningEvent{eventType: eventType, payload: payload})
+	return nil
+}
+
+func (c *captureDispatcher) firstOf(eventType string) (map[string]any, bool) {
+	for _, e := range c.events {
+		if e.eventType == eventType {
+			return e.payload, true
+		}
+	}
+	return nil, false
+}
+
+// TestDunningResolved_EventFires covers the medium-severity audit finding:
+// dunning.resolved was advertised in the event catalog but never dispatched,
+// silently dropping the payment-recovery signal that integrators subscribe to.
+// Both operator-facing resolution paths (ResolveRun, ResolveByInvoice) must
+// fire it with the run/invoice/customer/resolution payload.
+func TestDunningResolved_EventFires(t *testing.T) {
+	t.Run("ResolveRun", func(t *testing.T) {
+		store := newMemStore()
+		svc := NewService(store, &noopRetrier{}, nil)
+		disp := &captureDispatcher{}
+		svc.SetEventDispatcher(disp)
+		ctx := context.Background()
+
+		run, _ := svc.StartDunning(ctx, "t1", "inv_1", "cus_1", time.Now())
+		if _, err := svc.ResolveRun(ctx, "t1", run.ID, domain.ResolutionPaymentRecovered); err != nil {
+			t.Fatalf("ResolveRun: %v", err)
+		}
+
+		payload, ok := disp.firstOf(domain.EventDunningResolved)
+		if !ok {
+			t.Fatalf("dunning.resolved not dispatched; got %+v", disp.events)
+		}
+		assertResolvedPayload(t, payload, "inv_1", "cus_1", string(domain.ResolutionPaymentRecovered))
+	})
+
+	t.Run("ResolveByInvoice", func(t *testing.T) {
+		store := newMemStore()
+		svc := NewService(store, &noopRetrier{}, nil)
+		disp := &captureDispatcher{}
+		svc.SetEventDispatcher(disp)
+		ctx := context.Background()
+
+		if _, err := svc.StartDunning(ctx, "t1", "inv_2", "cus_2", time.Now()); err != nil {
+			t.Fatalf("StartDunning: %v", err)
+		}
+		if err := svc.ResolveByInvoice(ctx, "t1", "inv_2", domain.ResolutionPaymentRecovered); err != nil {
+			t.Fatalf("ResolveByInvoice: %v", err)
+		}
+
+		payload, ok := disp.firstOf(domain.EventDunningResolved)
+		if !ok {
+			t.Fatalf("dunning.resolved not dispatched; got %+v", disp.events)
+		}
+		assertResolvedPayload(t, payload, "inv_2", "cus_2", string(domain.ResolutionPaymentRecovered))
+	})
+}
+
+func assertResolvedPayload(t *testing.T, payload map[string]any, invoiceID, customerID, resolution string) {
+	t.Helper()
+	if payload["invoice_id"] != invoiceID {
+		t.Errorf("invoice_id: got %v, want %s", payload["invoice_id"], invoiceID)
+	}
+	if payload["customer_id"] != customerID {
+		t.Errorf("customer_id: got %v, want %s", payload["customer_id"], customerID)
+	}
+	if payload["resolution"] != resolution {
+		t.Errorf("resolution: got %v, want %s", payload["resolution"], resolution)
+	}
+	if payload["run_id"] == nil || payload["run_id"] == "" {
+		t.Errorf("run_id missing from payload: %+v", payload)
+	}
+}

--- a/internal/dunning/service.go
+++ b/internal/dunning/service.go
@@ -329,7 +329,7 @@ func (s *Service) ProcessDueRuns(ctx context.Context, tenantID string, limit int
 	if err != nil {
 		return 0, []error{fmt.Errorf("list due runs: %w", err)}
 	}
-	return s.processRunsBatch(ctx, tenantID, dueRuns)
+	return s.processRunsBatch(ctx, tenantID, dueRuns, false /* wall-clock cron */)
 }
 
 // ProcessDueRunsForClock is the catchup-path counterpart. ADR-029
@@ -393,7 +393,7 @@ func (s *Service) ProcessDueRunsForClock(ctx context.Context, tenantID, clockID 
 		for _, r := range dueRuns {
 			seen[r.ID] = r.AttemptCount
 		}
-		n, errs := s.processRunsBatch(ctx, tenantID, dueRuns)
+		n, errs := s.processRunsBatch(ctx, tenantID, dueRuns, true /* test-clock catchup */)
 		total += n
 		allErrs = append(allErrs, errs...)
 	}
@@ -405,11 +405,11 @@ func (s *Service) ProcessDueRunsForClock(ctx context.Context, tenantID, clockID 
 // processRunsBatch is the shared per-run body of ProcessDueRuns and
 // ProcessDueRunsForClock. The candidate list shape differs by trigger;
 // the per-run state-machine step is identical.
-func (s *Service) processRunsBatch(ctx context.Context, tenantID string, dueRuns []domain.InvoiceDunningRun) (int, []error) {
+func (s *Service) processRunsBatch(ctx context.Context, tenantID string, dueRuns []domain.InvoiceDunningRun, isCatchup bool) (int, []error) {
 	processed := 0
 	var runErrs []error
 	for _, run := range dueRuns {
-		if err := s.processRun(ctx, tenantID, run); err != nil {
+		if err := s.processRun(ctx, tenantID, run, isCatchup); err != nil {
 			runErrs = append(runErrs, fmt.Errorf("run %s: %w", run.ID, err))
 			continue
 		}
@@ -418,7 +418,7 @@ func (s *Service) processRunsBatch(ctx context.Context, tenantID string, dueRuns
 	return processed, runErrs
 }
 
-func (s *Service) processRun(ctx context.Context, tenantID string, run domain.InvoiceDunningRun) error {
+func (s *Service) processRun(ctx context.Context, tenantID string, run domain.InvoiceDunningRun, isCatchup bool) error {
 	// Resolve the policy bound to this run at StartDunning time.
 	// Runs stay on their original policy for their lifetime — if the
 	// customer's dunning_policy_id assignment changed mid-flight (or
@@ -443,21 +443,30 @@ func (s *Service) processRun(ctx context.Context, tenantID string, run domain.In
 
 	// Attempt retry
 	run.AttemptCount++
-	ctx = s.bindForInvoice(ctx, tenantID, run.InvoiceID)
-	// Anchor this attempt on the simulated moment it was scheduled
-	// for (run.NextActionAt) rather than the orchestrator's
-	// frozen_time. Without this, every retry under catchup gets
-	// last_attempt_at = advance-end frozen_time, and the next retry
-	// is scheduled at frozen_time + interval (always past advance-end,
-	// so it never fires in the same Advance click). Anchoring on
-	// NextActionAt walks the state machine through simulated time:
-	// retry 1 at NextActionAt (May 4), schedules retry 2 at May 7,
-	// etc. Falls back to clock.Now() for runs missing NextActionAt
-	// (defensive — shouldn't happen for runs that just passed
-	// `next_action_at <= frozen_time`).
+	var pinned bool
+	ctx, pinned = clock.BindEffectiveNow(ctx, s.resolver, clock.Pin{TenantID: tenantID, InvoiceID: run.InvoiceID})
+	// Anchor this attempt's instant.
+	//
+	// Simulated time (test-clock catchup, or a clock-pinned customer): anchor
+	// on the simulated moment the retry was scheduled for (run.NextActionAt)
+	// rather than the orchestrator's frozen_time. Without this, every retry
+	// under catchup gets last_attempt_at = advance-end frozen_time, and the
+	// next retry is scheduled at frozen_time + interval (always past
+	// advance-end, so it never fires in the same Advance click). Anchoring on
+	// NextActionAt walks the state machine through simulated time.
+	//
+	// Pure wall-clock cron (not catchup, not pinned): anchor on
+	// max(now, NextActionAt). In steady state NextActionAt == now. But after
+	// the scheduler is down for several intervals, NextActionAt is
+	// stale-in-the-past; anchoring on it would schedule the next retry at
+	// staleNextActionAt + interval — still in the past — so the whole backlog
+	// fires back-to-back in one tick, collapsing the configured cadence.
+	// Clamping to now resumes the cadence from the recovery instant.
 	now := s.clock.Now(ctx)
 	if run.NextActionAt != nil {
-		now = *run.NextActionAt
+		if isCatchup || pinned || run.NextActionAt.After(now) {
+			now = *run.NextActionAt
+		}
 	}
 	run.LastAttemptAt = &now
 
@@ -552,6 +561,13 @@ func (s *Service) processRun(ctx context.Context, tenantID string, run domain.In
 		if _, err := s.store.UpdateRun(ctx, tenantID, run); err != nil {
 			return err
 		}
+
+		s.fireEvent(ctx, tenantID, domain.EventDunningResolved, map[string]any{
+			"run_id":      run.ID,
+			"invoice_id":  run.InvoiceID,
+			"customer_id": run.CustomerID,
+			"resolution":  string(run.Resolution),
+		})
 		return nil
 	}
 
@@ -760,6 +776,13 @@ func (s *Service) ResolveRun(ctx context.Context, tenantID, runID string, resolu
 		return domain.InvoiceDunningRun{}, err
 	}
 
+	s.fireEvent(ctx, tenantID, domain.EventDunningResolved, map[string]any{
+		"run_id":      updated.ID,
+		"invoice_id":  updated.InvoiceID,
+		"customer_id": updated.CustomerID,
+		"resolution":  string(updated.Resolution),
+	})
+
 	if resolution == domain.ResolutionInvoiceNotCollectible && s.invoiceUncollect != nil {
 		if err := s.invoiceUncollect.MarkUncollectible(ctx, tenantID, run.InvoiceID); err != nil {
 			// Already-uncollectible is benign (race with automated
@@ -799,8 +822,17 @@ func (s *Service) ResolveByInvoice(ctx context.Context, tenantID, invoiceID stri
 		CreatedAt: now,
 	})
 
-	_, err = s.store.UpdateRun(ctx, tenantID, run)
-	return err
+	if _, err = s.store.UpdateRun(ctx, tenantID, run); err != nil {
+		return err
+	}
+
+	s.fireEvent(ctx, tenantID, domain.EventDunningResolved, map[string]any{
+		"run_id":      run.ID,
+		"invoice_id":  run.InvoiceID,
+		"customer_id": run.CustomerID,
+		"resolution":  string(run.Resolution),
+	})
+	return nil
 }
 
 // GetDefaultPolicy returns the tenant's default dunning policy.


### PR DESCRIPTION
Two medium-severity backend-audit findings in the dunning service.

## 1. `dunning.resolved` advertised but never fired (`service.go:530`)

`dunning.resolved` is in the event catalog and integrators subscribe to it as the payment-recovery signal — but it was never dispatched. Now fired at all three resolution sites (processRun's payment-recovered branch, `ResolveRun`, `ResolveByInvoice`) with the `run_id` / `invoice_id` / `customer_id` / `resolution` payload, mirroring `dunning.started` / `dunning.escalated`.

## 2. Cadence collapse after scheduler downtime (`service.go:459`)

`processRun` anchored `last_attempt_at` and the next retry's `next_action_at` on the stale `run.NextActionAt`. After the scheduler was down for several intervals, that's far in the past — so the next retry landed at `staleNextActionAt + interval`, still in the past, and the whole overdue backlog fired back-to-back in a single tick, collapsing the configured cadence.

The anchor now clamps to `max(now, NextActionAt)` on the **pure wall-clock** path. Test-clock catchup and clock-pinned customers still replay through simulated time off `NextActionAt` — discriminated by an explicit `isCatchup` flag threaded from the two batch callers, plus the resolver-pin bool from `BindEffectiveNow`.

## Tests

- `dunning.resolved` fires on `ResolveRun` + `ResolveByInvoice` with the correct payload.
- Wall-clock cadence resumes from recovery-now (not stale-past + interval) after simulated multi-interval downtime.
- All existing catchup / clock-resolver tests remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)