### PR TITLE
revert(db): drop speculative per-query timeout wraps from #137

### DIFF
--- a/internal/feature/service.go
+++ b/internal/feature/service.go
@@ -186,8 +186,6 @@ func NewPostgresStore(db *postgres.DB) *PostgresStore {
 }
 
 func (s *PostgresStore) GetFlag(ctx context.Context, key string) (Flag, error) {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	var f Flag
 	err := s.db.Pool.QueryRowContext(ctx, `
 		SELECT key, enabled, description, created_at, updated_at
@@ -200,8 +198,6 @@ func (s *PostgresStore) GetFlag(ctx context.Context, key string) (Flag, error) {
 }
 
 func (s *PostgresStore) GetOverride(ctx context.Context, key, tenantID string) (FlagOverride, bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	var o FlagOverride
 	err := s.db.Pool.QueryRowContext(ctx, `
 		SELECT flag_key, tenant_id, enabled, created_at
@@ -217,8 +213,6 @@ func (s *PostgresStore) GetOverride(ctx context.Context, key, tenantID string) (
 }
 
 func (s *PostgresStore) SetGlobal(ctx context.Context, key string, enabled bool) error {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	res, err := s.db.Pool.ExecContext(ctx, `
 		UPDATE feature_flags SET enabled = $1, updated_at = NOW() WHERE key = $2
 	`, enabled, key)
@@ -233,8 +227,6 @@ func (s *PostgresStore) SetGlobal(ctx context.Context, key string, enabled bool)
 }
 
 func (s *PostgresStore) SetOverride(ctx context.Context, tenantID, key string, enabled bool) error {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	_, err := s.db.Pool.ExecContext(ctx, `
 		INSERT INTO feature_flag_overrides (flag_key, tenant_id, enabled)
 		VALUES ($1, $2, $3)
@@ -244,8 +236,6 @@ func (s *PostgresStore) SetOverride(ctx context.Context, tenantID, key string, e
 }
 
 func (s *PostgresStore) RemoveOverride(ctx context.Context, tenantID, key string) error {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	_, err := s.db.Pool.ExecContext(ctx, `
 		DELETE FROM feature_flag_overrides WHERE flag_key = $1 AND tenant_id = $2
 	`, key, tenantID)
@@ -253,8 +243,6 @@ func (s *PostgresStore) RemoveOverride(ctx context.Context, tenantID, key string
 }
 
 func (s *PostgresStore) List(ctx context.Context) ([]Flag, error) {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	rows, err := s.db.Pool.QueryContext(ctx, `
 		SELECT key, enabled, description, created_at, updated_at
 		FROM feature_flags ORDER BY key LIMIT 500
@@ -276,8 +264,6 @@ func (s *PostgresStore) List(ctx context.Context) ([]Flag, error) {
 }
 
 func (s *PostgresStore) ListOverrides(ctx context.Context, tenantID string) ([]FlagOverride, error) {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	rows, err := s.db.Pool.QueryContext(ctx, `
 		SELECT flag_key, tenant_id, enabled, created_at
 		FROM feature_flag_overrides WHERE tenant_id = $1 ORDER BY flag_key LIMIT 500

--- a/internal/tenant/bootstrap.go
+++ b/internal/tenant/bootstrap.go
@@ -1,7 +1,6 @@
 package tenant
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -88,13 +87,11 @@ func (h *BootstrapHandler) bootstrap(w http.ResponseWriter, r *http.Request) {
 	tenantID := postgres.NewID("vlx_ten")
 	now := time.Now().UTC()
 
-	qctx, cancel := context.WithTimeout(ctx, h.db.QueryTimeout)
-	result, err := h.db.Pool.ExecContext(qctx,
+	result, err := h.db.Pool.ExecContext(ctx,
 		`INSERT INTO tenants (id, name, status, created_at, updated_at)
 		SELECT $1, $2, 'active', $3, $3
 		WHERE NOT EXISTS (SELECT 1 FROM tenants LIMIT 1)`,
 		tenantID, req.TenantName, now)
-	cancel()
 	if err != nil {
 		respond.InternalError(w, r)
 		return

--- a/internal/tenant/settings.go
+++ b/internal/tenant/settings.go
@@ -41,8 +41,6 @@ func NewSettingsStore(db *postgres.DB) *SettingsStore {
 // and cannot carry a per-tenant context. The tenants table itself has no
 // RLS, so this query runs on the bare pool without a transaction.
 func (s *SettingsStore) ListTenantIDs(ctx context.Context) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, s.db.QueryTimeout)
-	defer cancel()
 	rows, err := s.db.Pool.QueryContext(ctx, `SELECT id FROM tenants`)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reverts only the backend query-timeout portion of #137 — the `context.WithTimeout(ctx, db.QueryTimeout)` wraps on the direct `Pool` query sites in `feature/service.go` (7 methods), `tenant/settings.go` (`ListTenantIDs`), and `tenant/bootstrap.go`.

**Why:** that was latent prod-scale hardening, not a fix for the reported "pending" symptom (root cause was the Vite IPv6 bind, #139). Per the pre-launch lean bias, keeping the diff minimal — these paths run on tiny local data, and requests already carry `middleware.Timeout(30s)`. Re-add per-site query bounds when real load makes unbounded hot-path queries an actual risk.

**Kept:** #137's frontend pieces (client fetch timeout, Vite proxy timeout/error-handler) — those prevent real infinite-pending and paid off during the backend-down restart window. `#138` (refetch-taming) and `#139` (IPv6 bind) also stay.

Build + `go test` (feature, tenant) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)