### PR TITLE
fix(webhook): single-count failed attempts + claim retries for multi-replica

### DIFF
--- a/internal/webhook/claim_lease_integration_test.go
+++ b/internal/webhook/claim_lease_integration_test.go
@@ -1,0 +1,93 @@
+package webhook_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+	"github.com/sagarsuperuser/velox/internal/webhook"
+)
+
+// TestListPendingDeliveries_LeasesClaimedRows covers the medium-severity audit
+// finding: the retry worker had no row-claim, so two replicas would both pick
+// the same due delivery and double-deliver the webhook. ListPendingDeliveries
+// now atomically claims and leases each row (FOR UPDATE SKIP LOCKED + push
+// next_retry_at forward), so a second call in the same lease window returns
+// nothing — the claimed row is invisible to a concurrent worker.
+func TestListPendingDeliveries_LeasesClaimedRows(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx, cancel := context.WithTimeout(postgres.WithLivemode(context.Background(), false), 15*time.Second)
+	defer cancel()
+
+	tenantID := testutil.CreateTestTenant(t, db, "Webhook Claim Lease")
+	store := webhook.NewPostgresStore(db)
+
+	ep, err := store.CreateEndpoint(ctx, tenantID, domain.WebhookEndpoint{
+		URL: "https://example.test/hook", Events: []string{"invoice.created"}, Active: true, Secret: "whsec_test",
+	})
+	if err != nil {
+		t.Fatalf("create endpoint: %v", err)
+	}
+	evt, err := store.CreateEvent(ctx, tenantID, domain.WebhookEvent{
+		EventType: "invoice.created", Payload: map[string]any{"id": "inv_1"},
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+	del, err := store.CreateDelivery(ctx, tenantID, domain.WebhookDelivery{
+		WebhookEndpointID: ep.ID, WebhookEventID: evt.ID, Status: domain.DeliveryPending,
+	})
+	if err != nil {
+		t.Fatalf("create delivery: %v", err)
+	}
+
+	// Make the delivery due: status=pending, next_retry_at in the past.
+	setDuePast(t, db, del.ID)
+
+	first, err := store.ListPendingDeliveries(ctx, 100)
+	if err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	if !containsDelivery(first, del.ID) {
+		t.Fatalf("first claim should return the due delivery; got %d rows", len(first))
+	}
+
+	// Second worker (same lease window) must NOT see the leased row.
+	second, err := store.ListPendingDeliveries(ctx, 100)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if containsDelivery(second, del.ID) {
+		t.Errorf("second claim re-returned the leased delivery — double-delivery window still open")
+	}
+}
+
+func containsDelivery(ds []domain.WebhookDelivery, id string) bool {
+	for _, d := range ds {
+		if d.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func setDuePast(t *testing.T, db *postgres.DB, deliveryID string) {
+	t.Helper()
+	tx, err := db.BeginTx(context.Background(), postgres.TxBypass, "")
+	if err != nil {
+		t.Fatalf("begin bypass tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(`
+		UPDATE webhook_deliveries SET status='pending', next_retry_at = NOW() - INTERVAL '1 minute'
+		WHERE id = $1
+	`, deliveryID); err != nil {
+		t.Fatalf("set due past: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -509,6 +509,16 @@ func (s *PostgresStore) UpdateDelivery(ctx context.Context, tenantID string, d d
 	return d, nil
 }
 
+// ListPendingDeliveries atomically CLAIMS up to `limit` due deliveries and
+// returns them. It is not a pure read: each returned row is leased by pushing
+// next_retry_at retryLeaseWindow into the future, and rows already locked by a
+// concurrent worker are skipped (FOR UPDATE SKIP LOCKED). This makes the retry
+// worker safe to run on multiple replicas — two workers never claim the same
+// delivery, so a webhook isn't delivered twice per due-tick. The lease also
+// provides crash recovery: if the claiming worker dies before overwriting the
+// row's status, the lease expires after retryLeaseWindow and another worker
+// re-claims it. The window must exceed the per-attempt HTTP timeout (10s) by a
+// wide margin so an in-flight delivery is never re-claimed underneath itself.
 func (s *PostgresStore) ListPendingDeliveries(ctx context.Context, limit int) ([]domain.WebhookDelivery, error) {
 	if limit <= 0 {
 		limit = 100
@@ -521,14 +531,19 @@ func (s *PostgresStore) ListPendingDeliveries(ctx context.Context, limit int) ([
 	defer postgres.Rollback(tx)
 
 	rows, err := tx.QueryContext(ctx, `
-		SELECT id, tenant_id, livemode, webhook_endpoint_id, webhook_event_id, status,
+		UPDATE webhook_deliveries
+		SET next_retry_at = NOW() + make_interval(secs => $1)
+		WHERE id IN (
+			SELECT id FROM webhook_deliveries
+			WHERE status = 'pending' AND next_retry_at <= NOW()
+			ORDER BY next_retry_at ASC
+			LIMIT $2
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING id, tenant_id, livemode, webhook_endpoint_id, webhook_event_id, status,
 			COALESCE(http_status_code, 0), COALESCE(response_body,''), COALESCE(error_message,''),
 			attempt_count, next_retry_at, created_at, completed_at
-		FROM webhook_deliveries
-		WHERE status = 'pending' AND next_retry_at <= NOW()
-		ORDER BY next_retry_at ASC
-		LIMIT $1
-	`, limit)
+	`, int(retryLeaseWindow.Seconds()), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +559,10 @@ func (s *PostgresStore) ListPendingDeliveries(ctx context.Context, limit int) ([
 		}
 		deliveries = append(deliveries, d)
 	}
-	return deliveries, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return deliveries, tx.Commit()
 }
 
 func (s *PostgresStore) GetEndpointStats(ctx context.Context, tenantID string) ([]EndpointStats, error) {

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -29,6 +29,15 @@ import (
 
 const maxAttempts = 5
 
+// retryLeaseWindow is how far ListPendingDeliveries pushes next_retry_at
+// forward when it claims a due delivery, so a concurrent retry worker on
+// another replica won't re-claim the same row while it's being delivered. Must
+// comfortably exceed the per-attempt HTTP timeout (10s); if a claiming worker
+// crashes mid-delivery, the lease expires after this window and the row becomes
+// eligible again. Far below the smallest real retry backoff (1m) so it never
+// delays a legitimate scheduled retry.
+const retryLeaseWindow = 1 * time.Minute
+
 // retryBackoffs defines the delay before each retry attempt (index 0 = after attempt 1).
 var retryBackoffs = [maxAttempts]time.Duration{
 	1 * time.Minute,
@@ -368,10 +377,15 @@ func (s *Service) deliver(ctx context.Context, tenantID string, ep domain.Webhoo
 
 	delivery.HTTPStatusCode = resp.StatusCode
 	delivery.ResponseBody = string(respBody)
-	delivery.AttemptCount++
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		now := time.Now().UTC()
+		// Count this attempt only on success. scheduleRetryOrFail is the
+		// single owner of the increment on the failure path — incrementing
+		// here too double-counted, burning a retry and skipping the first
+		// backoff interval (retryBackoffs[AttemptCount-1] indexed off the
+		// inflated count). Mirrors retryDeliver.
+		delivery.AttemptCount++
 		delivery.Status = domain.DeliverySucceeded
 		delivery.CompletedAt = &now
 		delivery.NextRetryAt = nil

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -496,11 +496,20 @@ func TestDelivery_FailedHTTP(t *testing.T) {
 	if store.deliveries[0].Status != domain.DeliveryPending {
 		t.Errorf("status: got %q, want pending (scheduled for retry)", store.deliveries[0].Status)
 	}
-	if store.deliveries[0].AttemptCount != 2 {
-		t.Errorf("attempt_count: got %d, want 2", store.deliveries[0].AttemptCount)
+	// Exactly one attempt has happened. Pre-fix this was 2 — deliver()
+	// incremented unconditionally AND scheduleRetryOrFail incremented again,
+	// burning a retry and skipping the first backoff.
+	if store.deliveries[0].AttemptCount != 1 {
+		t.Errorf("attempt_count: got %d, want 1 (single increment per failed attempt)", store.deliveries[0].AttemptCount)
 	}
 	if store.deliveries[0].NextRetryAt == nil {
-		t.Error("next_retry_at should be set for retry")
+		t.Fatal("next_retry_at should be set for retry")
+	}
+	// The first retry must use the FIRST backoff (1m), not the second (5m).
+	// jitter adds 0–30s, so the gap lands in [1m, 1m30s).
+	gap := time.Until(*store.deliveries[0].NextRetryAt)
+	if gap < retryBackoffs[0] || gap >= retryBackoffs[0]+31*time.Second {
+		t.Errorf("next_retry_at gap = %v, want within [1m, 1m30s) — first backoff must not be skipped", gap)
 	}
 }
 


### PR DESCRIPTION
Two medium-severity backend-audit findings in the webhook delivery path.

## 1. AttemptCount double-incremented on failure (`service.go:371`)

`deliver()` incremented `AttemptCount` unconditionally, then `scheduleRetryOrFail` incremented it **again** — so one failed attempt recorded as 2, burning a retry and skipping the first backoff. Moved the increment into the **success branch only**, mirroring `retryDeliver`; `scheduleRetryOrFail` is the single owner on the failure path.

## 2. Retry worker had no row-claim (`service.go:712`)

With no claim, two replicas both picked the same due delivery and **double-delivered** the webhook. `ListPendingDeliveries` now atomically claims rows with `FOR UPDATE SKIP LOCKED` and **leases** each by pushing `next_retry_at` forward (`retryLeaseWindow`), so a concurrent worker skips in-flight rows. The lease doubles as crash recovery. No new status enum / migration: the lease (1m) far exceeds the 10s HTTP timeout and never delays a legitimate retry.

## Tests

- `TestDelivery_FailedHTTP` now asserts `attempt_count == 1` (was asserting the buggy `2`) and that the first backoff isn't skipped.
- `TestListPendingDeliveries_LeasesClaimedRows` (integration): a second claim within the lease window does not re-return the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)