### PR TITLE
fix(payment): atomic single-use consumption of payment-update tokens

### DIFF
--- a/internal/payment/public_handler.go
+++ b/internal/payment/public_handler.go
@@ -164,11 +164,34 @@ func (h *PublicPaymentHandler) createCheckoutSession(w http.ResponseWriter, r *h
 		return
 	}
 
+	// Scope ctx to the token's resolved (tenant, livemode) for all
+	// downstream tenant-scoped DB work.
+	scopedCtx := postgres.WithLivemode(r.Context(), token.Livemode)
+
+	// Atomically consume the single-use token BEFORE creating the checkout
+	// session. Validate's `used_at IS NULL` is only a read, so two concurrent
+	// requests for the same token both passed it and both opened a setup
+	// session (TOCTOU). The conditional UPDATE here is the compare-and-swap:
+	// only the winner proceeds; a loser (or a replay) sees consumed=false and
+	// gets the same generic invalid-token response. Consuming first means a
+	// later Stripe failure burns the token — acceptable for a single-use
+	// security credential; the customer requests a fresh link.
+	consumed, err := h.tokens.Consume(scopedCtx, token.TenantID, rawToken)
+	if err != nil {
+		slog.ErrorContext(scopedCtx, "public payment: consume token", "error", err)
+		respond.InternalError(w, r)
+		return
+	}
+	if !consumed {
+		respond.Error(w, r, http.StatusUnauthorized, "authentication_error", "invalid_token",
+			"invalid or expired token")
+		return
+	}
+
 	// Look up the customer's Stripe customer ID under TxTenant scoped
 	// to the token's resolved (tenant, livemode). RLS stays in play
 	// past the token gate; the token's JOIN already resolved livemode
 	// authoritatively, so no extra bypass-required lookup is needed.
