### PR TITLE
fix(timeouts): bound external calls + non-racing server hierarchy

### DIFF
--- a/cmd/velox/main.go
+++ b/cmd/velox/main.go
@@ -184,12 +184,18 @@ func serve() {
 	})
 
 	srv := &http.Server{
-		Addr:           fmt.Sprintf(":%s", cfg.Port),
-		Handler:        server,
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   30 * time.Second,
-		IdleTimeout:    60 * time.Second,
-		MaxHeaderBytes: 1 << 13, // 8 KB
+		Addr:    fmt.Sprintf(":%s", cfg.Port),
+		Handler: server,
+		// ReadHeaderTimeout bounds header parsing (slowloris guard); ReadTimeout
+		// gives the body a generous window so batch ingest (up to 1000 events)
+		// over a slow link isn't truncated. WriteTimeout MUST exceed the 30s
+		// request middleware.Timeout so the handler writes its clean 504 before
+		// the server closes the socket (equal values race → connection reset).
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      35 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 13, // 8 KB
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"log/slog"
 	"mime"
+	"net"
 	"net/mail"
 	"net/smtp"
 	"os"
@@ -807,10 +808,14 @@ func (s *Sender) deliver(to string, body []byte) error {
 	// Implicit TLS (port 465 / SMTPS): TLS-from-handshake. net/smtp's
 	// SendMail can't do this; manually dial + start the SMTP client
 	// over the TLS connection.
-	tlsConn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: s.host})
+	tlsConn, err := tls.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second}, "tcp", addr, &tls.Config{ServerName: s.host})
 	if err != nil {
 		return fmt.Errorf("tls dial: %w", err)
 	}
+	// Bound the whole SMTP exchange so a server that connects but then stalls
+	// mid-dialog can't hang the sender — matters most on the background
+	// dunning-email path, which has no request deadline.
+	_ = tlsConn.SetDeadline(time.Now().Add(30 * time.Second))
 	c, err := smtp.NewClient(tlsConn, s.host)
 	if err != nil {
 		_ = tlsConn.Close()

--- a/internal/payment/stripe_clients.go
+++ b/internal/payment/stripe_clients.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
+	"time"
 
 	"github.com/stripe/stripe-go/v82"
 
@@ -12,6 +14,14 @@ import (
 	"github.com/sagarsuperuser/velox/internal/platform/postgres"
 	"github.com/sagarsuperuser/velox/internal/tenantstripe"
 )
+
+// stripeHTTPClient bounds every Stripe API call. stripe-go's default backend
+// uses an http.Client with no Timeout (0 = unbounded), so a stalled Stripe or
+// network call would hang the caller indefinitely — and the background workers
+// (payment reconciler, tax retrier) run on the long-lived process context with
+// no request deadline to bail them out, holding the scheduler's advisory lock
+// and a DB connection. One shared, bounded client fixes that everywhere.
+var stripeHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 // StripeCredentials resolves decrypted Stripe secrets for a (tenant, mode).
 // Implemented by *tenantstripe.Service — payment depends only on this
@@ -74,7 +84,7 @@ func (c *StripeClients) For(ctx context.Context, tenantID string, livemode bool)
 	if creds.SecretKey == "" {
 		return nil
 	}
-	return stripe.NewClient(creds.SecretKey)
+	return stripe.NewClient(creds.SecretKey, stripe.WithBackends(stripe.NewBackends(stripeHTTPClient)))
 }
 
 // Has returns true iff a credential fetcher is wired. Used at server

--- a/internal/platform/postgres/postgres.go
+++ b/internal/platform/postgres/postgres.go
@@ -34,10 +34,6 @@ func NewDB(pool *sql.DB, queryTimeout time.Duration) *DB {
 	return &DB{Pool: pool, QueryTimeout: queryTimeout}
 }
 
-func (db *DB) Ctx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), db.QueryTimeout)
-}
-
 // TxMode controls how a transaction sets RLS session variables.
 type TxMode int
 

--- a/internal/webhook/sse.go
+++ b/internal/webhook/sse.go
@@ -60,6 +60,13 @@ func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Disable the server's WriteTimeout for this connection. The stream is
+	// long-lived (clients tail webhook events for hours); the zero deadline
+	// removes the hard cap that would otherwise drop it after WriteTimeout.
+	// The 15s heartbeat below keeps idle proxies from closing it. Best-effort:
+	// SetWriteDeadline only no-ops if the writer can't support it.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+
 	// SSE headers. Cache-Control:no-cache prevents proxies from
 	// buffering or replaying stale chunks; X-Accel-Buffering disables
 	// nginx's response buffering specifically.


### PR DESCRIPTION
From the timeout-architecture audit, filtered to genuine bugs/risks (not the speculative hardening).

## The real gap
**Stripe SDK calls were unbounded** — `stripe.NewClient(key)` uses stripe-go's default backend (`http.Client.Timeout = 0`). Only the charge path had an ad-hoc 15s ctx; everything else (tax, refunds, checkout, reconcile) inherited the caller's ctx — and the **background reconciler / tax-retrier run on the long-lived process ctx with no deadline**, so a stalled Stripe/network call hangs the scheduler tick forever, holding its advisory lock + a DB connection. Now one shared `http.Client{Timeout: 30s}` (`WithBackends`) bounds every Stripe call, foreground and background.

## Also fixed
- **`WriteTimeout` 30s → 35s** so it exceeds the 30s request `middleware.Timeout` — equal values raced and the client saw a connection reset instead of a clean 504. Plus `ReadHeaderTimeout=10s` (slowloris) and `ReadTimeout` 10s → 30s (don't truncate batch ingest).
- **SSE write deadline disabled** (`webhook/sse.go`) — the live webhook-events stream is exempt from `middleware.Timeout` but the server's `WriteTimeout` still dropped it every ~30s; now it streams as designed (heartbeat keeps proxies open).
- **SMTP implicit-TLS dial bounded** (`DialWithDialer` 10s + 30s exchange deadline) — a dead SMTP server can't hang the background dunning-email path.
- **Deleted unused `db.Ctx()`** — a detached-`context.Background()` footgun.

## Deliberately deferred (premature at this scale)
Per-tick scheduler deadlines (would risk killing legit long billing runs without load data to size them), Postgres `statement_timeout` backstop, the STARTTLS `SendMail` refactor (stdlib provides an OS connect timeout).

`go build` + `go test ./... -short` green. Separate from the in-flight MANUAL_TEST clarity edits (still uncommitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)