### PR TITLE
fix(api): gate X-Forwarded-For behind a trusted-proxy allowlist

### DIFF
--- a/internal/api/middleware/realip.go
+++ b/internal/api/middleware/realip.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ParseTrustedProxies parses a comma-separated TRUST_PROXY spec of CIDRs and/or
+// bare IPs into networks. A bare IP becomes a /32 (IPv4) or /128 (IPv6).
+// Blank/invalid entries are skipped. Empty input yields an empty slice, which
+// means "trust no proxy" — forwarding headers are then never honored.
+func ParseTrustedProxies(spec string) []*net.IPNet {
+	var nets []*net.IPNet
+	for _, raw := range strings.Split(spec, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		if !strings.Contains(raw, "/") {
+			if ip := net.ParseIP(raw); ip != nil {
+				bits := 32
+				if ip.To4() == nil {
+					bits = 128
+				}
+				raw += "/" + strconv.Itoa(bits)
+			}
+		}
+		if _, n, err := net.ParseCIDR(raw); err == nil {
+			nets = append(nets, n)
+		}
+	}
+	return nets
+}
+
+func ipInAny(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// TrustedRealIP rewrites r.RemoteAddr to the real client IP from
+// X-Forwarded-For / X-Real-IP, but ONLY when the immediate TCP peer
+// (r.RemoteAddr at entry) is one of the configured trusted proxies. When the
+// peer is untrusted — or no proxies are configured — the raw peer address is
+// kept, so a client behind no proxy cannot forge a forwarding header to rotate
+// its per-IP rate-limit bucket (enumeration bypass) or pin a victim's IP (DoS).
+//
+// Replaces chi's middleware.RealIP, which trusted those headers unconditionally.
+func TrustedRealIP(trusted []*net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ip := trustedClientIP(r, trusted); ip != "" {
+				r.RemoteAddr = ip
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// trustedClientIP returns the real client IP from forwarding headers when the
+// peer is a trusted proxy, or "" to signal "leave r.RemoteAddr unchanged".
+func trustedClientIP(r *http.Request, trusted []*net.IPNet) string {
+	peerHost, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		peerHost = r.RemoteAddr
+	}
+	peerIP := net.ParseIP(strings.TrimSpace(peerHost))
+	if peerIP == nil || !ipInAny(peerIP, trusted) {
+		// Direct or untrusted peer — forwarding headers are attacker-controlled.
+		return ""
+	}
+	// Peer is a trusted proxy. Walk X-Forwarded-For from the right (closest
+	// hop), skipping trusted-proxy hops; the first untrusted address is the
+	// real client. This stops a client from injecting fake left-most entries.
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		for i := len(parts) - 1; i >= 0; i-- {
+			cand := net.ParseIP(strings.TrimSpace(parts[i]))
+			if cand == nil || ipInAny(cand, trusted) {
+				continue
+			}
+			return cand.String()
+		}
+	}
+	if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {
+		if cand := net.ParseIP(xr); cand != nil {
+			return cand.String()
+		}
+	}
+	return ""
+}

--- a/internal/api/middleware/realip_test.go
+++ b/internal/api/middleware/realip_test.go
@@ -1,0 +1,71 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestTrustedRealIP covers the pass-3 [security] audit finding: chi's RealIP
+// honored X-Forwarded-For/X-Real-IP unconditionally, so any client could forge
+// a forwarding header to rotate its per-IP rate-limit bucket or pin a victim's
+// IP. TrustedRealIP only rewrites RemoteAddr when the TCP peer is a trusted
+// proxy.
+func TestTrustedRealIP(t *testing.T) {
+	trusted := ParseTrustedProxies("10.0.0.0/8,127.0.0.1")
+
+	run := func(remoteAddr, xff, xrealip string, nets []*net.IPNet) string {
+		var seen string
+		h := TrustedRealIP(nets)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			seen = r.RemoteAddr
+		}))
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = remoteAddr
+		if xff != "" {
+			req.Header.Set("X-Forwarded-For", xff)
+		}
+		if xrealip != "" {
+			req.Header.Set("X-Real-IP", xrealip)
+		}
+		h.ServeHTTP(httptest.NewRecorder(), req)
+		return seen
+	}
+
+	t.Run("untrusted peer: forged XFF ignored", func(t *testing.T) {
+		if got := run("203.0.113.9:5555", "1.2.3.4", "", trusted); got != "203.0.113.9:5555" {
+			t.Errorf("got %q, want raw peer (forged XFF must not be trusted)", got)
+		}
+	})
+
+	t.Run("trusted peer: XFF honored", func(t *testing.T) {
+		if got := run("10.1.2.3:443", "198.51.100.7", "", trusted); got != "198.51.100.7" {
+			t.Errorf("got %q, want 198.51.100.7 (real client via trusted proxy)", got)
+		}
+	})
+
+	t.Run("trusted peer: picks first untrusted from the right", func(t *testing.T) {
+		if got := run("127.0.0.1:8080", "198.51.100.7, 10.0.0.5, 10.0.0.6", "", trusted); got != "198.51.100.7" {
+			t.Errorf("got %q, want 198.51.100.7 (skip trusted hops, take real client)", got)
+		}
+	})
+
+	t.Run("trusted peer: X-Real-IP fallback", func(t *testing.T) {
+		if got := run("10.0.0.9:80", "", "192.0.2.44", trusted); got != "192.0.2.44" {
+			t.Errorf("got %q, want 192.0.2.44 (X-Real-IP from trusted proxy)", got)
+		}
+	})
+
+	t.Run("no trusted proxies configured: always raw peer", func(t *testing.T) {
+		if got := run("10.1.2.3:443", "198.51.100.7", "", nil); got != "10.1.2.3:443" {
+			t.Errorf("got %q, want raw peer (no proxies trusted)", got)
+		}
+	})
+}
+
+func TestParseTrustedProxies(t *testing.T) {
+	nets := ParseTrustedProxies("10.0.0.0/8, 127.0.0.1 , , bogus")
+	if len(nets) != 2 {
+		t.Fatalf("parsed %d nets, want 2 (CIDR + bare IP; blank/bogus skipped)", len(nets))
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -976,7 +976,17 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	r := chi.NewRouter()
 	r.Use(mw.Tracing())
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	// Only honor X-Forwarded-For / X-Real-IP from configured trusted proxies.
+	// chi's middleware.RealIP trusted them unconditionally, letting any client
+	// forge a forwarding header to rotate its per-IP rate-limit bucket
+	// (enumeration bypass) or pin a victim's IP. TRUST_PROXY is a comma-list of
+	// CIDRs / IPs (e.g. "10.0.0.0/8,127.0.0.1"); unset → trust nothing and key
+	// rate limits on the raw TCP peer.
+	trustedProxies := mw.ParseTrustedProxies(os.Getenv("TRUST_PROXY"))
+	if len(trustedProxies) == 0 {
+		slog.Info("TRUST_PROXY not set — X-Forwarded-For/X-Real-IP ignored; rate limiting keys on the direct TCP peer. Set TRUST_PROXY to your load balancer's CIDR if Velox runs behind a proxy.")
+	}
+	r.Use(mw.TrustedRealIP(trustedProxies))
 	corsEnv := os.Getenv("CORS_ALLOWED_ORIGINS")
 	if corsEnv == "" {
 		corsEnv = "http://localhost:3000,http://localhost:5173,http://localhost:5174"


### PR DESCRIPTION
Pass-3 medium **[security]** backend-audit finding (`router.go:979`).

## Problem

The router used chi's `middleware.RealIP`, which overwrites `RemoteAddr` from `X-Forwarded-For` / `X-Real-IP` **unconditionally**. The per-IP rate-limit bucket keys on `RemoteAddr`, so any client could forge the header to **rotate buckets** (public-surface enumeration / rate-limit bypass) or **pin a victim's IP** (targeted rate-limit DoS).

## Fix

`mw.TrustedRealIP`: forwarding headers are honored only when the immediate TCP peer is within a configured trusted-proxy CIDR (`TRUST_PROXY` env — comma-list of CIDRs / IPs). It walks `X-Forwarded-For` right→left, skipping trusted hops, and takes the first untrusted address as the real client. Untrusted peer or unset `TRUST_PROXY` → the raw TCP peer is kept; boot logs a notice so an operator behind a real LB knows to set it.

## Tests (no DB)

Forged XFF from an untrusted peer is ignored; a trusted proxy's XFF / X-Real-IP is honored; multi-hop chains pick the first untrusted hop; with no proxies configured the raw peer always wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)