### PR TITLE
fix(api): scope idempotency keys per portal customer + surface cache failures

### DIFF
--- a/internal/api/middleware/idempotency.go
+++ b/internal/api/middleware/idempotency.go
@@ -23,6 +23,23 @@ import (
 // are rare and the risk of key reuse with different bodies is low.
 const maxIdempotentBodyBytes = 1 << 20 // 1 MiB
 
+// statusPending marks a reserved-but-not-yet-completed idempotency row. The
+// request that claims the key writes this sentinel before running the handler;
+// concurrent requests that find it poll until the owner overwrites it with the
+// real status_code (always > 0). status_code is NOT NULL, so a sentinel value
+// is how "in flight" is encoded without a separate column.
+const statusPending = 0
+
+// idempotencyPollInterval / idempotencyPollTimeout bound how long a losing
+// concurrent request waits for the winning request to store its response
+// before giving up with 409. The timeout is shorter than typical handler
+// budgets — a request that's still pending after this either died mid-flight
+// or is a genuinely slow operation the client should retry, not block on.
+const (
+	idempotencyPollInterval = 25 * time.Millisecond
+	idempotencyPollTimeout  = 5 * time.Second
+)
+
 // Idempotency returns middleware that caches responses for POST/PUT/PATCH
 // requests that include an Idempotency-Key header. If a request with the same
 // key has been processed before, the cached response is returned.
@@ -81,26 +98,28 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 
 			fingerprint := fingerprintRequest(r.Method, r.URL.Path, bodyBytes)
 
-			cached, found, err := getCachedResponse(r.Context(), db, tenantID, key)
+			// RESERVE the key before running the handler. A single INSERT ...
+			// ON CONFLICT DO NOTHING is the serialization point: exactly one
+			// concurrent request with the same (tenant, livemode, key) inserts
+			// the pending row, every other request conflicts. Without this
+			// reserve-before-act step, two simultaneous retries both passed the
+			// old check-then-act read (no row yet) and both ran the side effect
+			// — double credit-grant / double-charge.
+			claimed, err := reserveKey(r.Context(), db, tenantID, key,
+				r.Method, r.URL.Path, fingerprint)
 			if err != nil {
-				// DB error — fail open (don't block the write). An idempotency
-				// check failure shouldn't prevent the actual operation.
+				// DB error on the reserve — fail open (don't block the write).
+				// An idempotency-infra failure shouldn't prevent the actual
+				// operation; this matches the prior read-path fail-open.
 				next.ServeHTTP(w, r)
 				return
 			}
-			if found {
-				// Fingerprint mismatch → key reused with different parameters.
-				// Stripe returns 422 idempotency_error here.
-				if len(cached.Fingerprint) > 0 &&
-					subtle.ConstantTimeCompare(cached.Fingerprint, fingerprint) != 1 {
-					ErrorJSON(w, http.StatusUnprocessableEntity, "idempotency_error",
-						"Keys for idempotent requests can only be used with the same parameters they were first used with.")
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				w.Header().Set("Idempotent-Replayed", "true")
-				w.WriteHeader(cached.StatusCode)
-				_, _ = w.Write(cached.Body)
+			if !claimed {
+				// Someone else owns this key. It either already completed (or is
+				// in flight from a concurrent request). Resolve it the same way
+				// a serial retry would: replay the stored response, 422 on a
+				// fingerprint mismatch, or 409 if it never resolves.
+				replayExistingKey(w, r.Context(), db, tenantID, key, fingerprint)
 				return
 			}
 
@@ -110,6 +129,12 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 				body:           &bytes.Buffer{},
 			}
 			next.ServeHTTP(recorder, r)
+
+			// Finalize the reservation. Run against context.Background (with the
+			// captured livemode) so the write survives a client disconnect — a
+			// dropped connection after the side effect committed must still
+			// persist the response, or the retry re-runs it.
+			bgCtx := postgres.WithLivemode(context.Background(), livemode)
 
 			// Cache 2xx/3xx/4xx/5xx except 409 and 422. The core value of
 			// idempotency is that a transient 500 retry must not re-run side
@@ -124,14 +149,15 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 			// contention clears may legitimately succeed), 422 typically
 			// from input validation (the client usually fixes the body, and
 			// our fingerprint check will flag that as a key-reuse error).
-			// Pinning either would trap the caller.
-			if recorder.statusCode != http.StatusConflict &&
-				recorder.statusCode != http.StatusUnprocessableEntity {
-				bgCtx := postgres.WithLivemode(context.Background(), livemode)
-				storeCachedResponse(bgCtx, db, tenantID, key,
-					r.Method, r.URL.Path, fingerprint,
-					recorder.statusCode, recorder.body.Bytes())
+			// Pinning either would trap the caller — so we DELETE the pending
+			// reservation instead, freeing the key for a clean retry.
+			if recorder.statusCode == http.StatusConflict ||
+				recorder.statusCode == http.StatusUnprocessableEntity {
+				releaseKey(bgCtx, db, tenantID, key)
+				return
 			}
+			finalizeKey(bgCtx, db, tenantID, key,
+				recorder.statusCode, recorder.body.Bytes())
 		})
 	}
 }
