### PR TITLE
fix(analytics): authoritative credit balance + currency-scoped money totals

### DIFF
--- a/internal/analytics/handler_test.go
+++ b/internal/analytics/handler_test.go
@@ -80,6 +80,7 @@ func TestRoutes_MethodNotAllowed(t *testing.T) {
 func TestOverviewResponse_JSONShape(t *testing.T) {
 	resp := OverviewResponse{
 		Period:              "30d",
+		Currency:            "USD",
 		MRR:                 1200_00,
 		MRRPrev:             1100_00,
 		ARR:                 14400_00,
@@ -118,7 +119,7 @@ func TestOverviewResponse_JSONShape(t *testing.T) {
 	}
 
 	expected := []string{
-		"period", "mrr", "mrr_prev", "arr", "arr_prev",
+		"period", "currency", "mrr", "mrr_prev", "arr", "arr_prev",
 		"revenue", "revenue_prev", "outstanding_ar", "avg_invoice_value", "credit_balance_total",
 		"active_customers", "new_customers", "active_subscriptions", "trialing_subscriptions",
 		"paid_invoices", "failed_payments", "open_invoices",

--- a/internal/analytics/overview.go
+++ b/internal/analytics/overview.go
@@ -17,6 +17,12 @@ import (
 type OverviewResponse struct {
 	Period string `json:"period"`
 
+	// Currency is the tenant's default currency. All money figures below are
+	// scoped to it — invoices in other currencies are excluded rather than
+	// summed into a meaningless mixed-currency total. The dashboard renders
+	// every amount labeled with this code.
+	Currency string `json:"currency"`
+
 	// Money (cents)
 	MRR             int64 `json:"mrr"`
 	MRRPrev         int64 `json:"mrr_prev"`
@@ -75,6 +81,20 @@ func (h *Handler) overview(w http.ResponseWriter, r *http.Request) {
 
 	resp := OverviewResponse{Period: period.Key}
 
+	// Resolve the tenant's default currency once. Every invoice-money
+	// aggregate (revenue, outstanding AR, avg invoice value) is scoped to it
+	// so the dashboard never sums amounts across currencies into a corrupt
+	// total. Defaults to USD when settings are unset (fresh tenant).
+	defaultCurrency := "USD"
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(NULLIF(default_currency, ''), 'USD') FROM tenant_settings LIMIT 1`,
+	).Scan(&defaultCurrency); err != nil && err != sql.ErrNoRows {
+		slog.Error("analytics overview: default currency", "error", err)
+		respond.InternalError(w, r)
+		return
+	}
+	resp.Currency = defaultCurrency
+
 	// MRR now and at the start of the period (approximated from current
 	// subscription state — see mrrAtPointInTime).
 	var err1, err2 error
@@ -89,8 +109,8 @@ func (h *Handler) overview(w http.ResponseWriter, r *http.Request) {
 	resp.ARRPrev = resp.MRRPrev * 12
 
 	// Revenue: paid invoices inside the period vs. the prior period.
-	resp.Revenue, err1 = sumPaidRevenue(ctx, tx, period.Start, period.End)
-	resp.RevenuePrev, err2 = sumPaidRevenue(ctx, tx, period.PrevStart, period.PrevEnd)
+	resp.Revenue, err1 = sumPaidRevenue(ctx, tx, period.Start, period.End, defaultCurrency)
+	resp.RevenuePrev, err2 = sumPaidRevenue(ctx, tx, period.PrevStart, period.PrevEnd, defaultCurrency)
 	if err := firstErr(err1, err2); err != nil {
 		slog.Error("analytics overview: revenue", "error", err)
 		respond.InternalError(w, r)
@@ -114,9 +134,11 @@ func (h *Handler) overview(w http.ResponseWriter, r *http.Request) {
 		{"trialing_subs", &resp.TrialingSubs,
 			`SELECT COUNT(*) FROM subscriptions WHERE status = 'active' AND trial_end_at IS NOT NULL AND trial_end_at > now()`, nil},
 		{"outstanding_ar", &resp.OutstandingAR,
-			`SELECT COALESCE(SUM(amount_due_cents), 0) FROM invoices WHERE status = 'finalized' AND payment_status != 'succeeded'`, nil},
+			`SELECT COALESCE(SUM(amount_due_cents), 0) FROM invoices WHERE status = 'finalized' AND payment_status != 'succeeded' AND currency = $1`,
+			[]any{defaultCurrency}},
 		{"avg_invoice", &resp.AvgInvoiceValue,
-			`SELECT COALESCE(AVG(total_amount_cents), 0)::bigint FROM invoices WHERE status = 'paid'`, nil},
+			`SELECT COALESCE(AVG(total_amount_cents), 0)::bigint FROM invoices WHERE status = 'paid' AND currency = $1`,
+			[]any{defaultCurrency}},
 		{"paid_invoices", &resp.PaidInvoices,
 			`SELECT COUNT(*) FROM invoices WHERE status = 'paid' AND paid_at >= $1 AND paid_at < $2`,
 			[]any{period.Start, period.End}},
@@ -144,14 +166,15 @@ func (h *Handler) overview(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Credit balance: latest ledger row per customer, summed.
+	// Credit balance: authoritative SUM(amount_cents) over the whole ledger,
+	// matching credit.GetBalance. The previous DISTINCT ON (customer_id)
+	// balance_after read the denormalized running balance of the latest row
+	// BY created_at — but catchup / late-cron expiry entries can be inserted
+	// out of created_at order, so "latest row" wasn't the true latest balance
+	// and total credit liability was mis-reported. Summing amount_cents is
+	// order-independent and exact.
 	err = tx.QueryRowContext(ctx, `
-		SELECT COALESCE(SUM(balance_after), 0)
-		FROM (
-			SELECT DISTINCT ON (customer_id) balance_after
-			FROM customer_credit_ledger
-			ORDER BY customer_id, created_at DESC
-		) latest
+		SELECT COALESCE(SUM(amount_cents), 0) FROM customer_credit_ledger
 	`).Scan(&resp.CreditBalance)
 	if err != nil {
 		slog.Error("analytics overview: credit balance", "error", err)
@@ -268,13 +291,13 @@ func mrrAtPointInTime(ctx context.Context, tx *sql.Tx, t any) (int64, error) {
 	return v, err
 }
 
-func sumPaidRevenue(ctx context.Context, tx *sql.Tx, start, end any) (int64, error) {
+func sumPaidRevenue(ctx context.Context, tx *sql.Tx, start, end any, currency string) (int64, error) {
 	var v int64
 	err := tx.QueryRowContext(ctx, `
 		SELECT COALESCE(SUM(total_amount_cents), 0)
 		FROM invoices
-		WHERE status = 'paid' AND paid_at >= $1 AND paid_at < $2
-	`, start, end).Scan(&v)
+		WHERE status = 'paid' AND paid_at >= $1 AND paid_at < $2 AND currency = $3
+	`, start, end, currency).Scan(&v)
 	return v, err
 }
 

--- a/internal/analytics/overview_integration_test.go
+++ b/internal/analytics/overview_integration_test.go
@@ -1,0 +1,144 @@
+package analytics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/auth"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestOverview_CreditAndCurrency covers two medium-severity audit findings:
+//   - credit_balance_total used DISTINCT ON balance_after (latest row by
+//     created_at), which mis-reports after out-of-order expiry inserts; it now
+//     sums amount_cents (order-independent, matches credit.GetBalance).
+//   - revenue/AR/avg summed total_amount_cents across currencies; they're now
+//     scoped to the tenant's default currency so a EUR invoice can't corrupt a
+//     USD-denominated total.
+func TestOverview_CreditAndCurrency(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	tenantID := testutil.CreateTestTenant(t, db, "Analytics Overview")
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_ov", DisplayName: "Overview",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	// Default currency = USD (no tenant_settings row → handler falls back to USD).
+	invoiceStore := invoice.NewPostgresStore(db)
+	now := time.Now().UTC()
+	usd := makePaidInvoice(t, ctx, invoiceStore, tenantID, cust.ID, "USD", 100_00)
+	_ = makePaidInvoice(t, ctx, invoiceStore, tenantID, cust.ID, "EUR", 999_00)
+	markPaidAt(t, db, usd.ID, now.Add(-1*time.Hour))
+	// EUR invoice is paid too but in a non-default currency — must be excluded.
+	eur := makePaidInvoice(t, ctx, invoiceStore, tenantID, cust.ID, "EUR", 500_00)
+	markPaidAt(t, db, eur.ID, now.Add(-1*time.Hour))
+
+	// Credit ledger: a grant (+5000) and an expiry (-2000) inserted OUT of
+	// created_at order — the expiry's created_at is EARLIER than the grant's,
+	// so "latest row by created_at" (the grant, balance_after=5000) disagrees
+	// with the true balance (3000). Authoritative SUM(amount_cents)=3000.
+	seedLedger(t, db, tenantID, cust.ID, now)
+
+	h := NewHandler(db)
+	req := httptest.NewRequest("GET", "/overview?period=30d", nil)
+	req = req.WithContext(auth.WithTenantID(postgres.WithLivemode(req.Context(), false), tenantID))
+	rr := httptest.NewRecorder()
+	h.overview(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status: got %d, body=%s", rr.Code, rr.Body.String())
+	}
+	var resp OverviewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Currency != "USD" {
+		t.Errorf("currency: got %q, want USD", resp.Currency)
+	}
+	if resp.Revenue != 100_00 {
+		t.Errorf("revenue: got %d, want 10000 (USD only — EUR invoices excluded, not summed)", resp.Revenue)
+	}
+	if resp.CreditBalance != 3000 {
+		t.Errorf("credit_balance_total: got %d, want 3000 (SUM(amount_cents), not latest balance_after)", resp.CreditBalance)
+	}
+}
+
+func makePaidInvoice(t *testing.T, ctx context.Context, store *invoice.PostgresStore, tenantID, custID, currency string, total int64) domain.Invoice {
+	t.Helper()
+	now := time.Now().UTC()
+	issued := now
+	inv, err := store.Create(ctx, tenantID, domain.Invoice{
+		CustomerID:         custID,
+		InvoiceNumber:      fmt.Sprintf("INV-%s-%d", currency, total),
+		Status:             domain.InvoicePaid,
+		PaymentStatus:      domain.PaymentSucceeded,
+		Currency:           currency,
+		SubtotalCents:      total,
+		TotalAmountCents:   total,
+		AmountDueCents:     0,
+		AmountPaidCents:    total,
+		BillingPeriodStart: now.Add(-30 * 24 * time.Hour),
+		BillingPeriodEnd:   now,
+		IssuedAt:           &issued,
+	})
+	if err != nil {
+		t.Fatalf("create %s invoice: %v", currency, err)
+	}
+	return inv
+}
+
+func markPaidAt(t *testing.T, db *postgres.DB, invoiceID string, at time.Time) {
+	t.Helper()
+	execBypass(t, db, `UPDATE invoices SET paid_at = $2 WHERE id = $1`, invoiceID, at)
+}
+
+func seedLedger(t *testing.T, db *postgres.DB, tenantID, custID string, now time.Time) {
+	t.Helper()
+	// Insert in a tenant tx so app.livemode is set (false) and the ledger
+	// rows land in the same partition the handler reads.
+	ctx := postgres.WithLivemode(context.Background(), false)
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		t.Fatalf("begin tenant tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	// grant +5000 at T (created later), expiry -2000 at T-2h (created earlier).
+	if _, err := tx.Exec(`
+		INSERT INTO customer_credit_ledger (id, tenant_id, customer_id, entry_type, amount_cents, balance_after, description, created_at)
+		VALUES ($1,$2,$3,'expiry',-2000,3000,'expiry', $5),
+		       ($4,$2,$3,'grant',  5000,5000,'grant',  $6)
+	`, postgres.NewID("vlx_ccl"), tenantID, custID, postgres.NewID("vlx_ccl"), now.Add(-2*time.Hour), now); err != nil {
+		t.Fatalf("seed ledger: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit ledger: %v", err)
+	}
+}
+
+func execBypass(t *testing.T, db *postgres.DB, q string, args ...any) {
+	t.Helper()
+	tx, err := db.BeginTx(context.Background(), postgres.TxBypass, "")
+	if err != nil {
+		t.Fatalf("begin bypass: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(q, args...); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}


### PR DESCRIPTION
Two medium-severity backend-audit findings in the analytics overview.

## 1. Credit balance mis-reported after out-of-order ledger inserts (`overview.go:148`)

`credit_balance_total` read `DISTINCT ON (customer_id) balance_after ORDER BY created_at DESC` — the denormalized running balance of the latest row *by created_at*. Catchup / late-cron expiry entries are inserted out of `created_at` order, so "latest row" isn't the true latest balance, and total credit liability was wrong. Now `SUM(amount_cents)` over the ledger — order-independent and exact, matching `credit.GetBalance`.

## 2. Mixed-currency money corruption (`overview.go:271`)

`revenue` / `outstanding_ar` / `avg_invoice_value` summed invoice amount columns across **all currencies** into one `int64` — a EUR invoice corrupting a USD total. They're now scoped to the tenant's **default currency** (resolved once from `tenant_settings`, USD fallback), and the response carries a `currency` field so the dashboard labels the figures. A full per-currency breakdown is deferred until a multi-currency design partner needs it (the overview has no currency dimension today).

## Test

`TestOverview_CreditAndCurrency` (integration): seeds an out-of-order expiry (true balance 3000 vs latest `balance_after` 5000) and a EUR invoice alongside a USD one, then asserts `credit_balance_total=3000`, `revenue=`USD-only, `currency=USD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)