### PR TITLE
fix(payment): ignore out-of-order payment_failed for a settled invoice

### DIFF
--- a/internal/payment/stripe.go
+++ b/internal/payment/stripe.go
@@ -712,6 +712,23 @@ func (s *Stripe) handlePaymentFailed(ctx context.Context, tenantID string, event
 		return fmt.Errorf("find invoice for PI %s: %w", event.PaymentIntentID, err)
 	}
 
+	// Ignore an out-of-order failure for an already-settled invoice. Stripe
+	// delivers webhooks at-least-once and without ordering guarantees, so a
+	// stale payment_intent.payment_failed can arrive AFTER the invoice was
+	// already marked paid (a retried PI failed upstream but a different PI
+	// succeeded first, or the success webhook simply landed first). Applying it
+	// would flip payment_status back to 'failed', null paid_at, relink the
+	// stale PI, and kick off dunning on a paid invoice. Treat it as a no-op.
+	if inv.Status == domain.InvoicePaid || inv.PaymentStatus == domain.PaymentSucceeded {
+		slog.Info("ignoring out-of-order payment_failed for already-settled invoice",
+			"invoice_id", inv.ID,
+			"invoice_status", inv.Status,
+			"payment_status", inv.PaymentStatus,
+			"event_payment_intent_id", event.PaymentIntentID,
+		)
+		return nil
+	}
+
 	// Bind effective-now so dunning's StartDunning (called below) and
 	// any UpdatePayment-side stamps land in simulated time on
 	// clock-pinned invoices.

--- a/internal/payment/stripe_test.go
+++ b/internal/payment/stripe_test.go
@@ -472,6 +472,58 @@ func TestHandleWebhook_PaymentFailed(t *testing.T) {
 	}
 }
 
+// TestHandleWebhook_PaymentFailed_IgnoredForPaidInvoice covers the pass-3
+// medium audit finding: an out-of-order payment_intent.payment_failed arriving
+// after an invoice is already paid must not corrupt it (flip to failed, null
+// paid_at, relink stale PI, start dunning). It's a no-op.
+func TestHandleWebhook_PaymentFailed_IgnoredForPaidInvoice(t *testing.T) {
+	paidAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name string
+		inv  domain.Invoice
+	}{
+		{"status paid", domain.Invoice{
+			ID: "inv_1", TenantID: "t1", Status: domain.InvoicePaid,
+			PaymentStatus: domain.PaymentSucceeded, PaidAt: &paidAt,
+			StripePaymentIntentID: "pi_ok",
+		}},
+		{"payment succeeded, finalized", domain.Invoice{
+			ID: "inv_1", TenantID: "t1", Status: domain.InvoiceFinalized,
+			PaymentStatus: domain.PaymentSucceeded, PaidAt: &paidAt,
+			StripePaymentIntentID: "pi_ok",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invoices := newMockInvoiceUpdater()
+			invoices.invoices["inv_1"] = tc.inv
+			invoices.byPI["pi_stale"] = "inv_1"
+
+			stripe := NewStripe(&mockStripeClient{}, invoices, newMockWebhookStore(), nil)
+
+			err := stripe.HandleWebhook(context.Background(), "t1", domain.StripeWebhookEvent{
+				StripeEventID:   "evt_ooo",
+				EventType:       "payment_intent.payment_failed",
+				PaymentIntentID: "pi_stale",
+				FailureMessage:  "Your card was declined.",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := invoices.invoices["inv_1"]
+			if got.PaymentStatus != domain.PaymentSucceeded {
+				t.Errorf("payment_status: got %q, want succeeded (out-of-order failure ignored)", got.PaymentStatus)
+			}
+			if got.PaidAt == nil {
+				t.Error("paid_at was nulled by an out-of-order failure")
+			}
+			if got.StripePaymentIntentID != "pi_ok" {
+				t.Errorf("stripe_payment_intent_id: got %q, want pi_ok (stale PI must not relink)", got.StripePaymentIntentID)
+			}
+		})
+	}
+}
+
 func TestHandleWebhook_DuplicateEvent(t *testing.T) {
 	invoices := newMockInvoiceUpdater()
 	invoices.invoices["inv_1"] = domain.Invoice{


### PR DESCRIPTION
Pass-3 medium backend-audit finding (`payment/stripe.go:725`).

## Problem

Stripe delivers webhooks **at-least-once and unordered**, so a stale `payment_intent.payment_failed` can arrive *after* an invoice is already paid (a retried PI failed upstream while a different PI succeeded first, or the success webhook simply landed first). `handlePaymentFailed` applied it unconditionally — flipping `payment_status` back to `failed`, nulling `paid_at` (UpdatePayment with `nil` paidAt), relinking the stale PI, and kicking off **dunning on a paid invoice**.

## Fix

When the resolved invoice is already settled (`Status == paid` OR `PaymentStatus == succeeded`), log and `return nil` before any mutation.

## Test

`TestHandleWebhook_PaymentFailed_IgnoredForPaidInvoice`: an out-of-order failure on a paid / succeeded-finalized invoice leaves `payment_status=succeeded`, `paid_at` intact, and the current PI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)