@@ -155,55 +181,183 @@ type cachedResponse struct {
 	Fingerprint []byte
 }
 
-func getCachedResponse(ctx context.Context, db *postgres.DB, tenantID, key string) (cachedResponse, bool, error) {
+// reserveKey atomically claims the idempotency key by inserting a pending row
+// (status_code = statusPending) with ON CONFLICT DO NOTHING. It reports whether
+// THIS request won the claim: RowsAffected == 1 → claimed (proceed to handler),
+// 0 → another request already owns the key (replay its outcome). This single
+// statement is the serialization point that prevents two concurrent requests
+// from both executing the side effect.
+//
+// livemode is omitted from the INSERT column list on purpose — the BEFORE
+// INSERT trigger (set_livemode_from_session) stamps it from the tx session, so
+// the row lands in the same mode partition the request runs under. The
+// (tenant_id, livemode, key) primary key is the unique constraint the conflict
+// resolves against.
+func reserveKey(ctx context.Context, db *postgres.DB, tenantID, key, method, path string, fingerprint []byte) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {
-		return cachedResponse{}, false, err
+		return false, err
 	}
 	defer postgres.Rollback(tx)
 
-	var c cachedResponse
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO idempotency_keys (key, tenant_id, http_method, http_path, request_fingerprint, status_code, response_body)
+		VALUES ($1, $2, $3, $4, $5, $6, ''::bytea)
+		ON CONFLICT (tenant_id, livemode, key) DO NOTHING`,
+		key, tenantID, method, path, fingerprint, statusPending,
+	)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		// Conflict: another request holds the key. Nothing to commit.
+		return false, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// finalizeKey writes the captured response onto the pending reservation. The
+// owning request always overwrites its own pending row, so an unconditional
+// UPDATE on (tenant_id, key) is correct.
+func finalizeKey(ctx context.Context, db *postgres.DB, tenantID, key string, statusCode int, body []byte) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE idempotency_keys SET status_code = $3, response_body = $4
+		WHERE tenant_id = $1 AND key = $2`,
+		tenantID, key, statusCode, body,
+	); err != nil {
+		return
+	}
+	_ = tx.Commit()
+}
+
+// releaseKey deletes the pending reservation so a key whose handler returned a
+// non-cacheable status (409/422) can be retried cleanly. Without this, the
+// pending row would linger until expiry and every retry would 409.
+func releaseKey(ctx context.Context, db *postgres.DB, tenantID, key string) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return
+	}
+	defer postgres.Rollback(tx)
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM idempotency_keys WHERE tenant_id = $1 AND key = $2 AND status_code = $3`,
+		tenantID, key, statusPending,
+	); err != nil {
+		return
+	}
+	_ = tx.Commit()
+}
+
+// readKey loads the current state of a reserved/completed idempotency row.
+// pending reports whether the owning request hasn't finalized yet
+// (status_code == statusPending). found is false when no live row exists.
+func readKey(ctx context.Context, db *postgres.DB, tenantID, key string) (c cachedResponse, found, pending bool, err error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
+	if err != nil {
+		return cachedResponse{}, false, false, err
+	}
+	defer postgres.Rollback(tx)
+
 	err = tx.QueryRowContext(ctx,
 		`SELECT status_code, response_body, request_fingerprint FROM idempotency_keys
 		WHERE tenant_id = $1 AND key = $2 AND expires_at > now()`,
 		tenantID, key,
 	).Scan(&c.StatusCode, &c.Body, &c.Fingerprint)
 	if errors.Is(err, sql.ErrNoRows) {
-		return c, false, nil
+		return cachedResponse{}, false, false, nil
 	}
 	if err != nil {
-		return c, false, err
+		return cachedResponse{}, false, false, err
 	}
 	if err := tx.Commit(); err != nil {
-		return c, false, err
+		return cachedResponse{}, false, false, err
 	}
-	return c, true, nil
+	return c, true, c.StatusCode == statusPending, nil
 }
 
-func storeCachedResponse(ctx context.Context, db *postgres.DB, tenantID, key, method, path string, fingerprint []byte, statusCode int, body []byte) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
-	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
-	if err != nil {
-		return
+// replayExistingKey resolves a request that lost the reserve race. It enforces
+// the fingerprint contract (422 on parameter mismatch), replays the stored
+// response once the owner finalizes, and polls briefly while the owner is still
+// in flight. If the owner never finalizes within the poll window — it died, or
+// the operation is too slow to block on — it returns 409 conflict_idempotency,
+// signaling the client to retry.
+func replayExistingKey(w http.ResponseWriter, ctx context.Context, db *postgres.DB, tenantID, key string, fingerprint []byte) {
+	deadline := time.Now().Add(idempotencyPollTimeout)
+	for {
+		c, found, pending, err := readKey(ctx, db, tenantID, key)
+		if err != nil {
+			// DB error resolving the conflict — fail open is unsafe here
+			// (the side effect may already be running), so surface a 409 the
+			// client retries rather than re-executing the operation.
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A request with this idempotency key is being processed. Please retry.")
+			return
+		}
+		if found && !pending {
+			// Fingerprint mismatch → key reused with different parameters.
+			// Stripe returns 422 idempotency_error here.
+			if len(c.Fingerprint) > 0 &&
+				subtle.ConstantTimeCompare(c.Fingerprint, fingerprint) != 1 {
+				ErrorJSON(w, http.StatusUnprocessableEntity, "idempotency_error",
+					"Keys for idempotent requests can only be used with the same parameters they were first used with.")
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Idempotent-Replayed", "true")
+			w.WriteHeader(c.StatusCode)
+			_, _ = w.Write(c.Body)
+			return
+		}
+		// Not found means the owner released the key (409/422 handler) — the
+		// key is free again, but this request already lost the race; treat it
+		// as a conflict so the client retries into a clean slot rather than
+		// re-running concurrently.
+		if !found {
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A concurrent request with this idempotency key did not complete. Please retry.")
+			return
+		}
+		// Still pending. Wait for the owner to finalize, bounded by the poll
+		// timeout and the request context.
+		if time.Now().After(deadline) {
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A request with this idempotency key is still being processed. Please retry.")
+			return
+		}
+		select {
+		case <-ctx.Done():
+			ErrorJSON(w, http.StatusConflict, "conflict_idempotency",
+				"A request with this idempotency key is being processed. Please retry.")
+			return
+		case <-time.After(idempotencyPollInterval):
+		}
 	}
-	defer postgres.Rollback(tx)
-
-	livemode := auth.Livemode(ctx)
-
-	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO idempotency_keys (key, tenant_id, livemode, http_method, http_path, request_fingerprint, status_code, response_body)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		ON CONFLICT (tenant_id, livemode, key) DO NOTHING`,
-		key, tenantID, livemode, method, path, fingerprint, statusCode, body,
-	); err != nil {
-		return
-	}
-	_ = tx.Commit()
 }
 
 // responseRecorder captures the response for caching while writing to the client.

