### PR TITLE
fix(creditnote): close credit-note cap TOCTOU with a per-invoice advisory lock

### DIFF
--- a/internal/creditnote/captoctou_integration_test.go
+++ b/internal/creditnote/captoctou_integration_test.go
@@ -1,0 +1,120 @@
+package creditnote_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/creditnote"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestCreateUnderInvoiceLock_SerializesCap covers the pass-3 medium audit
+// finding: the credit-note total cap was a TOCTOU — two concurrent Create
+// calls both read the same pre-state (no existing CNs), both passed the
+// "existing + new ≤ invoice total" check, and both inserted, crediting beyond
+// the invoice total. CreateUnderInvoiceLock takes a per-invoice advisory lock
+// so the second call sees the first's row and is capped.
+//
+// Invoice total = 10000. Two goroutines each try to create a 6000 CN. With the
+// lock exactly one wins (6000 ≤ 10000); the other sees 6000 already and its cap
+// rejects 6000+6000 > 10000. Persisted total must be 6000, never 12000.
+func TestCreateUnderInvoiceLock_SerializesCap(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	tenantID := testutil.CreateTestTenant(t, db, "CN Cap TOCTOU")
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_cap", DisplayName: "Cap",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	now := time.Now().UTC()
+	issued := now
+	inv, err := invoice.NewPostgresStore(db).Create(ctx, tenantID, domain.Invoice{
+		CustomerID:         cust.ID,
+		InvoiceNumber:      "INV-CAP-1",
+		Status:             domain.InvoiceFinalized,
+		PaymentStatus:      domain.PaymentPending,
+		Currency:           "USD",
+		SubtotalCents:      10000,
+		TotalAmountCents:   10000,
+		AmountDueCents:     10000,
+		BillingPeriodStart: now.Add(-30 * 24 * time.Hour),
+		BillingPeriodEnd:   now,
+		IssuedAt:           &issued,
+	})
+	if err != nil {
+		t.Fatalf("create invoice: %v", err)
+	}
+
+	store := creditnote.NewPostgresStore(db)
+
+	const amount = 6000
+	build := func(i int) func(existing []domain.CreditNote) (domain.CreditNote, error) {
+		return func(existing []domain.CreditNote) (domain.CreditNote, error) {
+			var existingTotal int64
+			for _, cn := range existing {
+				if cn.Status != domain.CreditNoteVoided {
+					existingTotal += cn.TotalCents
+				}
+			}
+			if existingTotal+amount > inv.TotalAmountCents {
+				return domain.CreditNote{}, fmt.Errorf("over cap")
+			}
+			return domain.CreditNote{
+				InvoiceID:         inv.ID,
+				CustomerID:        cust.ID,
+				CreditNoteNumber:  fmt.Sprintf("CN-CAP-%d", i),
+				Status:            domain.CreditNoteDraft,
+				Reason:            "concurrent",
+				SubtotalCents:     amount,
+				TotalCents:        amount,
+				CreditAmountCents: amount,
+				Currency:          "USD",
+				RefundStatus:      domain.RefundNone,
+			}, nil
+		}
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successes := 0
+	for i := range 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if _, err := store.CreateUnderInvoiceLock(ctx, tenantID, inv.ID, build(i)); err == nil {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if successes != 1 {
+		t.Errorf("successes: got %d, want 1 (lock must serialize the cap)", successes)
+	}
+
+	// Persisted credit-note total must not exceed the invoice total.
+	all, err := store.List(ctx, creditnote.ListFilter{TenantID: tenantID, InvoiceID: inv.ID})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	var persisted int64
+	for _, cn := range all {
+		persisted += cn.TotalCents
+	}
+	if persisted != amount {
+		t.Errorf("persisted CN total: got %d, want %d (never the un-capped 12000)", persisted, amount)
+	}
+}

--- a/internal/creditnote/postgres.go
+++ b/internal/creditnote/postgres.go
@@ -28,6 +28,56 @@ func (s *PostgresStore) Create(ctx context.Context, tenantID string, cn domain.C
 	}
 	defer postgres.Rollback(tx)
 
+	created, err := s.insertCreditNoteTx(ctx, tx, tenantID, cn)
+	if err != nil {
+		return domain.CreditNote{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.CreditNote{}, err
+	}
+	return created, nil
+}
+
+// CreateUnderInvoiceLock serializes credit-note creation per invoice. It takes
+// a transaction-scoped advisory lock keyed on (tenant, invoice), lists the
+// invoice's existing credit notes inside the same transaction, hands them to
+// `build` (which runs the over-credit / over-refund cap checks and returns the
+// credit note to insert), and inserts it — all atomically. A concurrent Create
+// for the same invoice blocks on the lock until this transaction commits, then
+// sees this credit note in its own list, so the caps can't be bypassed by a
+// time-of-check/time-of-use race. The lock releases automatically on commit.
+func (s *PostgresStore) CreateUnderInvoiceLock(ctx context.Context, tenantID, invoiceID string, build func(existing []domain.CreditNote) (domain.CreditNote, error)) (domain.CreditNote, error) {
+	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return domain.CreditNote{}, err
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, tenantID+":"+invoiceID,
+	); err != nil {
+		return domain.CreditNote{}, fmt.Errorf("acquire credit-note invoice lock: %w", err)
+	}
+
+	existing, err := s.listByInvoiceTx(ctx, tx, invoiceID)
+	if err != nil {
+		return domain.CreditNote{}, err
+	}
+	cn, err := build(existing)
+	if err != nil {
+		return domain.CreditNote{}, err
+	}
+	created, err := s.insertCreditNoteTx(ctx, tx, tenantID, cn)
+	if err != nil {
+		return domain.CreditNote{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.CreditNote{}, err
+	}
+	return created, nil
+}
+
+func (s *PostgresStore) insertCreditNoteTx(ctx context.Context, tx *sql.Tx, tenantID string, cn domain.CreditNote) (domain.CreditNote, error) {
 	id := postgres.NewID("vlx_cn")
 	// Honors ctx-bound effective-now (ADR-030) — credit notes against
 	// invoices on clock-pinned subs inherit sim-time. Falls back to
@@ -38,7 +88,7 @@ func (s *PostgresStore) Create(ctx context.Context, tenantID string, cn domain.C
 		metaJSON = []byte("{}")
 	}
 
-	err = tx.QueryRowContext(ctx, `
+	err := tx.QueryRowContext(ctx, `
 		INSERT INTO credit_notes (id, tenant_id, invoice_id, customer_id, credit_note_number,
 			status, reason, subtotal_cents, tax_amount_cents, total_cents,
 			refund_amount_cents, credit_amount_cents, out_of_band_amount_cents,
@@ -65,10 +115,42 @@ func (s *PostgresStore) Create(ctx context.Context, tenantID string, cn domain.C
 		return domain.CreditNote{}, err
 	}
 	_ = json.Unmarshal(metaJSON, &cn.Metadata)
-	if err := tx.Commit(); err != nil {
-		return domain.CreditNote{}, err
-	}
 	return cn, nil
+}
+
+// listByInvoiceTx lists every credit note for an invoice inside the caller's
+// transaction (used under the advisory lock in CreateUnderInvoiceLock). Mirrors
+// List's column projection.
+func (s *PostgresStore) listByInvoiceTx(ctx context.Context, tx *sql.Tx, invoiceID string) ([]domain.CreditNote, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, tenant_id, invoice_id, customer_id, credit_note_number,
+			status, reason, subtotal_cents, tax_amount_cents, total_cents,
+			refund_amount_cents, credit_amount_cents, out_of_band_amount_cents,
+			currency, issued_at, voided_at, refund_status, COALESCE(stripe_refund_id,''),
+			COALESCE(tax_transaction_id,''),
+			metadata, created_at, updated_at
+		FROM credit_notes WHERE invoice_id = $1`, invoiceID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var notes []domain.CreditNote
+	for rows.Next() {
+		var cn domain.CreditNote
+		var metaJSON []byte
+		if err := rows.Scan(&cn.ID, &cn.TenantID, &cn.InvoiceID, &cn.CustomerID, &cn.CreditNoteNumber,
+			&cn.Status, &cn.Reason, &cn.SubtotalCents, &cn.TaxAmountCents, &cn.TotalCents,
+			&cn.RefundAmountCents, &cn.CreditAmountCents, &cn.OutOfBandAmountCents,
+			&cn.Currency, &cn.IssuedAt, &cn.VoidedAt, &cn.RefundStatus, &cn.StripeRefundID,
+			&cn.TaxTransactionID,
+			&metaJSON, &cn.CreatedAt, &cn.UpdatedAt); err != nil {
+			return nil, err
+		}
+		_ = json.Unmarshal(metaJSON, &cn.Metadata)
+		notes = append(notes, cn)
+	}
+	return notes, rows.Err()
 }
 
 func (s *PostgresStore) Get(ctx context.Context, tenantID, id string) (domain.CreditNote, error) {

--- a/internal/creditnote/service.go
+++ b/internal/creditnote/service.go
@@ -173,31 +173,61 @@ func (s *Service) Create(ctx context.Context, tenantID string, input CreateInput
 		subtotal += line.Quantity * line.UnitAmountCents
 	}
 
-	// Validate: total credit notes cannot exceed invoice total.
-	// For unpaid invoices, also cap at current amount_due.
-	existingCNs, err := s.store.List(ctx, ListFilter{TenantID: tenantID, InvoiceID: input.InvoiceID})
+	// Build + insert the credit note under a per-invoice advisory lock so the
+	// over-credit / over-refund caps are evaluated against a snapshot that
+	// can't change underneath us. Two concurrent Create calls for the same
+	// invoice serialize on the lock: the second sees the first's note in
+	// `existingCNs` and is capped correctly, closing the TOCTOU where both
+	// read the same pre-state and both inserted past the invoice total.
+	cn, err := s.store.CreateUnderInvoiceLock(ctx, tenantID, input.InvoiceID, func(existingCNs []domain.CreditNote) (domain.CreditNote, error) {
+		// Validate: total credit notes cannot exceed invoice total.
+		// For unpaid invoices, also cap at current amount_due.
+		var existingTotal, existingTaxReversed int64
+		for _, cn := range existingCNs {
+			if cn.Status != domain.CreditNoteVoided {
+				existingTotal += cn.TotalCents
+				existingTaxReversed += cn.TaxAmountCents
+			}
+		}
+		if existingTotal+subtotal > inv.TotalAmountCents {
+			remaining := inv.TotalAmountCents - existingTotal
+			if remaining <= 0 {
+				return domain.CreditNote{}, errs.InvalidState("invoice has already been fully credited")
+			}
+			return domain.CreditNote{}, errs.Invalid("lines", fmt.Sprintf("credit note amount exceeds remaining creditable amount (%.2f)", float64(remaining)/100))
+		}
+		// For unpaid invoices, credit note cannot exceed current amount_due
+		if inv.Status == domain.InvoiceFinalized && subtotal > inv.AmountDueCents {
+			return domain.CreditNote{}, errs.Invalid("lines", fmt.Sprintf("credit note amount (%.2f) exceeds amount due (%.2f)", float64(subtotal)/100, float64(inv.AmountDueCents)/100))
+		}
+
+		return s.buildCreditNote(ctx, tenantID, input, inv, subtotal, existingTotal, existingTaxReversed, existingCNs)
+	})
 	if err != nil {
-		return domain.CreditNote{}, fmt.Errorf("list existing credit notes: %w", err)
-	}
-	var existingTotal, existingTaxReversed int64
-	for _, cn := range existingCNs {
-		if cn.Status != domain.CreditNoteVoided {
-			existingTotal += cn.TotalCents
-			existingTaxReversed += cn.TaxAmountCents
-		}
-	}
-	if existingTotal+subtotal > inv.TotalAmountCents {
-		remaining := inv.TotalAmountCents - existingTotal
-		if remaining <= 0 {
-			return domain.CreditNote{}, errs.InvalidState("invoice has already been fully credited")
-		}
-		return domain.CreditNote{}, errs.Invalid("lines", fmt.Sprintf("credit note amount exceeds remaining creditable amount (%.2f)", float64(remaining)/100))
-	}
-	// For unpaid invoices, credit note cannot exceed current amount_due
-	if inv.Status == domain.InvoiceFinalized && subtotal > inv.AmountDueCents {
-		return domain.CreditNote{}, errs.Invalid("lines", fmt.Sprintf("credit note amount (%.2f) exceeds amount due (%.2f)", float64(subtotal)/100, float64(inv.AmountDueCents)/100))
+		return domain.CreditNote{}, err
 	}
 
+	// Create line items
+	for _, line := range input.Lines {
+		_, err := s.store.CreateLineItem(ctx, tenantID, domain.CreditNoteLineItem{
+			CreditNoteID:      cn.ID,
+			InvoiceLineItemID: line.InvoiceLineItemID,
+			Description:       line.Description,
+			Quantity:          line.Quantity,
+			UnitAmountCents:   line.UnitAmountCents,
+			AmountCents:       line.Quantity * line.UnitAmountCents,
+		})
+		if err != nil {
+			return domain.CreditNote{}, fmt.Errorf("create line item: %w", err)
+		}
+	}
+	return cn, nil
+}
+
+// buildCreditNote runs the tax-breakout, three-channel allocation, refund cap,
+// and number generation, returning the credit note to insert. Called inside
+// CreateUnderInvoiceLock with the lock-stable `existingCNs` snapshot.
+func (s *Service) buildCreditNote(ctx context.Context, tenantID string, input CreateInput, inv domain.Invoice, subtotal, existingTotal, existingTaxReversed int64, existingCNs []domain.CreditNote) (domain.CreditNote, error) {
 	// Break out proportional tax from the gross subtotal. The invoice's
 	// tax_amount / total_amount ratio tells us what fraction of the gross
 	// was tax; apply the same ratio to the CN's gross subtotal so a
@@ -315,7 +345,7 @@ func (s *Service) Create(ctx context.Context, tenantID string, input CreateInput
 		cnNumber = fmt.Sprintf("CN-%s-%06d", now.Format("200601"), now.UnixNano()%1000000)
 	}
 
-	cn, err := s.store.Create(ctx, tenantID, domain.CreditNote{
+	return domain.CreditNote{
 		InvoiceID:            input.InvoiceID,
 		CustomerID:           inv.CustomerID,
 		CreditNoteNumber:     cnNumber,
@@ -329,27 +359,7 @@ func (s *Service) Create(ctx context.Context, tenantID string, input CreateInput
 		OutOfBandAmountCents: outOfBandAmount,
 		Currency:             inv.Currency,
 		RefundStatus:         domain.RefundNone,
-	})
-	if err != nil {
-		return domain.CreditNote{}, err
-	}
-
-	// Create line items
-	for _, line := range input.Lines {
-		_, err := s.store.CreateLineItem(ctx, tenantID, domain.CreditNoteLineItem{
-			CreditNoteID:      cn.ID,
-			InvoiceLineItemID: line.InvoiceLineItemID,
-			Description:       line.Description,
-			Quantity:          line.Quantity,
-			UnitAmountCents:   line.UnitAmountCents,
-			AmountCents:       line.Quantity * line.UnitAmountCents,
-		})
-		if err != nil {
-			return domain.CreditNote{}, fmt.Errorf("create line item: %w", err)
-		}
-	}
-
-	return cn, nil
+	}, nil
 }
 
 // RefundInput describes a direct refund against a paid invoice. It bypasses

--- a/internal/creditnote/service_test.go
+++ b/internal/creditnote/service_test.go
@@ -32,6 +32,20 @@ func (m *memStore) Create(_ context.Context, tenantID string, cn domain.CreditNo
 	return cn, nil
 }
 
+func (m *memStore) CreateUnderInvoiceLock(ctx context.Context, tenantID, invoiceID string, build func(existing []domain.CreditNote) (domain.CreditNote, error)) (domain.CreditNote, error) {
+	var existing []domain.CreditNote
+	for _, cn := range m.notes {
+		if cn.TenantID == tenantID && cn.InvoiceID == invoiceID {
+			existing = append(existing, cn)
+		}
+	}
+	cn, err := build(existing)
+	if err != nil {
+		return domain.CreditNote{}, err
+	}
+	return m.Create(ctx, tenantID, cn)
+}
+
 func (m *memStore) Get(_ context.Context, tenantID, id string) (domain.CreditNote, error) {
 	cn, ok := m.notes[id]
 	if !ok || cn.TenantID != tenantID {

--- a/internal/creditnote/store.go
+++ b/internal/creditnote/store.go
@@ -8,6 +8,12 @@ import (
 
 type Store interface {
 	Create(ctx context.Context, tenantID string, cn domain.CreditNote) (domain.CreditNote, error)
+	// CreateUnderInvoiceLock serializes credit-note creation for one invoice:
+	// it takes a per-invoice advisory lock, lists the invoice's existing credit
+	// notes in the same transaction, lets `build` run the cap checks against
+	// that locked snapshot and return the note to insert, and inserts it
+	// atomically — closing the over-credit TOCTOU on concurrent Create.
+	CreateUnderInvoiceLock(ctx context.Context, tenantID, invoiceID string, build func(existing []domain.CreditNote) (domain.CreditNote, error)) (domain.CreditNote, error)
 	Get(ctx context.Context, tenantID, id string) (domain.CreditNote, error)
 	List(ctx context.Context, filter ListFilter) ([]domain.CreditNote, error)
 	UpdateStatus(ctx context.Context, tenantID, id string, status domain.CreditNoteStatus) (domain.CreditNote, error)


### PR DESCRIPTION
Pass-3 medium backend-audit finding (`creditnote/service.go:178`).

## Problem

The over-credit / over-refund caps in `Create()` read the invoice's existing credit notes in one transaction and inserted the new note in another. Two concurrent `Create` calls for the same invoice both read the same pre-state, both passed `existing + new ≤ invoice total`, and both inserted — crediting/refunding **beyond the invoice total** (TOCTOU).

## Fix

`Store.CreateUnderInvoiceLock`: within a single transaction it takes `pg_advisory_xact_lock` keyed on `(tenant, invoice)`, lists the invoice's existing credit notes, runs the caps against that **locked snapshot** (via a `build` callback that keeps all business logic in the service), and inserts — atomically. A concurrent `Create` blocks on the lock until the first commits, then sees the new row and is capped. The cap/tax/allocation logic moved into `Service.buildCreditNote`, invoked inside the callback; line items are inserted afterward under the returned id.

## Test

`TestCreateUnderInvoiceLock_SerializesCap` fires two concurrent 6000 CNs at a 10000 invoice and asserts exactly one wins and the persisted total is 6000, never 12000.

⚠️ **The concurrency integration test requires postgres and could not be executed locally** (Docker daemon stopped mid-session). It compiles and type-checks (`go vet` clean); the unit suite passes; CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)