### PR TITLE
fix(dev+api): stop dashboard requests hanging "pending" forever

### DIFF
--- a/internal/feature/service.go
+++ b/internal/feature/service.go
@@ -186,6 +186,8 @@ func NewPostgresStore(db *postgres.DB) *PostgresStore {
 }
 
 func (s *PostgresStore) GetFlag(ctx context.Context, key string) (Flag, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	var f Flag
 	err := s.db.Pool.QueryRowContext(ctx, `
 		SELECT key, enabled, description, created_at, updated_at
@@ -198,6 +200,8 @@ func (s *PostgresStore) GetFlag(ctx context.Context, key string) (Flag, error) {
 }
 
 func (s *PostgresStore) GetOverride(ctx context.Context, key, tenantID string) (FlagOverride, bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	var o FlagOverride
 	err := s.db.Pool.QueryRowContext(ctx, `
 		SELECT flag_key, tenant_id, enabled, created_at
@@ -213,6 +217,8 @@ func (s *PostgresStore) GetOverride(ctx context.Context, key, tenantID string) (
 }
 
 func (s *PostgresStore) SetGlobal(ctx context.Context, key string, enabled bool) error {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	res, err := s.db.Pool.ExecContext(ctx, `
 		UPDATE feature_flags SET enabled = $1, updated_at = NOW() WHERE key = $2
 	`, enabled, key)
@@ -227,6 +233,8 @@ func (s *PostgresStore) SetGlobal(ctx context.Context, key string, enabled bool)
 }
 
 func (s *PostgresStore) SetOverride(ctx context.Context, tenantID, key string, enabled bool) error {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	_, err := s.db.Pool.ExecContext(ctx, `
 		INSERT INTO feature_flag_overrides (flag_key, tenant_id, enabled)
 		VALUES ($1, $2, $3)
@@ -236,6 +244,8 @@ func (s *PostgresStore) SetOverride(ctx context.Context, tenantID, key string, e
 }
 
 func (s *PostgresStore) RemoveOverride(ctx context.Context, tenantID, key string) error {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	_, err := s.db.Pool.ExecContext(ctx, `
 		DELETE FROM feature_flag_overrides WHERE flag_key = $1 AND tenant_id = $2
 	`, key, tenantID)
@@ -243,6 +253,8 @@ func (s *PostgresStore) RemoveOverride(ctx context.Context, tenantID, key string
 }
 
 func (s *PostgresStore) List(ctx context.Context) ([]Flag, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	rows, err := s.db.Pool.QueryContext(ctx, `
 		SELECT key, enabled, description, created_at, updated_at
 		FROM feature_flags ORDER BY key LIMIT 500
@@ -264,6 +276,8 @@ func (s *PostgresStore) List(ctx context.Context) ([]Flag, error) {
 }
 
 func (s *PostgresStore) ListOverrides(ctx context.Context, tenantID string) ([]FlagOverride, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	rows, err := s.db.Pool.QueryContext(ctx, `
 		SELECT flag_key, tenant_id, enabled, created_at
 		FROM feature_flag_overrides WHERE tenant_id = $1 ORDER BY flag_key LIMIT 500

--- a/internal/tenant/bootstrap.go
+++ b/internal/tenant/bootstrap.go
@@ -1,6 +1,7 @@
 package tenant
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -87,11 +88,13 @@ func (h *BootstrapHandler) bootstrap(w http.ResponseWriter, r *http.Request) {
 	tenantID := postgres.NewID("vlx_ten")
 	now := time.Now().UTC()
 
-	result, err := h.db.Pool.ExecContext(ctx,
+	qctx, cancel := context.WithTimeout(ctx, h.db.QueryTimeout)
+	result, err := h.db.Pool.ExecContext(qctx,
 		`INSERT INTO tenants (id, name, status, created_at, updated_at)
 		SELECT $1, $2, 'active', $3, $3
 		WHERE NOT EXISTS (SELECT 1 FROM tenants LIMIT 1)`,
 		tenantID, req.TenantName, now)
+	cancel()
 	if err != nil {
 		respond.InternalError(w, r)
 		return

--- a/internal/tenant/settings.go
+++ b/internal/tenant/settings.go
@@ -41,6 +41,8 @@ func NewSettingsStore(db *postgres.DB) *SettingsStore {
 // and cannot carry a per-tenant context. The tenants table itself has no
 // RLS, so this query runs on the bare pool without a transaction.
 func (s *SettingsStore) ListTenantIDs(ctx context.Context) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
+	defer cancel()
 	rows, err := s.db.Pool.QueryContext(ctx, `SELECT id FROM tenants`)
 	if err != nil {
 		return nil, err

--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -48,6 +48,35 @@ function humanizeError(msg: string): string {
 // reach the same endpoints with a Bearer header instead, which the
 // server's MiddlewareOrAPIKey accepts as a fallback when the cookie is
 // missing.
+// DEFAULT_REQUEST_TIMEOUT_MS bounds every API call. A request that never
+// receives a response — a stalled dev proxy, a reset/half-open connection, a
+// wedged upstream — must NOT leave the UI spinning forever. We abort after
+// this window so React Query surfaces a recoverable error instead of an
+// infinite loading state. Set a touch above the backend's 30s WriteTimeout so
+// the server's own error wins when the backend is merely slow.
+const DEFAULT_REQUEST_TIMEOUT_MS = 40_000
+
+// fetchWithTimeout wraps fetch with an AbortController so a hung request fails
+// fast instead of pending indefinitely. Used by every API + file call.
+export async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      throw new ApiError(
+        `Request timed out after ${Math.round(timeoutMs / 1000)}s — the server didn't respond. Check the API is running and reachable, then retry.`,
+        0,
+        { code: 'timeout' },
+      )
+    }
+    throw e
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export async function apiRequest<T>(method: string, path: string, body?: unknown, opts?: { idempotencyKey?: string }): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -56,7 +85,7 @@ export async function apiRequest<T>(method: string, path: string, body?: unknown
     headers['Idempotency-Key'] = opts.idempotencyKey
   }
 
-  const res = await fetch(`${API_BASE}${path}`, {
+  const res = await fetchWithTimeout(`${API_BASE}${path}`, {
     method,
     headers,
     credentials: 'include',
@@ -1541,7 +1570,7 @@ export interface UsageAnalyticsResponse {
 }
 
 export async function downloadPDF(invoiceId: string, invoiceNumber: string) {
-  const res = await fetch(`${API_BASE}/invoices/${invoiceId}/pdf`, {
+  const res = await fetchWithTimeout(`${API_BASE}/invoices/${invoiceId}/pdf`, {
     credentials: 'include',
   })
   const blob = await res.blob()
@@ -1554,7 +1583,7 @@ export async function downloadPDF(invoiceId: string, invoiceNumber: string) {
 }
 
 export async function downloadCreditNotePDF(creditNoteId: string, creditNoteNumber: string) {
-  const res = await fetch(`${API_BASE}/credit-notes/${creditNoteId}/pdf`, {
+  const res = await fetchWithTimeout(`${API_BASE}/credit-notes/${creditNoteId}/pdf`, {
     credentials: 'include',
   })
   if (!res.ok) {

--- a/web-v2/vite.config.ts
+++ b/web-v2/vite.config.ts
@@ -8,5 +8,34 @@ export default defineConfig({
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },
   },
-  server: { port: 5173, proxy: { '/v1': 'http://localhost:8080' } },
+  server: {
+    port: 5173,
+    proxy: {
+      // Bounded + error-handled so a stalled/reset upstream surfaces as a 502
+      // instead of leaving the browser request "pending" forever (the dev
+      // infinite-spinner). timeout/proxyTimeout sit just above the backend's
+      // 30s WriteTimeout so the backend's own response wins when it's merely
+      // slow; the proxy only fires on a genuinely dead/wedged upstream.
+      '/v1': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        timeout: 35_000,
+        proxyTimeout: 35_000,
+        configure: (proxy) => {
+          proxy.on('error', (err, _req, res) => {
+            // res is a ServerResponse for normal requests (not WS upgrades).
+            const sr = res as unknown as {
+              writeHead?: (s: number, h: Record<string, string>) => void
+              end?: (b?: string) => void
+              headersSent?: boolean
+            }
+            if (sr && typeof sr.writeHead === 'function' && !sr.headersSent) {
+              sr.writeHead(502, { 'Content-Type': 'application/json' })
+              sr.end?.(JSON.stringify({ error: { message: `dev proxy: upstream error or timeout (${(err as NodeJS.ErrnoException).code ?? err.message})` } }))
+            }
+          })
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Symptom
Intermittent: dashboard API requests stick at **(pending)** for minutes, the app spins forever, and it clears on reload. Diagnosed via a 5-angle investigation + live DB/process inspection.

## Root cause
**No timeout at any layer**, so a *transient* stall becomes *permanent* — and HTTP/1.1's ~6-connections-per-origin limit on the single `:5173` dev origin then wedges the whole UI when a stuck connection slot is never freed.

## Fixes
- **`lib/api.ts`** — `fetchWithTimeout` (AbortController, 40s) on `apiRequest` + PDF downloads → a hung request fails with a recoverable error instead of an infinite spinner.
- **`vite.config.ts`** — harden the bare dev proxy: `timeout`/`proxyTimeout` (35s, just over the backend's 30s `WriteTimeout`) + an `error` handler returning **502** instead of leaving the request pending on an upstream stall/reset.
- **Backend** — enforce the existing 5s `QueryTimeout` on the direct `Pool.Query*/Exec*` sites that bypassed it: `feature/service.go` (all 7 flag methods — the hot auth path), `tenant/settings.go:ListTenantIDs` (scheduler path), `tenant/bootstrap.go`. (`tenant/postgres.go` + `billing/ttfi` already wrapped.) A stuck query can no longer hold a pool connection unbounded.

## Refuted / deferred (verified)
- **Leaked SSE** — ❌ `WebhookEvents.tsx` closes the `EventSource` on unmount and only mounts on the Webhooks page.
- **Pool exhaustion / leak** — ❌ DB idle (5 conns) at rest; stalls self-clear.
- **Missing `invoices.paid_at` index + `overview` query parallelization** — real but **prod-scale only** (tiny local data); deferred.

Build + `go test ./... -short` + `tsc -b` all green. Separate from the in-flight MANUAL_TEST clarity edits (still uncommitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)