--- a/internal/api/middleware/idempotency.go
+++ b/internal/api/middleware/idempotency.go
@@ -9,11 +9,13 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/sagarsuperuser/velox/internal/auth"
+	"github.com/sagarsuperuser/velox/internal/customerportal"
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
 )
 
@@ -98,6 +100,17 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 
 			fingerprint := fingerprintRequest(r.Method, r.URL.Path, bodyBytes)
 
+			// Scope the key to the acting customer on the customer-portal
+			// surface (/v1/me). The idempotency_keys row is keyed on
+			// (tenant, livemode, key) only — without the customer actor folded
+			// in, two different portal customers under the same tenant sending
+			// the same Idempotency-Key would collide, and customer B could be
+			// served customer A's cached profile response. Namespacing the
+			// stored key with the customer id makes the rows disjoint. Operator
+			// (Bearer/session) requests carry no portal customer, so their key
+			// is unchanged.
+			key = scopeKeyToCustomer(r.Context(), key)
+
 			// RESERVE the key before running the handler. A single INSERT ...
 			// ON CONFLICT DO NOTHING is the serialization point: exactly one
 			// concurrent request with the same (tenant, livemode, key) inserts
@@ -110,7 +123,13 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 			if err != nil {
 				// DB error on the reserve — fail open (don't block the write).
 				// An idempotency-infra failure shouldn't prevent the actual
-				// operation; this matches the prior read-path fail-open.
+				// operation; this matches the prior read-path fail-open. But it
+				// IS an idempotency lapse: a concurrent/retried request can now
+				// re-run the side effect, so make it observable rather than
+				// silent — operators need to see it during a DB blip.
+				idempotencyCacheErrors.WithLabelValues("reserve").Inc()
+				slog.ErrorContext(r.Context(), "idempotency reserve failed; failing open (side effect may re-execute on retry)",
+					"tenant_id", tenantID, "path", r.URL.Path, "error", err)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -160,6 +179,17 @@ func Idempotency(db *postgres.DB) func(http.Handler) http.Handler {
 				recorder.statusCode, recorder.body.Bytes())
 		})
 	}
