### PR TITLE
ci: pin Go toolchain to 1.25.11 (clear govulncheck blocker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
 
       - name: Build
         run: go build ./...
@@ -85,7 +85,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
 
       - uses: golangci/golangci-lint-action@v7
 
@@ -118,7 +118,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Why

`govulncheck` (in the `test` job) started failing **every** PR on freshly-published Go **standard-library** CVEs — `GO-2026-5039` (`net/textproto`) and `GO-2026-5037` — both fixed in **go1.25.11**. CI used `go-version: '1.25'`, which was resolving to the still-vulnerable **1.25.10** (the setup-go version manifest lagged the release).

## Change

Pin all three `setup-go` steps to `go-version: '1.25.11'` (confirmed released in the go.dev/dl manifest). With `GOTOOLCHAIN: local` this builds + vulnchecks against the patched stdlib. Toolchain only — no code change.

Unblocks the merge queue (this was red on `test` for all open PRs, e.g. #146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)