### PR TITLE
fix(auth): don't leak account-lockout state on login (enumeration oracle)

### DIFF
--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -116,9 +116,15 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Is(err, ErrAccountLocked) {
-			respond.Error(w, r, http.StatusTooManyRequests,
-				"authentication_error", "account_locked",
-				"too many failed attempts — try again in 15 minutes")
+			// Return the SAME generic 401 as a wrong password / unknown email.
+			// A distinct 429 'account_locked' was an enumeration oracle: it
+			// confirmed the email belongs to a real account (only real accounts
+			// can be locked). Lockout is still enforced — Authenticate refuses
+			// the login during the window even with the correct password — we
+			// just don't disclose that state. (The 15-minute window is short
+			// enough that a legitimately locked-out operator recovers by
+			// retrying later.)
+			respond.Unauthorized(w, r, "invalid email or password")
 			return
 		}
 		respond.FromError(w, r, err, "user")


### PR DESCRIPTION
Low-severity **[security]** backend-audit finding (`user/service.go:238` → handler mapping).

## Problem

The login handler returned a distinct **429 `account_locked`** for a locked account vs a generic **401** for a wrong password / unknown email. Only a real, existing account can be locked, so the 429 confirmed the email belongs to a registered operator — an **enumeration oracle**.

## Fix

The locked path now returns the **same generic 401** `invalid email or password`. Lockout is still **enforced** — `Service.Authenticate` refuses the login during the window even with the correct password — we simply stop disclosing that state. The 15-minute window is short enough that a legitimately locked-out operator recovers by retrying later.

## Test coverage

`internal/user` has no handler test harness and the `Handler` holds a concrete `*Service` (so `Authenticate` can't be stubbed without a DB-backed store; the DB path can't run with Docker down in this session). The change is a status-code swap on an already-failing path; the service-level lockout enforcement is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)