+}
+
+// scopeKeyToCustomer namespaces the idempotency key with the acting portal
+// customer, when present, so two customers under the same tenant can't collide
+// on (tenant, livemode, key) and replay each other's cached responses. Operator
+// requests (no portal customer in ctx) return the key unchanged.
+func scopeKeyToCustomer(ctx context.Context, key string) string {
+	if cid := customerportal.CustomerID(ctx); cid != "" {
+		return "cust:" + cid + ":" + key
+	}
+	return key
 }
 
 // fingerprintRequest returns a stable hash of the request's identifying
@@ -233,8 +263,19 @@ func finalizeKey(ctx context.Context, db *postgres.DB, tenantID, key string, sta
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
+	// A finalize failure leaves the row 'pending', so a retry under the same
+	// key re-runs the handler (the response was never cached) — the exact
+	// double-execution idempotency exists to prevent. Make every failure path
+	// observable instead of swallowing it.
+	fail := func(stage string, err error) {
+		idempotencyCacheErrors.WithLabelValues("finalize").Inc()
+		slog.ErrorContext(ctx, "idempotency finalize failed; response NOT cached, retry will re-run the handler",
+			"stage", stage, "tenant_id", tenantID, "status_code", statusCode, "error", err)
+	}
+
 	tx, err := db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {
+		fail("begin", err)
 		return
 	}
 	defer postgres.Rollback(tx)
@@ -244,9 +285,12 @@ func finalizeKey(ctx context.Context, db *postgres.DB, tenantID, key string, sta
 		WHERE tenant_id = $1 AND key = $2`,
 		tenantID, key, statusCode, body,
 	); err != nil {
+		fail("update", err)
 		return
 	}
-	_ = tx.Commit()
+	if err := tx.Commit(); err != nil {
+		fail("commit", err)
+	}
 }
 
 // releaseKey deletes the pending reservation so a key whose handler returned a

--- a/internal/api/middleware/idempotency_cache_test.go
+++ b/internal/api/middleware/idempotency_cache_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sagarsuperuser/velox/internal/auth"
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
@@ -136,6 +138,78 @@ func TestIdempotency_FingerprintMismatchStill422(t *testing.T) {
 	}
 	if !strings.Contains(rec2.Body.String(), "idempotency_error") {
 		t.Errorf("mismatch: expected idempotency_error in body, got: %s", rec2.Body.String())
+	}
+}
+
+// TestIdempotency_ConcurrentSameKey_RunsOnce is the regression test for the
+// check-then-act race: two concurrent requests with the same idempotency key
+// must execute the side effect exactly once. Before the reserve-before-act
+// fix, both requests passed the read (no row yet) and both invoked the handler
+// — a double credit-grant / double-charge. With the fix, exactly one request
+// claims the key and runs the handler; the other either replays the stored
+// response or gets a 409 conflict_idempotency, but never re-executes.
+func TestIdempotency_ConcurrentSameKey_RunsOnce(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	tenantID := testutil.CreateTestTenant(t, db, "Idempotency Concurrent")
+
+	var calls atomic.Int64
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Count the side effect (the "credit grant"). Sleep briefly while
+		// holding the claim so the racing request reliably reaches the
+		// conflict path and starts polling — exercising the serialization.
+		calls.Add(1)
+		time.Sleep(150 * time.Millisecond)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"granted"}`))
+	})
+	handler := Idempotency(db)(inner)
+
+	const n = 2
+	var (
+		wg      sync.WaitGroup
+		start   = make(chan struct{})
+		codes   [n]int
+		replays [n]string
+	)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release both goroutines as close to simultaneously as possible
+			rec := invokeWithKey(t, handler, tenantID, "idem-concurrent", `{"amount":100}`)
+			codes[i] = rec.Code
+			replays[i] = rec.Header().Get("Idempotent-Replayed")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// The side effect must have run exactly once.
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("concurrent same-key: handler must run exactly once, got %d", got)
+	}
+
+	// Exactly one request executed (201, no replay header). The other must be
+	// either a replay of that 201, or a 409 conflict_idempotency — never a
+	// second fresh execution.
+	executed, replayed, conflicted := 0, 0, 0
+	for i := 0; i < n; i++ {
+		switch {
+		case codes[i] == http.StatusCreated && replays[i] == "":
+			executed++
+		case codes[i] == http.StatusCreated && replays[i] == "true":
+			replayed++
+		case codes[i] == http.StatusConflict:
+			conflicted++
+		default:
+			t.Errorf("request %d: unexpected outcome code=%d replayed=%q", i, codes[i], replays[i])
+		}
+	}
+	if executed != 1 {
+		t.Errorf("exactly one request should have executed fresh, got %d (codes=%v replays=%v)", executed, codes, replays)
+	}
+	if replayed+conflicted != 1 {
+		t.Errorf("the other request should replay or 409, got replayed=%d conflicted=%d (codes=%v)", replayed, conflicted, codes)
 	}
 }
 

