### PR TITLE
fix(testclock): recover catchup panics + flip failed clock on a live ctx

### DIFF
--- a/internal/testclock/catchup.go
+++ b/internal/testclock/catchup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -139,6 +140,22 @@ func (w *CatchupWorker) process(job CatchupJob) {
 	ctx, cancel := context.WithTimeout(context.Background(), CatchupTimeout)
 	defer cancel()
 	ctx = postgres.WithLivemode(ctx, false)
+
+	// A panic in the runner (nil-deref in some billing path, etc.) would
+	// otherwise unwind this goroutine and crash the whole process, taking
+	// down the API server for every tenant. Recover, log with the stack, and
+	// let the drain loop continue — one bad clock can't kill the server.
+	// Mirrors scheduler.runOneTick's recovering wrapper.
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("test-clock catchup panicked",
+				"clock_id", job.ClockID,
+				"tenant_id", job.TenantID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
 
 	start := time.Now()
 	if err := w.runner(ctx, job); err != nil {

--- a/internal/testclock/catchup_failctx_test.go
+++ b/internal/testclock/catchup_failctx_test.go
@@ -1,0 +1,69 @@
+package testclock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// ctxCheckingStore embeds the unit mockStore but makes MarkFailed fail when its
+// context is already canceled/expired — modelling the real store, where a write
+// on a dead ctx can't land. This is the condition the fix addresses: the
+// catchup ctx hits CatchupTimeout, so reusing it for the failure-flip would
+// also fail and leave the clock stuck in 'advancing'.
+type ctxCheckingStore struct {
+	*mockStore
+	markFailedSawLiveCtx bool
+}
+
+func (s *ctxCheckingStore) MarkFailed(ctx context.Context, tenantID, id, reason string) (domain.TestClock, error) {
+	if ctx.Err() != nil {
+		return domain.TestClock{}, ctx.Err()
+	}
+	s.markFailedSawLiveCtx = true
+	return s.mockStore.MarkFailed(ctx, tenantID, id, reason)
+}
+
+// TestRunCatchup_MarksFailedOnExpiredCtx covers the medium-severity audit
+// finding: when catchup timed out, MarkFailed ran on the already-expired
+// catchup ctx and failed, leaving the clock stuck in 'advancing' forever. The
+// failure-flip now runs on a ctx detached from the catchup deadline.
+func TestRunCatchup_MarksFailedOnExpiredCtx(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	base := newMockStore()
+	base.clocks["c1"] = domain.TestClock{
+		ID: "c1", TenantID: "t1", Status: domain.TestClockStatusAdvancing, FrozenTime: start,
+	}
+	sub := domain.Subscription{ID: "s1", TenantID: "t1", TestClockID: "c1", Status: domain.SubscriptionActive}
+	nextBilling := start.Add(1 * time.Hour)
+	sub.NextBillingAt = &nextBilling
+	base.subsOnClock["c1"] = []domain.Subscription{sub}
+
+	store := &ctxCheckingStore{mockStore: base}
+	runner := &stubRunner{store: base, clockID: "c1", subID: "s1", err: errors.New("catchup deadline exceeded")}
+	s := NewService(store)
+	s.SetBillingRunner(runner)
+
+	// Simulate the catchup ctx having hit CatchupTimeout: already canceled.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.RunCatchup(ctx, CatchupJob{TenantID: "t1", ClockID: "c1"})
+	if err == nil {
+		t.Fatal("expected RunCatchup to return the catchup error")
+	}
+
+	if !store.markFailedSawLiveCtx {
+		t.Error("MarkFailed was not called with a live (detached) ctx — failure-flip reused the expired catchup ctx")
+	}
+	got := store.clocks["c1"]
+	if got.Status != domain.TestClockStatusInternalFailed {
+		t.Errorf("status: got %q, want internal_failure (clock must not be left stuck in 'advancing')", got.Status)
+	}
+	if got.LastFailureReason == "" {
+		t.Error("last_failure_reason should be populated")
+	}
+}

--- a/internal/testclock/catchup_panic_test.go
+++ b/internal/testclock/catchup_panic_test.go
@@ -1,0 +1,21 @@
+package testclock
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCatchupProcess_RecoversPanic covers the medium-severity audit finding:
+// the catchup worker goroutine had no panic recovery, so a panic in the runner
+// (a nil-deref in some billing path) would unwind the goroutine and crash the
+// whole process, taking down the API for every tenant. process() now recovers,
+// logs, and returns so the drain loop continues.
+func TestCatchupProcess_RecoversPanic(t *testing.T) {
+	w := NewCatchupWorker(NewCatchupQueue(1), func(_ context.Context, _ CatchupJob) error {
+		panic("boom: nil deref in billing path")
+	})
+
+	// If process did not recover, the panic would propagate and fail the test.
+	// Reaching the line after the call proves recovery.
+	w.process(CatchupJob{TenantID: "t1", ClockID: "c1"})
+}

--- a/internal/testclock/service.go
+++ b/internal/testclock/service.go
@@ -662,7 +662,15 @@ func (s *Service) RunCatchup(ctx context.Context, job CatchupJob) error {
 			// belt-and-suspenders against future paths.
 			reason = errs.SanitizeForOperator(runErr, job.ClockID)
 		}
-		if _, ferr := s.store.MarkFailed(ctx, job.TenantID, job.ClockID, reason); ferr != nil {
+		// The common cause of runErr is the catchup ctx hitting CatchupTimeout.
+		// Reusing that already-expired ctx for MarkFailed would fail too,
+		// leaving the clock stuck in 'advancing' forever. Detach from the
+		// catchup deadline (retaining ctx values — the livemode pin) and give
+		// the failure-flip its own short timeout so the clock always lands in
+		// internal_failure where the operator can retry or delete it.
+		failCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if _, ferr := s.store.MarkFailed(failCtx, job.TenantID, job.ClockID, reason); ferr != nil {
 			slog.Error("test clock: failed to mark clock as failed after catchup error",
 				"clock_id", job.ClockID, "catchup_err", runErr, "mark_err", ferr)
 		}


### PR DESCRIPTION
Two medium-severity backend-audit findings in the test-clock catchup path.

## 1. No panic recovery in the catchup worker (`catchup.go:138`)

A panic in the runner (a nil-deref in some billing path) unwound the worker goroutine and **crashed the whole process** — taking the API down for every tenant. `process()` now wraps the runner in `recover()`, logging the panic + stack and continuing the drain loop (mirrors `scheduler.runOneTick`). One bad clock can't kill the server.

## 2. CatchupTimeout left the clock stuck in 'advancing' (`service.go:665`)

The common cause of a catchup error is the ctx hitting `CatchupTimeout` — but `MarkFailed` reused that **already-expired** ctx and failed too, so the clock never flipped to `internal_failure` and the operator could neither retry nor delete it. The failure-flip now runs on a ctx detached from the catchup deadline (`context.WithoutCancel` + a fresh 30s timeout), retaining the livemode pin.

## Tests

- `TestCatchupProcess_RecoversPanic`: a panicking runner is recovered (the test reaches the line after `process()`).
- `TestRunCatchup_MarksFailedOnExpiredCtx`: `RunCatchup` with an already-canceled ctx still marks the clock `internal_failure` — a store wrapper that rejects an expired ctx in `MarkFailed` proves the failure-flip uses a detached ctx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)