### PR TITLE
fix(dunning): scope at-risk stat to the tenant default currency

### DIFF
--- a/internal/dunning/postgres.go
+++ b/internal/dunning/postgres.go
@@ -652,16 +652,28 @@ func (s *PostgresStore) GetStats(ctx context.Context, tenantID string) (Stats, e
 	}
 	defer postgres.Rollback(tx)
 
+	// Resolve the tenant's default currency once. The at-risk total is scoped
+	// to it so we never sum amount_due across currencies into a corrupt figure
+	// (a EUR invoice's cents are not a USD invoice's cents). Defaults to USD
+	// when settings are unset.
+	defaultCurrency := "USD"
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COALESCE(NULLIF(default_currency, ''), 'USD') FROM tenant_settings LIMIT 1`,
+	).Scan(&defaultCurrency); err != nil && err != sql.ErrNoRows {
+		return Stats{}, err
+	}
+
 	var stats Stats
+	stats.Currency = defaultCurrency
 	err = tx.QueryRowContext(ctx, `
 		SELECT
 		    COUNT(*) FILTER (WHERE r.state = 'active')                                AS active_count,
 		    COUNT(*) FILTER (WHERE r.state = 'escalated')                             AS escalated_count,
 		    COUNT(*) FILTER (WHERE r.state = 'resolved')                              AS resolved_count,
-		    COALESCE(SUM(i.amount_due_cents) FILTER (WHERE r.state IN ('active','escalated')), 0) AS at_risk_cents
+		    COALESCE(SUM(i.amount_due_cents) FILTER (WHERE r.state IN ('active','escalated') AND i.currency = $1), 0) AS at_risk_cents
 		FROM invoice_dunning_runs r
 		LEFT JOIN invoices i ON i.id = r.invoice_id
-	`).Scan(&stats.ActiveCount, &stats.EscalatedCount, &stats.ResolvedCount, &stats.AtRiskCents)
+	`, defaultCurrency).Scan(&stats.ActiveCount, &stats.EscalatedCount, &stats.ResolvedCount, &stats.AtRiskCents)
 	if err != nil {
 		return Stats{}, err
 	}

--- a/internal/dunning/stats_currency_integration_test.go
+++ b/internal/dunning/stats_currency_integration_test.go
@@ -1,0 +1,80 @@
+package dunning_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/dunning"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestGetStats_AtRiskScopedToDefaultCurrency covers the low audit finding: the
+// dunning at-risk stat summed amount_due_cents across mixed currencies into one
+// integer. It's now scoped to the tenant's default currency so a EUR invoice
+// can't corrupt a USD-denominated at-risk figure.
+func TestGetStats_AtRiskScopedToDefaultCurrency(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	tenantID := testutil.CreateTestTenant(t, db, "Dunning Stats Currency")
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_dun", DisplayName: "Dun",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	store := dunning.NewPostgresStore(db)
+	policy, err := store.UpsertPolicy(ctx, tenantID, domain.DunningPolicy{
+		Name: "default", Enabled: true,
+		RetrySchedule: []string{"72h", "120h"}, MaxRetryAttempts: 3,
+		FinalAction: domain.DunningFinalAction("mark_uncollectible"), GracePeriodDays: 3,
+	})
+	if err != nil {
+		t.Fatalf("upsert policy: %v", err)
+	}
+
+	invStore := invoice.NewPostgresStore(db)
+	// USD invoice $100 due, EUR invoice $999 due — both with an active run.
+	mkInvoice := func(num, currency string, due int64) string {
+		now := time.Now().UTC()
+		issued := now
+		inv, err := invStore.Create(ctx, tenantID, domain.Invoice{
+			CustomerID: cust.ID, InvoiceNumber: num,
+			Status: domain.InvoiceFinalized, PaymentStatus: domain.PaymentFailed,
+			Currency: currency, SubtotalCents: due, TotalAmountCents: due, AmountDueCents: due,
+			BillingPeriodStart: now.Add(-time.Hour), BillingPeriodEnd: now, IssuedAt: &issued,
+		})
+		if err != nil {
+			t.Fatalf("create %s invoice: %v", currency, err)
+		}
+		if _, err := store.CreateRun(ctx, tenantID, domain.InvoiceDunningRun{
+			InvoiceID: inv.ID, CustomerID: cust.ID, PolicyID: policy.ID,
+			State: domain.DunningActive, Reason: "payment_failed",
+		}); err != nil {
+			t.Fatalf("create run for %s: %v", currency, err)
+		}
+		return inv.ID
+	}
+	mkInvoice("INV-USD", "USD", 100_00)
+	mkInvoice("INV-EUR", "EUR", 999_00)
+
+	stats, err := store.GetStats(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get stats: %v", err)
+	}
+	if stats.Currency != "USD" {
+		t.Errorf("currency: got %q, want USD", stats.Currency)
+	}
+	if stats.AtRiskCents != 100_00 {
+		t.Errorf("at_risk_cents: got %d, want 10000 (USD only — EUR excluded, not summed in)", stats.AtRiskCents)
+	}
+	if stats.ActiveCount != 2 {
+		t.Errorf("active_count: got %d, want 2 (count is currency-agnostic)", stats.ActiveCount)
+	}
+}

--- a/internal/dunning/store.go
+++ b/internal/dunning/store.go
@@ -64,10 +64,14 @@ type Store interface {
 // the invoices behind active+escalated runs). Computed server-side so
 // the cards stay correct regardless of how many runs exist.
 type Stats struct {
-	ActiveCount    int   `json:"active_count"`
-	EscalatedCount int   `json:"escalated_count"`
-	ResolvedCount  int   `json:"resolved_count"`
-	AtRiskCents    int64 `json:"at_risk_cents"`
+	ActiveCount    int    `json:"active_count"`
+	EscalatedCount int    `json:"escalated_count"`
+	ResolvedCount  int    `json:"resolved_count"`
+	AtRiskCents    int64  `json:"at_risk_cents"`
+	// Currency scopes AtRiskCents to the tenant's default currency — the
+	// dashboard shows one coherent at-risk figure instead of a meaningless
+	// sum across mixed-currency invoices.
+	Currency string `json:"currency"`
 }
 
 type RunListFilter struct {


### PR DESCRIPTION
Low-severity backend-audit finding (`dunning/postgres.go:661`).

## Problem

`GetStats` summed `amount_due_cents` across the invoices behind active+escalated runs with no currency filter, so a tenant with mixed-currency invoices got a meaningless at-risk total (a EUR invoice's cents added to a USD invoice's).

## Fix

Scope the `SUM` to the tenant's default currency (resolved once from `tenant_settings`, USD fallback) and surface that `currency` on `Stats` so the dashboard labels the figure — same approach as the analytics-overview fix (#108). Counts stay currency-agnostic.

## Test (integration)

A USD ($100) and a EUR ($999) invoice, each with an active run → `at_risk_cents = 10000` (USD only), `currency = USD`, `active_count = 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)