### PR TITLE
fix(tax): classify Stripe 'not configured' errors correctly

### DIFF
--- a/internal/tax/classify.go
+++ b/internal/tax/classify.go
@@ -107,10 +107,11 @@ func Classify(err error) ErrorCode {
 	low := strings.ToLower(msg)
 
 	// Not configured: provider was never connected for the active
-	// mode. Velox's own wrapper produces "no client configured for
-	// livemode=…"; this match must run BEFORE provider_auth because
-	// "configured" can co-occur with "key" / "credential" phrasings
-	// in adjacent provider error variants.
+	// mode. Velox's own wrapper (tax/stripe.go) produces "no Stripe
+	// credentials connected for livemode=…" on Calculate and "no client
+	// for context (livemode=…)" on reverse. This match must run BEFORE
+	// provider_auth because "credentials" can co-occur with "key" /
+	// "credential" phrasings in adjacent provider error variants.
 	if reNotConfigured.MatchString(low) {
 		return ErrCodeProviderNotConfigured
 	}
@@ -153,7 +154,7 @@ var errSentinelContextCanceled = errors.New("context canceled")
 
 var (
 	reNotConfigured = regexp.MustCompile(
-		`no client configured|no credentials configured|provider not connected|not configured for livemode`,
+		`no client configured|no credentials configured|provider not connected|not configured for livemode|credentials connected for livemode|no .*credentials connected|no client for (mode|context)`,
 	)
 	reAuth = regexp.MustCompile(
 		`invalid api key|expired api key|authentication required|unauthorized|invalid_api_key|api_key_invalid`,

--- a/internal/tax/classify_test.go
+++ b/internal/tax/classify_test.go
@@ -24,6 +24,13 @@ func TestClassify_TableDriven(t *testing.T) {
 		{"invalid-api-key", errors.New("Invalid API Key provided: sk_test_***"), ErrCodeProviderAuth},
 		{"unauthorized", errors.New("401 unauthorized"), ErrCodeProviderAuth},
 		{"unknown-blob", errors.New("an unexpected error happened"), ErrCodeUnknown},
+		// Not-configured: must match the actual messages tax/stripe.go emits.
+		// Pre-fix the regex was written against a drifted "no client configured
+		// for livemode" string, so these fell through to ErrCodeUnknown and
+		// triggered futile auto-retries with the wrong operator remediation.
+		{"stripe-calculate-no-credentials", errors.New("stripe tax: no Stripe credentials connected for livemode=true — connect Stripe in Settings → Payments or change tax provider"), ErrCodeProviderNotConfigured},
+		{"stripe-reverse-no-client", errors.New("stripe tax: reverse: no client for context (livemode=false)"), ErrCodeProviderNotConfigured},
+		{"legacy-no-client-configured", errors.New("no client configured for livemode=true"), ErrCodeProviderNotConfigured},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Medium-severity backend-audit finding (`tax/classify.go:156`).

## Problem

`reNotConfigured` was written against a `no client configured for livemode` string that **drifted**. `tax/stripe.go` actually emits:
- `no Stripe credentials connected for livemode=…` (Calculate)
- `no client for context (livemode=…)` (reverse)

Neither matched the regex, so a genuinely-not-configured failure classified as `ErrCodeUnknown` — driving **futile auto-retries** (it's not transient) and showing the operator the wrong remediation instead of "connect Stripe in Settings → Payments."

## Fix

Extended `reNotConfigured` to match the real emitted messages (kept the legacy alternative for safety) and corrected the stale doc comment that described the drifted string.

## Test

Added table cases for both live messages (`stripe-calculate-no-credentials`, `stripe-reverse-no-client`) and the legacy phrasing — all now classify to `ErrCodeProviderNotConfigured`. Existing ordering/auth/outage cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)