### PR TITLE
fix(credit): serialize ledger appends with a per-customer advisory lock

### DIFF
--- a/internal/credit/empty_ledger_lock_integration_test.go
+++ b/internal/credit/empty_ledger_lock_integration_test.go
@@ -1,0 +1,80 @@
+package credit_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/credit"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestAppendEntry_SerializesOnEmptyLedger covers the pass-3 low audit finding:
+// the serialization lock was a `SELECT ... FOR UPDATE` over
+// customer_credit_ledger, which matches zero rows for a customer with an empty
+// ledger — so the first concurrent grants acquired no lock and computed
+// balance_after off the same stale (zero) snapshot. A per-customer advisory
+// lock serializes regardless of ledger state.
+//
+// Two concurrent first-grants ($50 and $30) must serialize: the running
+// balance_after of the later entry must reflect BOTH (== $80), never just its
+// own amount.
+func TestAppendEntry_SerializesOnEmptyLedger(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	tenantID := testutil.CreateTestTenant(t, db, "Credit Empty Ledger Lock")
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_emptylock", DisplayName: "Empty Lock",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	svc := credit.NewService(credit.NewPostgresStore(db))
+
+	var wg sync.WaitGroup
+	for _, amt := range []int64{5000, 3000} {
+		wg.Add(1)
+		go func(amt int64) {
+			defer wg.Done()
+			if _, err := svc.Grant(ctx, tenantID, credit.GrantInput{
+				CustomerID: cust.ID, AmountCents: amt, Description: "concurrent first grant",
+			}); err != nil {
+				t.Errorf("grant %d: %v", amt, err)
+			}
+		}(amt)
+	}
+	wg.Wait()
+
+	// Final authoritative balance is order-independent.
+	bal, err := svc.GetBalance(ctx, tenantID, cust.ID)
+	if err != nil {
+		t.Fatalf("get balance: %v", err)
+	}
+	if bal.BalanceCents != 8000 {
+		t.Errorf("balance: got %d, want 8000", bal.BalanceCents)
+	}
+
+	// The serialization invariant: exactly one entry carries the cumulative
+	// running balance ($80). Without the lock, both first-grants computed
+	// balance_after off zero and the max would be only $50 (or $30).
+	tx, err := db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		t.Fatalf("begin bypass: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var maxBalanceAfter int64
+	if err := tx.QueryRow(`
+		SELECT COALESCE(MAX(balance_after), 0) FROM customer_credit_ledger
+		WHERE customer_id = $1 AND entry_type = 'grant'
+	`, cust.ID).Scan(&maxBalanceAfter); err != nil {
+		t.Fatalf("read max balance_after: %v", err)
+	}
+	if maxBalanceAfter != 8000 {
+		t.Errorf("max running balance_after: got %d, want 8000 (the later grant must see the earlier — proves serialization)", maxBalanceAfter)
+	}
+}

--- a/internal/credit/postgres.go
+++ b/internal/credit/postgres.go
@@ -49,18 +49,22 @@ func (s *PostgresStore) AppendEntryTx(ctx context.Context, tx *sql.Tx, tenantID 
 // appendEntryInTx is the shared body. AppendEntry opens+commits its
 // own tx; AppendEntryTx delegates to the caller.
 func (s *PostgresStore) appendEntryInTx(ctx context.Context, tx *sql.Tx, tenantID string, entry domain.CreditLedgerEntry) (domain.CreditLedgerEntry, error) {
-	// Lock existing rows for this customer to serialize concurrent writes.
-	// This prevents two concurrent grants from computing the same balance_after.
-	// We lock first, then aggregate — FOR UPDATE can't be used directly with aggregates in all cases.
+	// Serialize concurrent writes for this customer so two grants can't compute
+	// the same balance_after off a stale snapshot. A `SELECT ... FOR UPDATE`
+	// over customer_credit_ledger only locks EXISTING rows — for a customer
+	// with an empty ledger (the very first grant) it matches zero rows and
+	// acquires no lock, so the first concurrent appends raced. A per-customer
+	// transaction advisory lock always serializes, regardless of ledger state;
+	// it releases automatically on commit/rollback.
 	//
-	// tenant_id is included in every predicate as defense-in-depth: RLS (TxTenant)
-	// already restricts rows to this tenant, but if RLS were ever misconfigured or
-	// a future refactor opened a tx without tenant scope, these filters prevent
-	// cross-tenant balance leakage.
-	_, _ = tx.ExecContext(ctx,
-		`SELECT 1 FROM customer_credit_ledger WHERE tenant_id = $1 AND customer_id = $2 FOR UPDATE`,
-		tenantID, entry.CustomerID,
-	)
+	// tenant_id is folded into the lock key as defense-in-depth (RLS already
+	// scopes the tx to this tenant).
+	if _, err := tx.ExecContext(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		tenantID+":"+entry.CustomerID,
+	); err != nil {
+		return domain.CreditLedgerEntry{}, fmt.Errorf("acquire credit ledger lock: %w", err)
+	}
 	var currentBalance int64
 	if err := tx.QueryRowContext(ctx,
 		`SELECT COALESCE(SUM(amount_cents), 0) FROM customer_credit_ledger WHERE tenant_id = $1 AND customer_id = $2`,


### PR DESCRIPTION
Pass-3 low backend-audit finding (`credit/postgres.go:60`).

## Problem

The append serialization lock was a `SELECT 1 FROM customer_credit_ledger WHERE ... FOR UPDATE`, which only locks **existing** rows. For a customer with an **empty ledger** (the very first grant) it matches zero rows and acquires no lock — so the first concurrent appends both read `currentBalance=0` and wrote `balance_after` off the same stale snapshot, producing inconsistent per-entry running balances.

## Fix

Replace it with `pg_advisory_xact_lock` keyed on `(tenant, customer)`, which serializes every append for that customer regardless of ledger state and releases on commit/rollback. The authoritative balance (`SUM(amount_cents)`) was always correct; this fixes the denormalized `balance_after` running total under first-write concurrency.

## Test (integration)

Two concurrent first-grants ($50 + $30) serialize so the later entry's `balance_after` is the cumulative $80, not just its own amount. 5× stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)