### PR TITLE
fix(usage): bound live ingest timestamps and quantity magnitude

### DIFF
--- a/internal/usage/service.go
+++ b/internal/usage/service.go
@@ -66,6 +66,15 @@ func (s *Service) Backfill(ctx context.Context, tenantID string, input IngestInp
 // cap on meter_pricing_rules.dimension_match (16 keys).
 const MaxDimensionKeys = 16
 
+// usageFutureSkew is how far ahead of wall-clock a live usage event timestamp
+// may be before it's rejected — absorbs minor client clock drift without
+// letting events be parked in a future billing period.
+const usageFutureSkew = 5 * time.Minute
+
+// maxQuantityMagnitude is the exclusive upper bound on |quantity|. The column
+// is NUMERIC(38,12) → 26 integer digits, so values ≥ 10^26 overflow it.
+var maxQuantityMagnitude = decimal.New(1, 26) // 10^26
+
 // validateDimensions enforces the v1 dimension contract: at most
 // MaxDimensionKeys keys, scalar values only (string, number, bool, nil).
 // Object/array values are rejected — Postgres `@>` would still match
@@ -101,9 +110,25 @@ func (s *Service) ingest(ctx context.Context, tenantID string, input IngestInput
 		// Negative values are allowed as usage corrections.
 		input.Quantity = decimal.NewFromInt(1)
 	}
+	// The quantity column is NUMERIC(38,12): at most 26 integer digits. A value
+	// with |q| ≥ 10^26 overflows the column and Postgres rejects the INSERT,
+	// surfacing as an HTTP 500. Reject it here as a clean 422 instead. (Excess
+	// fractional precision beyond 12 places is rounded by the column, not an
+	// error, so only the integer magnitude is gated.)
+	if input.Quantity.Abs().Cmp(maxQuantityMagnitude) >= 0 {
+		return domain.UsageEvent{}, errs.Invalid("quantity", "magnitude too large — must be less than 10^26")
+	}
 
 	ts := time.Now().UTC()
 	if input.Timestamp != nil {
+		// Reject future-dated live events (a small clock-skew tolerance keeps
+		// legitimate near-now client clocks working). Without this, only
+		// Backfill rejected future timestamps and a live POST could park usage
+		// in a future billing period. Backfill applies its own stricter
+		// past-only gate before reaching here.
+		if input.Timestamp.After(time.Now().UTC().Add(usageFutureSkew)) {
+			return domain.UsageEvent{}, errs.Invalid("timestamp", "must not be in the future")
+		}
 		ts = input.Timestamp.UTC()
 	}
 

--- a/internal/usage/service_test.go
+++ b/internal/usage/service_test.go
@@ -130,6 +130,43 @@ func TestIngest(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects future timestamp on live ingest", func(t *testing.T) {
+		future := time.Now().UTC().Add(2 * time.Hour)
+		_, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "cus_fut", MeterID: "mtr_1", Quantity: dec(1), Timestamp: &future,
+		})
+		if err == nil {
+			t.Error("expected rejection for future-dated live usage event")
+		}
+	})
+
+	t.Run("allows near-now timestamp within skew", func(t *testing.T) {
+		near := time.Now().UTC().Add(1 * time.Minute) // within usageFutureSkew
+		_, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "cus_near", MeterID: "mtr_1", Quantity: dec(1), Timestamp: &near,
+		})
+		if err != nil {
+			t.Errorf("near-now timestamp within skew should be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("rejects quantity exceeding NUMERIC(38,12) envelope", func(t *testing.T) {
+		huge := decimal.New(1, 26) // 10^26 — one past the 26-integer-digit limit
+		_, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "cus_big", MeterID: "mtr_1", Quantity: huge,
+		})
+		if err == nil {
+			t.Error("expected 422-style rejection for over-magnitude quantity (would 500 on INSERT)")
+		}
+		// A large-but-representable value (just under the bound) is accepted.
+		ok := decimal.New(999, 23) // 9.99e25 < 10^26
+		if _, err := svc.Ingest(ctx, "t1", IngestInput{
+			CustomerID: "cus_ok_big", MeterID: "mtr_1", Quantity: ok,
+		}); err != nil {
+			t.Errorf("representable large quantity should be accepted, got: %v", err)
+		}
+	})
+
 	t.Run("default origin is api", func(t *testing.T) {
 		e, err := svc.Ingest(ctx, "t1", IngestInput{
 			CustomerID: "cus_origin_api", MeterID: "mtr_1", Quantity: dec(1),


### PR DESCRIPTION
Two pass-3 low-severity backend-audit findings on the live usage-ingest path.

## 1. Unbounded future timestamps (`service.go:105`)

The live `POST /usage-events` path accepted any future timestamp — only `Backfill` rejected them — so a client could park usage in a **future billing period**. `ingest()` now rejects `input.Timestamp` beyond `now + 5m` (a small clock-skew tolerance); `Backfill` keeps its stricter past-only gate.

## 2. Quantity overflow → HTTP 500 (`service.go:99`)

A high-magnitude quantity (`|q| ≥ 10^26`) overflows the `NUMERIC(38,12)` column and Postgres rejects the INSERT, surfacing as a **500**. `ingest()` now rejects it up front with `errs.Invalid` (clean **422**). Excess fractional precision is rounded by the column, so only integer magnitude is gated.

Both guards live in the shared `ingest()`, so `Ingest`, `Backfill`, and `BatchIngest` inherit them.

## Tests (no DB)

Future timestamp rejected; near-now accepted; over-magnitude quantity rejected; representable large value accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)