-	scopedCtx := postgres.WithLivemode(r.Context(), token.Livemode)
 	tx, err := h.db.BeginTx(scopedCtx, postgres.TxTenant, token.TenantID)
 	if err != nil {
 		slog.ErrorContext(scopedCtx, "public payment: begin tx", "error", err)
@@ -231,17 +254,8 @@ func (h *PublicPaymentHandler) createCheckoutSession(w http.ResponseWriter, r *h
 		return
 	}
 
-	// Mark token as used (single use). Pass scopedCtx (with livemode
-	// pinned from the validated token), not raw r.Context() — MarkUsed
-	// opens TxTenant internally, and post-ADR-029's fail-closed
-	// BeginTx guard returns an error when ctx has no livemode. Using
-	// the bare request context here was a copy-paste miss when the
-	// scoped variable was introduced; without livemode the token
-	// silently failed to mark used, leaving the magic-link reusable.
-	if err := h.tokens.MarkUsed(scopedCtx, token.TenantID, rawToken); err != nil {
-		slog.ErrorContext(scopedCtx, "public payment: failed to mark token used", "error", err)
-		// Non-fatal: session was already created.
-	}
+	// Token was already atomically consumed above (before the session was
+	// created), so there's no post-success mark step here.
 
 	slog.InfoContext(r.Context(), "public payment update session created",
 		"customer_id", token.CustomerID,

--- a/internal/payment/token.go
+++ b/internal/payment/token.go
@@ -116,24 +116,41 @@ func (s *TokenService) Validate(ctx context.Context, rawToken string) (*PaymentU
 	return &t, nil
 }
 
-// MarkUsed marks a token as consumed (prevents reuse). The caller passes the
-// tenantID returned by Validate so the update runs under tenant RLS.
-func (s *TokenService) MarkUsed(ctx context.Context, tenantID, rawToken string) error {
+// Consume atomically marks a token used and reports whether THIS call was the
+// one that consumed it. The conditional UPDATE (used_at IS NULL) is a
+// compare-and-swap: under concurrent requests for the same single-use token,
+// exactly one gets consumed=true and may proceed; the others get false and must
+// abort. This closes the validate→mark-used TOCTOU where two requests both
+// passed Validate's `used_at IS NULL` read and both opened a setup-mode checkout
+// session. Callers must consume BEFORE the side effect, not after.
+//
+// The caller passes the tenantID returned by Validate so the update runs under
+// tenant RLS.
+func (s *TokenService) Consume(ctx context.Context, tenantID, rawToken string) (bool, error) {
 	hash := sha256.Sum256([]byte(rawToken))
 	tokenHash := hex.EncodeToString(hash[:])
 
 	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer postgres.Rollback(tx)
 
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE payment_update_tokens SET used_at = NOW() WHERE token_hash = $1
-	`, tokenHash); err != nil {
-		return err
+	res, err := tx.ExecContext(ctx, `
+		UPDATE payment_update_tokens SET used_at = NOW()
+		WHERE token_hash = $1 AND used_at IS NULL
+	`, tokenHash)
+	if err != nil {
+		return false, err
 	}
-	return tx.Commit()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return n == 1, nil
 }
 
 // Cleanup deletes expired tokens older than 7 days across all tenants. Runs

--- a/internal/payment/token_consume_integration_test.go
+++ b/internal/payment/token_consume_integration_test.go
@@ -1,0 +1,78 @@
+package payment_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/payment"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestTokenConsume_AtomicSingleUse covers the pass-3 low [security] audit
+// finding: the payment-update token's validate→mark-used was a TOCTOU, so two
+// concurrent requests for the same single-use token both passed Validate's
+// `used_at IS NULL` read and both opened a setup-mode checkout session. Consume
+// is now an atomic compare-and-swap (UPDATE ... WHERE used_at IS NULL); exactly
+// one caller wins.
+func TestTokenConsume_AtomicSingleUse(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	tenantID := testutil.CreateTestTenant(t, db, "Token TOCTOU")
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_tok", DisplayName: "Tok",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+	now := time.Now().UTC()
+	issued := now
+	inv, err := invoice.NewPostgresStore(db).Create(ctx, tenantID, domain.Invoice{
+		CustomerID: cust.ID, InvoiceNumber: "INV-TOK-1",
+		Status: domain.InvoiceFinalized, PaymentStatus: domain.PaymentPending,
+		Currency: "USD", SubtotalCents: 100, TotalAmountCents: 100, AmountDueCents: 100,
+		BillingPeriodStart: now.Add(-time.Hour), BillingPeriodEnd: now, IssuedAt: &issued,
+	})
+	if err != nil {
+		t.Fatalf("create invoice: %v", err)
+	}
+
+	tokens := payment.NewTokenService(db)
+	rawToken, err := tokens.Create(ctx, tenantID, cust.ID, inv.ID)
+	if err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+
+	// Two concurrent consumers race for the same token.
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	wins := 0
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, err := tokens.Consume(ctx, tenantID, rawToken)
+			if err == nil && ok {
+				mu.Lock()
+				wins++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if wins != 1 {
+		t.Errorf("concurrent Consume wins: got %d, want 1 (single-use must be atomic)", wins)
+	}
+
+	// A subsequent Consume must also lose.
+	if ok, err := tokens.Consume(ctx, tenantID, rawToken); err != nil || ok {
+		t.Errorf("post-consume Consume: got ok=%v err=%v, want ok=false", ok, err)
+	}
+}


### PR DESCRIPTION
Pass-3 low **[security]** backend-audit finding (`payment/token.go:104`).

## Problem

The payment-update token flow was validate→mark-used: `Validate` checked `used_at IS NULL` (a **read**) and `MarkUsed` unconditionally set `used_at` at the **end**, after the Stripe checkout session was created. Two concurrent requests for the same single-use token both passed `Validate` and both opened a setup-mode checkout session (TOCTOU).

## Fix

Replace `MarkUsed` with `Consume` — an atomic compare-and-swap (`UPDATE ... SET used_at=NOW() WHERE token_hash=$1 AND used_at IS NULL`) that returns whether **this** call won. `createCheckoutSession` now consumes the token **before** creating the session: the winner proceeds; a loser/replay gets `consumed=false` and the same generic invalid-token `401`. Consuming first means a later Stripe failure burns the token — acceptable for a single-use credential (customer requests a fresh link) — and it also fixes the prior bug where a failed *late* mark-used left the token reusable.

## Test (integration)

Two concurrent `Consume` calls on one token → exactly one wins; a subsequent `Consume` loses. (3× stable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)