--- a/internal/api/middleware/idempotency_scope_test.go
+++ b/internal/api/middleware/idempotency_scope_test.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/customerportal"
+)
+
+// TestScopeKeyToCustomer covers the pass-3 [security] audit finding: the
+// idempotency row is keyed on (tenant, livemode, key) only, so two portal
+// customers under the same tenant sending the same Idempotency-Key collided and
+// could replay each other's cached responses. scopeKeyToCustomer namespaces the
+// key with the acting customer so the rows are disjoint; operator requests
+// (no portal customer) keep the raw key.
+func TestScopeKeyToCustomer(t *testing.T) {
+	t.Run("operator request: key unchanged", func(t *testing.T) {
+		got := scopeKeyToCustomer(context.Background(), "idem-123")
+		if got != "idem-123" {
+			t.Errorf("got %q, want unchanged key for non-portal request", got)
+		}
+	})
+
+	t.Run("portal customers get disjoint scopes", func(t *testing.T) {
+		ctxA := customerportal.WithTestIdentity(context.Background(), "t1", "cus_A")
+		ctxB := customerportal.WithTestIdentity(context.Background(), "t1", "cus_B")
+
+		gotA := scopeKeyToCustomer(ctxA, "idem-123")
+		gotB := scopeKeyToCustomer(ctxB, "idem-123")
+
+		if gotA == gotB {
+			t.Fatalf("same scoped key for different customers (%q) — cross-customer replay still possible", gotA)
+		}
+		if gotA == "idem-123" || gotB == "idem-123" {
+			t.Errorf("portal key was not namespaced: A=%q B=%q", gotA, gotB)
+		}
+	})
+
+	t.Run("same customer + key is stable", func(t *testing.T) {
+		ctx1 := customerportal.WithTestIdentity(context.Background(), "t1", "cus_A")
+		ctx2 := customerportal.WithTestIdentity(context.Background(), "t1", "cus_A")
+		if scopeKeyToCustomer(ctx1, "k") != scopeKeyToCustomer(ctx2, "k") {
+			t.Error("scoped key must be deterministic for the same customer+key")
+		}
+	})
+}

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -43,6 +43,20 @@ var (
 		},
 	)
 
