### PR TITLE
docs(customerportal): correct the magic-link constant-time claim

### DIFF
--- a/internal/customerportal/request.go
+++ b/internal/customerportal/request.go
@@ -45,10 +45,19 @@ type MagicLinkDelivery interface {
 const maxEmailMatches = 10
 
 // MagicLinkRequestService drives the public "I forgot my portal link"
-// flow. Input is an email; output is always a 202 from the handler.
-// Match-or-miss, malformed-or-clean, the service takes the same code path
-// and same (bounded) time so an attacker can't learn anything from
-// differential response behavior.
+// flow. Input is an email; output is always a 202 from the handler —
+// match-or-miss, malformed-or-clean — so the response BODY/STATUS leaks
+// nothing.
+//
+// Timing is NOT fully constant: a match does extra synchronous work (per-
+// match Mint + DeliverMagicLink) that a miss skips, so response latency is
+// measurably longer on a hit. This is a residual email-enumeration oracle,
+// accepted as low-risk because (a) the email lookup itself is constant-time
+// via the blind index, and (b) the endpoint is rate-limited, so an attacker
+// can't gather enough timing samples to extract signal at scale. Closing it
+// fully would mean decoupling delivery onto a background queue so both paths
+// return after identical synchronous work — deferred until a threat model
+// justifies it. Do NOT re-add a "constant-time" claim here without that.
 type MagicLinkRequestService struct {
 	magic    *MagicLinkService
 	lookup   CustomerLookup


### PR DESCRIPTION
Pass-3 low **[security]** backend-audit finding (`customerportal/request.go:139`).

## Problem

The `MagicLinkRequestService` doc asserted the service "takes the same code path and same (bounded) time" — but a **match** does extra synchronous work (per-match `Mint` + `DeliverMagicLink`) that a **miss** skips, so response latency is measurably longer on a hit. That's a residual email-enumeration **timing oracle**, and the comment claiming constant-time was a doc-lie future readers would trust.

## Fix (the audit's minimal honest option)

Amend the comment to state the truth: body/status leak nothing (always 202), but timing is **not** constant. The oracle is accepted as low-risk because (a) the email lookup itself is constant-time (blind index) and (b) the endpoint is rate-limited, so an attacker can't gather enough timing samples to extract signal at scale. The full fix — decoupling delivery onto a background queue so both paths do identical synchronous work — is deferred until a threat model justifies it (it would change delivery semantics and the Docker-dependent integration tests). The comment now explicitly warns against re-adding a constant-time claim without that work.

No code-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)