### PR TITLE
fix(web): consistent simulated-invoice marker + dedupe timeline chip (MEDIUM)

### DIFF
--- a/web-v2/src/pages/Dashboard.tsx
+++ b/web-v2/src/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import { formatInTimeZone } from 'date-fns-tz'
 import { api, formatCents, formatRelativeTime, getTenantTimezone } from '@/lib/api'
 import type { Invoice } from '@/lib/api'
 import { Layout } from '@/components/Layout'
-import { TestClockBadge } from '@/components/TestClockBadge'
+import { SimulatedBadge } from '@/components/TestClockBadge'
 import { cn } from '@/lib/utils'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -57,16 +57,6 @@ export default function DashboardPage() {
     queryKey: ['dashboard-recent-invoices'],
     queryFn: () => api.listInvoices('limit=5'),
   })
-  // Sub map for test-clock chips on the recent-invoices rows.
-  const { data: subscriptionsData } = useQuery({
-    queryKey: ['subscriptions-for-test-clock-chip'],
-    queryFn: () => api.listSubscriptions(),
-  })
-  const subTestClockMap = useMemo(() => {
-    const m: Record<string, string> = {}
-    ;(subscriptionsData?.data ?? []).forEach(s => { if (s.test_clock_id) m[s.id] = s.test_clock_id })
-    return m
-  }, [subscriptionsData])
 
   const chartData = useMemo(() => chartRes?.data ?? [], [chartRes])
   const error = errorObj instanceof Error ? errorObj.message : errorObj ? String(errorObj) : null
@@ -279,9 +269,10 @@ export default function DashboardPage() {
                             {inv.payment_status}
                           </Badge>
                         )}
-                        {inv.subscription_id && subTestClockMap[inv.subscription_id] && (
-                          <TestClockBadge testClockId={subTestClockMap[inv.subscription_id]} />
-                        )}
+                        {/* Authoritative per-invoice flag — same rule as the
+                            Invoices list; covers manual one-off invoices that
+                            the old sub→clock lookup missed. */}
+                        {inv.is_simulated && <SimulatedBadge />}
                       </div>
                       <div className="flex items-center gap-4 shrink-0">
                         <span className="text-sm tabular-nums text-foreground">

--- a/web-v2/src/pages/InvoiceDetail.tsx
+++ b/web-v2/src/pages/InvoiceDetail.tsx
@@ -1157,12 +1157,7 @@ export default function InvoiceDetailPage() {
                       <div className="flex items-center gap-1.5 min-w-0">
                         <p className="text-sm text-foreground">{event.description}</p>
                         {isSimulated && (
-                          <span
-                            title="Timestamp came from a test-clock-advanced engine run, not wall-clock"
-                            className="inline-flex shrink-0 items-center rounded border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-amber-800 dark:text-amber-300"
-                          >
-                            simulated
-                          </span>
+                          <SimulatedBadge title="This timestamp came from a test-clock simulation, not wall-clock time." />
                         )}
                       </div>
                       <span className="text-xs text-muted-foreground ml-4 whitespace-nowrap">{formatDateTime(event.timestamp)}</span>


### PR DESCRIPTION
Simulation-UX audit — the **consistency** items (follow-up to #148's HIGH fixes).

- **Dashboard recent-invoice rows** used a subscription→`test_clock_id` lookup for the "Test clock" badge, which **missed manual one-off invoices** and **diverged from the Invoices list** (which uses the authoritative `invoice.is_simulated`). Switched to `SimulatedBadge` driven by `inv.is_simulated` — the same rule everywhere. Removed the now-dead subscriptions-for-chip query + map.
- **Invoice activity timeline** rendered a hand-rolled inline "simulated" span; replaced it with the shared `SimulatedBadge` so wording/styling can't drift from the header + list markers.

## Deferred (deliberately — noted in the audit)
- The audit-row "Effect on test clock at <time>" **subline** dedupe (SubscriptionDetail + AuditLog): low drift risk, and it's a *subline*, not the same component as the chip — not worth conflating.
- **AuditLog list-row chip** (sim context currently only on expand): coverage nicety, low value.
- **CreditNotes badge:** the `CreditNote` API response has no `is_simulated` (only `invoice_id`), so this needs the field plumbed onto the credit-note response — **backend work**, not a frontend consistency fix. Flagging rather than building an N+1 fetch.

tsc + `npm run build` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)