+	// idempotencyCacheErrors counts idempotency-layer DB failures by stage.
+	// Non-zero means the idempotency guarantee lapsed: a "reserve" failure
+	// fell open (the handler ran without a claim, so a concurrent/retried
+	// request could re-execute the side effect), and a "finalize" failure
+	// means the response wasn't cached (a retry under the same key re-runs the
+	// handler). Operators should alert on any sustained rate here.
+	idempotencyCacheErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "velox_idempotency_cache_errors_total",
+			Help: "Idempotency cache DB errors by stage (reserve|finalize).",
+		},
+		[]string{"stage"},
+	)
+
 	invoicesGenerated = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "velox_invoices_generated_total",


### PR DESCRIPTION
Three pass-3 backend-audit findings in the idempotency middleware.

> **Stacked on #98** (`audit/idempotency`) — base is that branch, not `main`, because these build on #98's `reserveKey`/`finalizeKey` structure. Merge #98 first, then rebase this onto `main` (or merge in order).

## 1. [security] Cross-customer replay on `/v1/me` (`idempotency.go:50`)

The `idempotency_keys` row is keyed on `(tenant, livemode, key)` only, so two portal customers under the same tenant sending the same `Idempotency-Key` collided — customer B could be served customer A's cached profile response. `scopeKeyToCustomer` namespaces the stored key with the acting portal customer (`customerportal.CustomerID`), making the rows disjoint. Operator (Bearer/session) requests carry no portal customer → key unchanged.

## 2. [security] Reserve fail-open was silent (`idempotency.go:85`)

A DB error on `reserveKey` falls open (runs the handler without a claim) → a concurrent/retried request can re-execute the side effect. Now increments `velox_idempotency_cache_errors_total{stage="reserve"}` and logs at ERROR so the lapse is observable.

## 3. [security] Finalize swallowed write errors (`idempotency.go:186`)

A failed finalize leaves the row `pending`, so a retry re-runs the handler (response never cached). Every failure path (begin/update/commit) now increments `{stage="finalize"}` and logs at ERROR instead of returning silently.

## Test

`TestScopeKeyToCustomer`: disjoint keys for different customers, unchanged key for operator requests, deterministic for the same customer+key. The DB-backed reserve/finalize paths are covered by existing idempotency integration tests; the new observability is log/metric only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)