### PR TITLE
fix(api): neutralize CSV formula injection in exports

### DIFF
--- a/internal/api/exports.go
+++ b/internal/api/exports.go
@@ -100,6 +100,24 @@ func writeCSVHeaders(w http.ResponseWriter, filenameStem string) *csv.Writer {
 	return csv.NewWriter(w)
 }
 
+// csvSafe neutralizes spreadsheet (CSV) formula injection. A cell whose first
+// character is one of = + - @ TAB CR is interpreted as a formula by Excel,
+// Google Sheets, and LibreOffice — so a customer-controlled value like
+// "=HYPERLINK(...)" or "@SUM(...)" executes when the operator opens the export.
+// Prefixing such values with a single quote forces them to render as text.
+// Empty strings pass through. Applied to free-text, externally-controlled
+// columns (display names, external IDs, emails, codes, idempotency keys).
+func csvSafe(s string) string {
+	if s == "" {
+		return s
+	}
+	switch s[0] {
+	case '=', '+', '-', '@', 0x09, 0x0d:
+		return "'" + s
+	}
+	return s
+}
+
 // flushAndContinue flushes the csv buffer to the underlying response
 // so streaming clients see partial output. Without the flush, large
 // exports buffer until completion.
@@ -169,7 +187,7 @@ func (h *exportsHandler) exportCustomers(w http.ResponseWriter, r *http.Request)
 				continue
 			}
 			if err := cw.Write([]string{
-				c.ID, c.ExternalID, c.DisplayName, c.Email,
+				c.ID, csvSafe(c.ExternalID), csvSafe(c.DisplayName), csvSafe(c.Email),
 				string(c.Status),
 				string(c.EmailStatus),
 				c.CreatedAt.UTC().Format(time.RFC3339),
@@ -240,7 +258,7 @@ func (h *exportsHandler) exportInvoices(w http.ResponseWriter, r *http.Request) 
 				continue
 			}
 			if err := cw.Write([]string{
-				inv.ID, inv.InvoiceNumber, inv.CustomerID, inv.SubscriptionID,
+				inv.ID, csvSafe(inv.InvoiceNumber), inv.CustomerID, inv.SubscriptionID,
 				string(inv.Status), string(inv.PaymentStatus), inv.Currency,
 				strconv.FormatInt(inv.SubtotalCents, 10),
 				strconv.FormatInt(inv.TaxAmountCents, 10),
@@ -329,7 +347,7 @@ func (h *exportsHandler) exportSubscriptions(w http.ResponseWriter, r *http.Requ
 				planIDs += item.PlanID
 			}
 			if err := cw.Write([]string{
-				sub.ID, sub.Code, sub.DisplayName, sub.CustomerID,
+				sub.ID, csvSafe(sub.Code), csvSafe(sub.DisplayName), sub.CustomerID,
 				string(sub.Status), string(sub.BillingTime),
 				timePtrCSV(sub.TrialStartAt), timePtrCSV(sub.TrialEndAt),
 				timePtrCSV(sub.StartedAt), timePtrCSV(sub.ActivatedAt),
@@ -415,7 +433,7 @@ func (h *exportsHandler) exportUsageEvents(w http.ResponseWriter, r *http.Reques
 				ev.ID, ev.CustomerID, ev.MeterID,
 				ev.Quantity.String(),
 				ev.Timestamp.UTC().Format(time.RFC3339),
-				ev.IdempotencyKey,
+				csvSafe(ev.IdempotencyKey),
 				string(ev.Origin),
 				dimsJSON,
 			}); err != nil {

--- a/internal/api/exports_csvsafe_test.go
+++ b/internal/api/exports_csvsafe_test.go
@@ -1,0 +1,27 @@
+package api
+
+import "testing"
+
+// TestCSVSafe covers the low-severity [security] audit finding: free-text
+// columns in CSV exports were written unescaped, so a customer-controlled value
+// beginning with a formula character executes when an operator opens the file in
+// Excel / Sheets / LibreOffice. csvSafe prefixes those with a single quote.
+func TestCSVSafe(t *testing.T) {
+	cases := map[string]string{
+		"":                  "",
+		"Acme Inc":          "Acme Inc",      // plain text untouched
+		"cus_123":           "cus_123",       // id untouched
+		"user@example.com":  "user@example.com",
+		"=HYPERLINK(\"x\")": "'=HYPERLINK(\"x\")", // formula neutralized
+		"+1234567890":       "'+1234567890",
+		"-2+3":              "'-2+3",
+		"@SUM(A1:A9)":       "'@SUM(A1:A9)",
+		"\tTabbed":          "'\tTabbed",
+		"\rCarriage":        "'\rCarriage",
+	}
+	for in, want := range cases {
+		if got := csvSafe(in); got != want {
+			t.Errorf("csvSafe(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Low-severity **[security]** backend-audit finding (`exports.go:171`).

## Problem

The customers / invoices / subscriptions / usage CSV exports wrote free-text, externally-controlled columns (display name, external id, email, subscription code, invoice number, usage idempotency key) **unescaped**. A value beginning with `=` `+` `-` `@` TAB CR is interpreted as a formula by Excel / Google Sheets / LibreOffice — so a customer could put `=HYPERLINK(...)` / `@SUM(...)` in their display name and have it execute when an operator opens the export.

## Fix

`csvSafe()` prefixes any such cell with a single quote so spreadsheets render it as text. Applied to the free-text columns across all four exports. Numeric / id / enum / date columns are left untouched (a leading `-` on a real amount is a number, not a formula).

## Test

`TestCSVSafe`: plain / email / id values pass through; `=`, `+`, `-`, `@`, TAB, CR-leading values are quoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)