### PR TITLE
fix(web): bind Vite dev server to all interfaces (IPv4 + IPv6)

### DIFF
--- a/web-v2/vite.config.ts
+++ b/web-v2/vite.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     alias: { '@': path.resolve(__dirname, './src') },
   },
   server: {
+    // Bind all interfaces (IPv4 + IPv6), not the default `localhost` which on
+    // macOS resolves to ::1 and binds IPv6-only — so a browser that resolves
+    // `localhost` to 127.0.0.1 (IPv4, listed first in /etc/hosts) hits a dead
+    // address and the page hangs "pending". host:true makes 127.0.0.1, ::1,
+    // and localhost all reach the dev server.
+    host: true,
     port: 5173,
     proxy: {
       // Bounded + error-handled so a stalled/reset upstream surfaces as a 502


### PR DESCRIPTION
## Symptom
Intermittent **blank page** — the root document request to `localhost:5173` stuck `(pending)`, surviving restarts.

## Root cause (verified live)
Vite's default `server.host: 'localhost'` resolved to `::1` on this macOS box and bound the dev server **IPv6-only** (`lsof` showed `[::1]:5173`). `/etc/hosts` lists `127.0.0.1 localhost` **first**, so when the browser resolved `localhost` → `127.0.0.1` (IPv4), it hit a dead address → `pending`. IPv6 resolution worked; IPv4 didn't — hence intermittent.

```
before:  127.0.0.1:5173 → refused    [::1]:5173 → 200    bind: [::1]:5173
after:   127.0.0.1:5173 → 200        [::1]:5173 → 200    bind: *:5173
```

## Fix
`server.host: true` → binds `*:5173` (IPv4 + IPv6). Verified both stacks now return 200.

Unrelated to the API-pending work (#137/#138) — that was a separate connection/timeout issue. Frontend dev-config only; `tsc -b` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)