### PR TITLE
fix(web): tame React Query refetch churn (duplicate global-query storm)

### DIFF
--- a/web-v2/src/contexts/QueryProvider.tsx
+++ b/web-v2/src/contexts/QueryProvider.tsx
@@ -2,11 +2,19 @@ import { useMemo, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useAuth } from '@/contexts/AuthContext'
 
+// Refetch posture (2026-06-02): operator billing data changes on the order of
+// minutes and is refreshed explicitly via invalidateQueries after mutations,
+// so aggressive time/focus-based refetching just churns the single HTTP/1.1
+// dev origin (and prod) with duplicate global queries. staleTime=30s lets
+// normal page-to-page navigation serve from cache; refetchOnWindowFocus=false
+// stops a full re-fetch on every alt-tab. Real-time surfaces (test-clock
+// advancing, invoice payment status) opt into polling via per-query
+// refetchInterval, which is independent of these defaults.
 const queryDefaults = {
   queries: {
-    staleTime: 5_000,
+    staleTime: 30_000,
     retry: 1,
-    refetchOnWindowFocus: true,
+    refetchOnWindowFocus: false,
     refetchOnMount: true,
   },
 } as const


### PR DESCRIPTION
Follow-up to #137. Network-panel evidence showed the residual `(pending)` churn is a **duplicate-query storm**, not a hang: the global Layout queries (`settings`, `overview`, `stripe`, `meters`, `customers`) re-fire on every navigation — backend is fast (40–440ms) — and the duplicates queue behind the dev origin's ~6 HTTP/1.1 connection slots.

`staleTime: 5_000 → 30_000` and `refetchOnWindowFocus: true → false`. The app already refreshes via `invalidateQueries` after mutations, so aggressive time/focus refetch was redundant. Real-time views (`test-clock` advancing, invoice payment status) opt into polling via per-query `refetchInterval`, independent of these defaults — unaffected.

Pairs with unchecking DevTools "Disable cache" (which re-downloads all Vite modules per load and is the other half of the churn). Frontend-only; `tsc -b` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)