### PR TITLE
fix(web): test-clock banner on manual simulated invoices (+ DueBadge, Customer spec)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -63,6 +63,14 @@ components:
         created_at:
           type: string
           format: date-time
+        test_clock_id:
+          type: string
+          description: |
+            Test clock this customer is pinned to (test mode only). When set,
+            the customer — and any invoices/subscriptions created for it —
+            run on the clock's simulated time. Empty for live customers. The
+            dashboard reads it to show the "test clock" badge + simulated-time
+            banner on the customer and its invoices.
 
     Meter:
       type: object

--- a/internal/api/generated/api.gen.go
+++ b/internal/api/generated/api.gen.go
@@ -672,6 +672,13 @@ type Customer struct {
 	ExternalId  string         `json:"external_id,omitempty"`
 	Id          string         `json:"id,omitempty"`
 	Status      CustomerStatus `json:"status,omitempty"`
+
+	// TestClockId Test clock this customer is pinned to (test mode only). When set,
+	// the customer — and any invoices/subscriptions created for it —
+	// run on the clock's simulated time. Empty for live customers. The
+	// dashboard reads it to show the "test clock" badge + simulated-time
+	// banner on the customer and its invoices.
+	TestClockId string `json:"test_clock_id,omitempty"`
 }
 
 // CustomerStatus defines model for Customer.Status.

--- a/web-v2/public/openapi.yaml
+++ b/web-v2/public/openapi.yaml
@@ -63,6 +63,14 @@ components:
         created_at:
           type: string
           format: date-time
+        test_clock_id:
+          type: string
+          description: |
+            Test clock this customer is pinned to (test mode only). When set,
+            the customer — and any invoices/subscriptions created for it —
+            run on the clock's simulated time. Empty for live customers. The
+            dashboard reads it to show the "test clock" badge + simulated-time
+            banner on the customer and its invoices.
 
     Meter:
       type: object

--- a/web-v2/src/lib/api.gen.ts
+++ b/web-v2/src/lib/api.gen.ts
@@ -1908,6 +1908,14 @@ export interface components {
             status?: "active" | "archived";
             /** Format: date-time */
             created_at?: string;
+            /**
+             * @description Test clock this customer is pinned to (test mode only). When set,
+             *     the customer — and any invoices/subscriptions created for it —
+             *     run on the clock's simulated time. Empty for live customers. The
+             *     dashboard reads it to show the "test clock" badge + simulated-time
+             *     banner on the customer and its invoices.
+             */
+            test_clock_id?: string;
         };
         Meter: {
             id?: string;

--- a/web-v2/src/lib/gen/schemas/customer.ts
+++ b/web-v2/src/lib/gen/schemas/customer.ts
@@ -16,4 +16,11 @@ export interface Customer {
   email?: string;
   status?: CustomerStatus;
   created_at?: string;
+  /** Test clock this customer is pinned to (test mode only). When set,
+  the customer — and any invoices/subscriptions created for it —
+  run on the clock's simulated time. Empty for live customers. The
+  dashboard reads it to show the "test clock" badge + simulated-time
+  banner on the customer and its invoices.
+   */
+  test_clock_id?: string;
 }

--- a/web-v2/src/pages/InvoiceDetail.tsx
+++ b/web-v2/src/pages/InvoiceDetail.tsx
@@ -156,14 +156,24 @@ export default function InvoiceDetailPage() {
     enabled: !!invoice?.subscription_id,
   })
 
+  // Resolve the test clock this invoice's dates live on. A subscription
+  // invoice inherits the sub's pin; a MANUAL one-off invoice has no
+  // subscription, so fall back to the customer's pin (the customer is
+  // already loaded above, so this is no extra fetch). invoice.is_simulated
+  // is the authoritative "these dates are simulated" flag; the resolved id
+  // just tells the banner which clock's "currently at" time to show.
+  const resolvedTestClockId = subscription?.test_clock_id || customer?.test_clock_id || ''
+
   // Test-clock frozen_time becomes the "now" for relative-time badges
   // (Due in N days) on this page. Without this the badge reads from
