### PR TITLE
fix(security): bump Go to 1.25.11 to clear stdlib CVEs failing the image scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+# Pin the exact patch (not the floating 1.25 tag) so the shipped binary always
+# carries the patched stdlib — the build cache otherwise reuses an older 1.25.x
+# layer and the image ships CVEs the Grype gate (critical) then rejects.
+FROM golang:1.25.11-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sagarsuperuser/velox
 
-go 1.25.1
+go 1.25.11
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5


### PR DESCRIPTION
## Problem

The `docker` job's **Grype SBOM scan** (`--fail-on critical`) has failed on **every** recent `main` push — including a docs-only commit (#163) and the tax fix (#165) — so `main` CI has been red regardless of content, and it gates green main.

Root cause: the shipped image's binary was built with **Go 1.25.1**, which `govulncheck` flags with **8 reachable stdlib CVEs**:

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-5039 | net/textproto | go1.25.11 |
| GO-2026-5037 | crypto/x509 | go1.25.11 |
| GO-2026-4986 | net/mail | go1.25.10 |
| GO-2026-4982 | html/template | go1.25.10 |
| GO-2026-4980 | html/template | go1.25.10 |
| GO-2026-4977 | net/mail | go1.25.10 |
| GO-2026-4971 | net | go1.25.10 |
| GO-2026-4947 | crypto/x509 | go1.25.9 |

The failures started when the daily Grype DB picked up these new GO-2026 advisories. CI's own jobs already use `setup-go` 1.25.11, so **unit tests built patched** — but the Dockerfile builder used the floating `golang:1.25-alpine` tag and the buildx cache reused a stale 1.25.1 layer, so only the **image** shipped the vulnerable stdlib (exactly Grype's scan target).

## Fix

- **Dockerfile** — pin builder to `golang:1.25.11-alpine` (exact patch, so the cache can't reuse an older 1.25.x and the binary always ships patched stdlib).
- **go.mod** — `go 1.25.1` → `go 1.25.11`, aligning the declared toolchain with CI so non-Docker builds and `govulncheck` are patched too.

## Verification

- `govulncheck ./...` → **0 vulnerabilities** (was 8).
- `go build ./...` + full `-short` suite green on go1.25.11.
- The `docker`/Grype job on this PR's merge is the final confirmation for the container scan (Grype can't be run on the image locally here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)