### PR TITLE
fix(creditnote): serialize Issue() with a draft→issued compare-and-swap

### DIFF
--- a/internal/creditnote/issue_idempotency_test.go
+++ b/internal/creditnote/issue_idempotency_test.go
@@ -1,0 +1,103 @@
+package creditnote
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+)
+
+// TestIssue_IdempotentNoDoubleApply covers the medium-severity audit finding:
+// Issue() on an unpaid invoice reduces amount_due via ApplyCreditNote, which is
+// not idempotent. The draft→issued flip used to happen LAST, so a concurrent or
+// retried Issue() that both passed the draft check double-reduced amount_due.
+// The draft→issued CAS now runs first: exactly one call wins and applies the
+// reduction; the loser returns the already-issued note unchanged.
+func TestIssue_IdempotentNoDoubleApply(t *testing.T) {
+	store := newMemStore()
+	invoices := &memInvoiceReader{
+		invoices: map[string]domain.Invoice{
+			"inv_1": {
+				ID: "inv_1", TenantID: "t1", CustomerID: "cus_1",
+				Status: domain.InvoiceFinalized, PaymentStatus: domain.PaymentPending,
+				Currency: "USD", TotalAmountCents: 10000, AmountDueCents: 10000,
+			},
+		},
+	}
+	svc := NewService(store, invoices, nil)
+	ctx := context.Background()
+
+	cn, err := svc.Create(ctx, "t1", CreateInput{
+		InvoiceID: "inv_1",
+		Reason:    "Overcharged",
+		Lines:     []CreditLineInput{{Description: "adjustment", Quantity: 1, UnitAmountCents: 4000}},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// First Issue: wins the CAS, reduces amount_due by 4000 → 6000.
+	issued, err := svc.Issue(ctx, "t1", cn.ID)
+	if err != nil {
+		t.Fatalf("first Issue: %v", err)
+	}
+	if issued.Status != domain.CreditNoteIssued {
+		t.Fatalf("status after first issue: got %q, want issued", issued.Status)
+	}
+	if got := invoices.invoices["inv_1"].AmountDueCents; got != 6000 {
+		t.Fatalf("amount_due after first issue: got %d, want 6000 ($100 - $40)", got)
+	}
+
+	// Second Issue (retry / concurrent loser): must NOT reduce amount_due again.
+	// It returns InvalidState from the fast pre-check OR the already-issued note
+	// — either way, amount_due must stay 6000.
+	_, err = svc.Issue(ctx, "t1", cn.ID)
+	if err == nil {
+		// The pre-check rejects a non-draft note; if it ever returns the note
+		// instead, that's also acceptable as long as no double-apply happened.
+		t.Log("second Issue returned no error (idempotent return of issued note)")
+	}
+	if got := invoices.invoices["inv_1"].AmountDueCents; got != 6000 {
+		t.Errorf("amount_due after second issue: got %d, want 6000 (no double-reduction)", got)
+	}
+}
+
+// TestIssue_CASLoserDoesNotApply exercises the race directly: a note that is
+// already 'issued' in the store (as if a concurrent winner flipped it between
+// our Get and our CAS) must lose the CAS and skip ApplyCreditNote entirely.
+func TestIssue_CASLoserDoesNotApply(t *testing.T) {
+	store := newMemStore()
+	invoices := &memInvoiceReader{
+		invoices: map[string]domain.Invoice{
+			"inv_1": {
+				ID: "inv_1", TenantID: "t1", CustomerID: "cus_1",
+				Status: domain.InvoiceFinalized, PaymentStatus: domain.PaymentPending,
+				Currency: "USD", TotalAmountCents: 10000, AmountDueCents: 10000,
+			},
+		},
+	}
+	svc := NewService(store, invoices, nil)
+	ctx := context.Background()
+
+	cn, err := svc.Create(ctx, "t1", CreateInput{
+		InvoiceID: "inv_1", Reason: "x",
+		Lines: []CreditLineInput{{Description: "adj", Quantity: 1, UnitAmountCents: 4000}},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Win the CAS out-of-band, simulating a concurrent winner that already
+	// flipped the note to issued (but leave amount_due untouched so we can
+	// detect any erroneous second application).
+	won, err := store.TransitionStatus(ctx, "t1", cn.ID, domain.CreditNoteDraft, domain.CreditNoteIssued)
+	if err != nil || !won {
+		t.Fatalf("setup CAS: won=%v err=%v", won, err)
+	}
+
+	// Now Issue() must observe the non-draft status (pre-check) and never apply.
+	_, _ = svc.Issue(ctx, "t1", cn.ID)
+	if got := invoices.invoices["inv_1"].AmountDueCents; got != 10000 {
+		t.Errorf("amount_due: got %d, want 10000 (CAS loser must not apply)", got)
+	}
+}

--- a/internal/creditnote/postgres.go
+++ b/internal/creditnote/postgres.go
@@ -176,6 +176,46 @@ func (s *PostgresStore) List(ctx context.Context, filter ListFilter) ([]domain.C
 	return notes, rows.Err()
 }
 
+// TransitionStatus atomically flips a credit note from `from` to `to` only if
+// it is currently in `from`, returning whether this call won the transition.
+// The conditional UPDATE ... WHERE status=$from is the compare-and-swap that
+// serializes concurrent/retried Issue() calls: exactly one caller gets won=true
+// and proceeds to the (non-idempotent) amount_due reduction; the losers get
+// won=false and must not re-apply.
+func (s *PostgresStore) TransitionStatus(ctx context.Context, tenantID, id string, from, to domain.CreditNoteStatus) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return false, err
+	}
+	defer postgres.Rollback(tx)
+
+	now := clock.Now(ctx)
+	var issuedAt, voidedAt *time.Time
+	if to == domain.CreditNoteIssued {
+		issuedAt = &now
+	}
+	if to == domain.CreditNoteVoided {
+		voidedAt = &now
+	}
+
+	res, err := tx.ExecContext(ctx, `
+		UPDATE credit_notes SET status=$1, issued_at=COALESCE($2, issued_at),
+			voided_at=COALESCE($3, voided_at), updated_at=$4
+		WHERE id=$5 AND status=$6`,
+		to, postgres.NullableTime(issuedAt), postgres.NullableTime(voidedAt), now, id, from)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return n == 1, nil
+}
+
 func (s *PostgresStore) UpdateStatus(ctx context.Context, tenantID, id string, status domain.CreditNoteStatus) (domain.CreditNote, error) {
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {

--- a/internal/creditnote/service.go
+++ b/internal/creditnote/service.go
@@ -476,6 +476,23 @@ func (s *Service) Issue(ctx context.Context, tenantID, id string) (domain.Credit
 		return domain.CreditNote{}, errs.InvalidState("can only issue draft credit notes")
 	}
 
+	// Compare-and-swap the draft→issued transition BEFORE any side effect.
+	// Issue() reduces the invoice amount_due (unpaid path) and grants/refunds
+	// (paid path); the amount_due reduction is not idempotent, so two
+	// concurrent or retried Issue() calls that both passed the draft check
+	// above would apply it twice — double-reducing amount_due. The CAS makes
+	// exactly one caller the winner; losers see won=false and return the
+	// already-issued credit note unchanged.
+	won, err := s.store.TransitionStatus(ctx, tenantID, id, domain.CreditNoteDraft, domain.CreditNoteIssued)
+	if err != nil {
+		return domain.CreditNote{}, fmt.Errorf("claim issue transition: %w", err)
+	}
+	if !won {
+		// A concurrent/retried Issue() already claimed the transition. Return
+		// the current credit note rather than re-applying side effects.
+		return s.store.Get(ctx, tenantID, id)
+	}
+
 	inv, err := s.invoices.Get(ctx, tenantID, cn.InvoiceID)
 	if err != nil {
 		return domain.CreditNote{}, fmt.Errorf("get invoice: %w", err)
@@ -546,10 +563,10 @@ func (s *Service) Issue(ctx context.Context, tenantID, id string) (domain.Credit
 			}
 		}
 	} else {
-		// Invoice not yet paid — reduce amount_due. Idempotent via
-		// the cn.AmountDueReduced flag we'd add for full safety; for
-		// now this path is single-shot per CN and the UpdateStatus
-		// at the end guards against re-entry.
+		// Invoice not yet paid — reduce amount_due. This is the
+		// non-idempotent step; the draft→issued CAS at the top of Issue
+		// guarantees exactly one caller reaches here per credit note, so a
+		// concurrent/retried Issue() can't double-reduce amount_due.
 		if _, err := s.invoices.ApplyCreditNote(ctx, tenantID, cn.InvoiceID, cn.TotalCents); err != nil {
 			return domain.CreditNote{}, fmt.Errorf("reduce invoice amount: %w", err)
 		}
@@ -599,7 +616,9 @@ func (s *Service) Issue(ctx context.Context, tenantID, id string) (domain.Credit
 		}
 	}
 
-	return s.store.UpdateStatus(ctx, tenantID, id, domain.CreditNoteIssued)
+	// Status was already flipped to issued by the CAS at the top; just return
+	// the current row (with the refund/tax fields persisted above).
+	return s.store.Get(ctx, tenantID, id)
 }
 
 // RetryRefund re-attempts the Stripe refund for an already-issued

--- a/internal/creditnote/service_test.go
+++ b/internal/creditnote/service_test.go
@@ -71,6 +71,26 @@ func (m *memStore) UpdateStatus(_ context.Context, tenantID, id string, status d
 	return cn, nil
 }
 
+func (m *memStore) TransitionStatus(_ context.Context, tenantID, id string, from, to domain.CreditNoteStatus) (bool, error) {
+	cn, ok := m.notes[id]
+	if !ok || cn.TenantID != tenantID {
+		return false, errs.ErrNotFound
+	}
+	if cn.Status != from {
+		return false, nil // lost the CAS — already transitioned
+	}
+	cn.Status = to
+	now := time.Now().UTC()
+	if to == domain.CreditNoteIssued {
+		cn.IssuedAt = &now
+	}
+	if to == domain.CreditNoteVoided {
+		cn.VoidedAt = &now
+	}
+	m.notes[id] = cn
+	return true, nil
+}
+
 func (m *memStore) UpdateRefundStatus(_ context.Context, tenantID, id string, status domain.RefundStatus, stripeRefundID string) error {
 	cn, ok := m.notes[id]
 	if !ok || cn.TenantID != tenantID {

--- a/internal/creditnote/store.go
+++ b/internal/creditnote/store.go
@@ -11,6 +11,10 @@ type Store interface {
 	Get(ctx context.Context, tenantID, id string) (domain.CreditNote, error)
 	List(ctx context.Context, filter ListFilter) ([]domain.CreditNote, error)
 	UpdateStatus(ctx context.Context, tenantID, id string, status domain.CreditNoteStatus) (domain.CreditNote, error)
+	// TransitionStatus is a compare-and-swap status flip: it succeeds (won=true)
+	// only if the credit note is currently in `from`. Used to serialize the
+	// draft→issued transition against concurrent/retried Issue() calls.
+	TransitionStatus(ctx context.Context, tenantID, id string, from, to domain.CreditNoteStatus) (bool, error)
 	UpdateRefundStatus(ctx context.Context, tenantID, id string, status domain.RefundStatus, stripeRefundID string) error
 	// SetTaxTransaction persists the reversal transaction id returned by
 	// the tax provider at Issue time.


### PR DESCRIPTION
Medium-severity backend-audit finding (`creditnote/service.go:553`).

## Problem

`Issue()` on an **unpaid** invoice reduces `amount_due` via `ApplyCreditNote`, which is **not idempotent**, and the draft→issued status flip happened *last*. Two concurrent or retried `Issue()` calls that both passed the `status == draft` pre-check therefore both ran `ApplyCreditNote` — **double-reducing** the invoice's `amount_due`.

## Fix

Make the draft→issued transition the **first** mutating step via a conditional compare-and-swap: `UPDATE credit_notes SET status='issued' WHERE id=$1 AND status='draft'`. Exactly one caller wins (`won=true`) and proceeds to the side effects; losers get `won=false` and return the already-issued note without re-applying. The previously-redundant final `UpdateStatus` is replaced with a `Get` (the CAS already flipped the status).

Adds `Store.TransitionStatus` (CAS) with its postgres impl and mock.

## Tests

- `TestIssue_IdempotentNoDoubleApply`: a second `Issue()` leaves `amount_due` reduced exactly once.
- `TestIssue_CASLoserDoesNotApply`: a note already issued out-of-band makes `Issue()` skip `ApplyCreditNote` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)