-  // wall-clock and understates urgency on simulated invoices —
-  // "Due in 45d" while the engine perceives 15d.
+  // wall-clock and understates urgency on simulated invoices — "Due in
+  // 45d" while the engine perceives 15d. Keyed off the resolved id so it
+  // works for manual simulated invoices too (was sub-only, which made the
+  // DueBadge count against wall-clock while the page claimed simulated).
   const { data: testClock } = useQuery({
-    queryKey: ['test-clock', subscription?.test_clock_id],
-    queryFn: () => api.getTestClock(subscription!.test_clock_id!),
-    enabled: !!subscription?.test_clock_id,
+    queryKey: ['test-clock', resolvedTestClockId],
+    queryFn: () => api.getTestClock(resolvedTestClockId),
+    enabled: !!resolvedTestClockId,
   })
 
   const { data: creditNotesData } = useQuery({
@@ -626,11 +636,15 @@ export default function InvoiceDetailPage() {
         </div>
       </div>
 
-      {/* Test-clock banner — sets expectation upfront when this
-          invoice's subscription is pinned to a clock. Some dates in
-          the activity feed (finalize, dunning) reflect simulated time. */}
-      {subscription?.test_clock_id && (
-        <TestClockBanner testClockId={subscription.test_clock_id} />
+      {/* Test-clock banner — the page-level "Currently at <sim time>"
+          anchor. Gated on the AUTHORITATIVE invoice.is_simulated (not the
+          subscription's clock id), so manual one-off invoices get the
+          banner too — they were previously left with the "Simulated" chip
+          but no reference point. resolvedTestClockId falls back to the
+          customer's pin; if it's empty (clock since deleted) the banner
+          renders its deleted-clock variant. */}
+      {invoice.is_simulated && (
+        <TestClockBanner testClockId={resolvedTestClockId} />
       )}
 
       {/* Uncollectible status banner — Stripe-parity bad-debt


### PR DESCRIPTION
Implements the **HIGH** items from the simulation-UX audit.

## Reported gap: manual invoice missing the banner
The page-level `TestClockBanner` ("Test clock simulation. Currently at <sim time>…") was gated on `subscription?.test_clock_id`. A **manual one-off invoice** has no subscription, so even with `is_simulated=true` it got only the small "Simulated" chip — no "currently at" reference point. The *same* wrong gate left the `testClock` fetch disabled, so `DueBadge` counted "Due in N days" against **wall-clock** while the page claimed all dates were simulated.

**Fix (`InvoiceDetail`):** gate the banner on the authoritative `invoice.is_simulated`, and resolve the clock id via `subscription?.test_clock_id ?? customer?.test_clock_id` (the customer is already loaded — no extra fetch). The `testClock` query uses the same resolved id, so `DueBadge` now computes against simulated time. If `is_simulated=true` but no id resolves (clock since deleted), `TestClockBanner` renders its existing deleted-clock variant. One change closes both the missing banner and the DueBadge contradiction.

## Spec gap: Customer.test_clock_id
The OpenAPI `Customer` schema omitted `test_clock_id` (the API returns it), so codegen emitted a `Customer` type blind to the field. Added it to the spec and regenerated **both** Go and TS bindings so the generated types match reality.

## Verification
tsc + `npm run build` + eslint clean; codegen regenerated in sync (Go `api.gen.go` + TS stub both now carry `test_clock_id`). CI Go is 1.25.11 (govulncheck clear).

Follow-up (MEDIUM consistency pass — separate PR): unify the 3 inline event chips into one `SimulatedEventChip`, switch Dashboard recent-invoice rows to `SimulatedBadge`, surface the audit sim-chip on list rows, add `SimulatedBadge` to CreditNotes. Public Portal/HostedInvoice simulated-date exposure remains a deliberate product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)