### PR TITLE
fix(api): namespace rate-limiter Redis keys per logical limiter

### DIFF
--- a/internal/api/middleware/idempotency_test.go
+++ b/internal/api/middleware/idempotency_test.go
@@ -153,7 +153,7 @@ func TestParsePageParams_MaxLimit(t *testing.T) {
 
 func TestRateLimiter_NilDB_FailsOpen(t *testing.T) {
 	// With nil db the rate limiter should fail open — every request is allowed.
-	rl := NewRateLimiter(nil, 1, time.Minute)
+	rl := NewRateLimiter(nil, "test", 1, time.Minute)
 	handler := rl.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -180,7 +180,7 @@ func TestRateLimiter_NilDB_FailsOpen(t *testing.T) {
 }
 
 func TestRateLimiter_NilDB_FailsClosed_WhenConfigured(t *testing.T) {
-	rl := NewRateLimiter(nil, 1, time.Minute)
+	rl := NewRateLimiter(nil, "test", 1, time.Minute)
 	rl.SetFailClosed(true)
 	handler := rl.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -195,7 +195,7 @@ func TestRateLimiter_NilDB_FailsClosed_WhenConfigured(t *testing.T) {
 }
 
 func TestRateLimiter_HealthSkipped(t *testing.T) {
-	rl := NewRateLimiter(nil, 1, time.Minute)
+	rl := NewRateLimiter(nil, "test", 1, time.Minute)
 	handler := rl.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -27,6 +27,13 @@ type RateLimiter struct {
 	limit      redis_rate.Limit
 	rdb        *goredis.Client
 	failClosed bool
+	// name namespaces this limiter's Redis keys. Distinct limiters (general
+	// API, hosted-invoice, setup-link cooldown) share one Redis and key on the
+	// same identifier (e.g. "ip:1.2.3.4"), but each has DIFFERENT GCRA
+	// parameters. Without a per-limiter namespace they'd collide on one bucket
+	// — a request to one surface would consume another's allowance and the
+	// conflicting rate/period would corrupt the smoothing state.
+	name string
 }
 
 // SetFailClosed controls what happens when Redis is unreachable or unconfigured.
@@ -37,12 +44,14 @@ func (rl *RateLimiter) SetFailClosed(v bool) {
 	rl.failClosed = v
 }
 
-// NewRateLimiter creates a Redis-backed GCRA rate limiter.
-// Example: NewRateLimiter(rdb, 100, time.Minute) = 100 requests per minute
-// with smooth distribution (no boundary bursts).
+// NewRateLimiter creates a Redis-backed GCRA rate limiter. name namespaces the
+// limiter's Redis keys so distinct limiters with different parameters don't
+// collide on a shared bucket (e.g. "general", "hosted_invoice", "setup_link").
+// Example: NewRateLimiter(rdb, "general", 100, time.Minute) = 100 requests per
+// minute with smooth distribution (no boundary bursts).
 // If rdb is nil, the limiter fails open (all requests allowed).
-func NewRateLimiter(rdb *goredis.Client, rate int, window time.Duration) *RateLimiter {
-	rl := &RateLimiter{rdb: rdb}
+func NewRateLimiter(rdb *goredis.Client, name string, rate int, window time.Duration) *RateLimiter {
+	rl := &RateLimiter{rdb: rdb, name: name}
 
 	// Convert rate + window to redis_rate.Limit
 	switch {
@@ -113,7 +122,7 @@ func (rl *RateLimiter) AllowKey(ctx context.Context, key string) (int, time.Time
 		}
 		return rl.limit.Rate - 1, now.Add(rl.limit.Period), true
 	}
-	res, err := rl.limiter.Allow(ctx, "rl:"+key, rl.limit)
+	res, err := rl.limiter.Allow(ctx, rl.bucketKey(key), rl.limit)
 	if err != nil {
 		if rl.failClosed {
 			slog.Error("rate_limiter: redis error on AllowKey, failing closed", "error", err, "key", key)
@@ -139,7 +148,7 @@ func (rl *RateLimiter) allow(r *http.Request, key string) (int, time.Time, bool)
 		return rl.limit.Rate - 1, now.Add(rl.limit.Period), true
 	}
 
-	res, err := rl.limiter.Allow(r.Context(), "rl:"+key, rl.limit)
+	res, err := rl.limiter.Allow(r.Context(), rl.bucketKey(key), rl.limit)
 	if err != nil {
 		if rl.failClosed {
 			slog.Error("rate_limiter: redis error, failing closed",
@@ -157,6 +166,12 @@ func (rl *RateLimiter) allow(r *http.Request, key string) (int, time.Time, bool)
 
 	resetAt := now.Add(res.ResetAfter)
 	return res.Remaining, resetAt, res.Allowed > 0
+}
+
+// bucketKey is the Redis key for a logical bucket: the per-limiter namespace
+// (name) keeps limiters with different GCRA parameters from colliding.
+func (rl *RateLimiter) bucketKey(key string) string {
+	return "rl:" + rl.name + ":" + key
 }
 
 // rateLimitKey chooses the most-specific bucket available for this request,

--- a/internal/api/middleware/ratelimit_namespace_test.go
+++ b/internal/api/middleware/ratelimit_namespace_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRateLimiterBucketKey_NamespacedByLimiter covers the pass-3 low audit
+// finding: distinct limiters (general / hosted-invoice / setup-link) keyed on
+// the same identifier (e.g. "ip:1.2.3.4") collided on one Redis bucket, so a
+// request to one surface consumed another's GCRA allowance. The per-limiter
+// name now namespaces the key.
+func TestRateLimiterBucketKey_NamespacedByLimiter(t *testing.T) {
+	general := NewRateLimiter(nil, "general", 100, time.Minute)
+	hosted := NewRateLimiter(nil, "hosted_invoice", 60, time.Minute)
+
+	id := "ip:1.2.3.4"
+	gk := general.bucketKey(id)
+	hk := hosted.bucketKey(id)
+
+	if gk == hk {
+		t.Fatalf("limiters with different names share a bucket key (%q) — GCRA state collides", gk)
+	}
+	if gk != "rl:general:ip:1.2.3.4" {
+		t.Errorf("general key = %q, want rl:general:ip:1.2.3.4", gk)
+	}
+	if hk != "rl:hosted_invoice:ip:1.2.3.4" {
+		t.Errorf("hosted key = %q, want rl:hosted_invoice:ip:1.2.3.4", hk)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -943,7 +943,7 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	if rdb != nil {
 		userSvc.SetFailureCounter(user.NewRedisFailureCounter(rdb))
 	}
-	rateLimiter := mw.NewRateLimiter(rdb, 100, time.Minute)
+	rateLimiter := mw.NewRateLimiter(rdb, "general", 100, time.Minute)
 	// In production, refuse requests when Redis is unreachable rather than
 	// silently disabling rate limiting (DDoS vector).
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("APP_ENV")), "production") {
@@ -959,7 +959,7 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	// requests per visit. 60/min per IP leaves headroom for ~10
 	// simultaneous customers behind a single corporate NAT while keeping
 	// enumerations and scraping bounded.
-	hostedInvoiceRL := mw.NewRateLimiter(rdb, 60, time.Minute)
+	hostedInvoiceRL := mw.NewRateLimiter(rdb, "hosted_invoice", 60, time.Minute)
 	if strings.EqualFold(strings.TrimSpace(os.Getenv("APP_ENV")), "production") {
 		hostedInvoiceRL.SetFailClosed(true)
 	}
@@ -970,7 +970,7 @@ func NewServer(db *postgres.DB, clk clock.Clock) *Server {
 	// a Redis hiccup shouldn't block a legitimate operator's "send link"
 	// action; the worst case (Redis down + actual double-click) is two
 	// near-identical emails, no money/state at risk.
-	setupLinkCooldown := mw.NewRateLimiter(rdb, 1, time.Minute)
+	setupLinkCooldown := mw.NewRateLimiter(rdb, "setup_link", 1, time.Minute)
 	paymentMethodsH.SetCooldown(setupLinkCooldown)
 
 	r := chi.NewRouter()


### PR DESCRIPTION
Pass-3 low backend-audit finding (`ratelimit.go:116`).

## Problem

Every `RateLimiter` built its Redis key as `"rl:"+key`, where `key` is the bucket identity (e.g. `ip:1.2.3.4`). The three limiters — general API (100/min), hosted-invoice (60/min), setup-link cooldown (1/min) — therefore **shared one bucket per identifier** despite having different GCRA parameters. A request to one surface consumed another's allowance, and the conflicting rate/period corrupted the smoothing state.

## Fix

Add a `name` to `NewRateLimiter` and build the key as `"rl:"+name+":"+key` (`bucketKey` helper). Callers pass `"general"` / `"hosted_invoice"` / `"setup_link"`; the per-limiter namespace keeps their GCRA state independent.

## Test

`bucketKey` on two differently-named limiters yields distinct keys for the same identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)