### PR TITLE
fix(tenant): constant-time compare for the bootstrap token

### DIFF
--- a/internal/tenant/bootstrap.go
+++ b/internal/tenant/bootstrap.go
@@ -3,6 +3,7 @@ package tenant
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -67,7 +68,11 @@ func (h *BootstrapHandler) bootstrap(w http.ResponseWriter, r *http.Request) {
 	if provided == "" {
 		provided = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 	}
-	if provided != h.token {
+	// Constant-time compare so the bootstrap token can't be recovered by
+	// timing how long the rejection takes (a byte-by-byte string != short-
+	// circuits on the first mismatched byte). The empty-token disable case is
+	// already handled above; subtle returns 0 on a length mismatch.
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(h.token)) != 1 {
 		respond.Error(w, r, http.StatusForbidden, "authentication_error", "forbidden",
 			"invalid bootstrap token")
 		return


### PR DESCRIPTION
Low-severity **[security]** backend-audit finding (`bootstrap.go:70`).

The bootstrap endpoint compared the presented token with a plain `!=`, which short-circuits on the first mismatched byte — leaking, via response timing, how many leading bytes were correct and making the token recoverable byte-by-byte. Now uses `crypto/subtle.ConstantTimeCompare`, matching the constant-time posture already used elsewhere for secret comparison.

Behavior is otherwise unchanged (empty token still disables bootstrap; mismatches still 403). Existing `TestBootstrap_Success` / `TestBootstrap_TokenRequired` cover the accept + reject paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)