### PR TITLE
test(proration): tighten tolerance-range assertions to exact cents

### DIFF
--- a/internal/billing/engine_integration_test.go
+++ b/internal/billing/engine_integration_test.go
@@ -629,12 +629,11 @@ func TestBillTiming_InAdvance_E2E(t *testing.T) {
 	if grant.ID == "" {
 		t.Fatal("BillOnCancel produced no credit grant entry")
 	}
-	// July 16 cancel of a July 1 - August 1 period: 16 unused days
-	// out of 31. 4900 * 16/31 = 2529 cents (rounded). Allow ±1 for
-	// banker's-rounding edge cases.
-	expected := int64(4900 * 16 / 31) // 2529
-	if grant.AmountCents < expected-1 || grant.AmountCents > expected+1 {
-		t.Errorf("cancel proration credit: got %d cents, want ~%d", grant.AmountCents, expected)
+	// July 16 cancel of a July 1 - August 1 period: 16 unused days out of
+	// 31. RoundHalfToEven(4900×16, 31) = RoundHalfToEven(78400, 31) = 2529
+	// (78400 = 31×2529 + 1; 2×1 = 2 < 31 → round down). Exact, no tolerance.
+	if grant.AmountCents != 2529 {
+		t.Errorf("cancel proration credit: got %d cents, want 2529 (4900 × 16/31, banker's)", grant.AmountCents)
 	}
 
 	t.Logf("in_advance E2E passed — day-1 inv: $%.2f, cycle base period: %v, cancel credit: $%.2f",

--- a/internal/billing/engine_test.go
+++ b/internal/billing/engine_test.go
@@ -3094,10 +3094,11 @@ func TestBillOnPlanSwapImmediate(t *testing.T) {
 		if len(granter.grants) != 1 {
 			t.Fatalf("expected 1 credit grant, got %d", len(granter.grants))
 		}
-		// Mar 1 → Apr 1 = 31 days; (Mar 16, Apr 1) = 16 unused days
-		// $60 × 16/31 ≈ $30.97 ≈ 3097¢. Tolerance ±2¢ for rounding.
-		if cents < 3095 || cents > 3100 {
-			t.Errorf("unused refund cents: got %d, want ~3097 ($60 × 16/31)", cents)
+		// Mar 1 → Apr 1 = 31 days; (Mar 16, Apr 1) = 16 unused days.
+		// RoundHalfToEven(6000×16, 31) = RoundHalfToEven(96000, 31) = 3097
+		// (96000 = 31×3096 + 24; 2×24 = 48 > 31 → round up). Exact, not ~.
+		if cents != 3097 {
+			t.Errorf("unused refund cents: got %d, want 3097 ($60 × 16/31, banker's)", cents)
 		}
 		if cents != granter.grants[0].AmountCents {
 			t.Errorf("return cents (%d) must match granter cents (%d)", cents, granter.grants[0].AmountCents)
@@ -3180,12 +3181,12 @@ func TestBillOnPlanSwapImmediate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("BillOnPlanSwapImmediate: %v", err)
 		}
-		// Stub paid amount = $60 × 8/31 ≈ $15.48. Swap at period start:
-		// all 8 stub days unused. Expected refund = $60 × 8/31 ≈
-		// 1548 cents. fullCycleDays = 31 (Mar 24 → Apr 24 monthly
-		// roll). Pre-fix this would have refunded $60 × 8/8 = $60.
-		if cents < 1540 || cents > 1560 {
-			t.Errorf("stub refund cents: got %d, want ~1548 ($60 × 8/31 stub-prorated); pre-fix would have been ~6000 (over-refund)", cents)
+		// Stub = 8 days, all unused (swap at period start). fullCycleDays
+		// = 31 (Mar 24 → Apr 24 monthly roll). RoundHalfToEven(6000×8, 31)
+		// = RoundHalfToEven(48000, 31) = 1548 (48000 = 31×1548 + 12; 2×12
+		// = 24 < 31 → round down). Pre-fix would have refunded $60 × 8/8.
+		if cents != 1548 {
+			t.Errorf("stub refund cents: got %d, want 1548 ($60 × 8/31 stub-prorated)", cents)
 		}
 	})
 
@@ -3348,12 +3349,13 @@ func TestRunCycle_SegmentAware_InArrears_MidPeriodPlanChange(t *testing.T) {
 	}
 
 	inv := invoices.invoices[0]
-	// March has 31 days. Segment 1: [Mar 1, Mar 15) = 14 days × pln_a
-	// ($30/31 × 14) ≈ 1355¢. Segment 2: [Mar 15, Apr 1) = 17 days
-	// × pln_b ($60/31 × 17) ≈ 3290¢. Total ≈ 4645¢. Tolerance 4500-
-	// 4800 absorbs day-rounding edges.
-	if inv.SubtotalCents < 4500 || inv.SubtotalCents > 4800 {
-		t.Errorf("segment-aware total: got %d cents, want ~4645 (14d @ pln_a $30 + 17d @ pln_b $60)", inv.SubtotalCents)
+	// March has 31 days. Segment 1: [Mar 1, Mar 15) = 14 days × pln_a:
+	// RoundHalfToEven(3000×14, 31) = 1355 (42000 = 31×1354 + 26; round up).
+	// Segment 2: [Mar 15, Apr 1) = 17 days × pln_b:
+	// RoundHalfToEven(6000×17, 31) = 3290 (102000 = 31×3290 + 10; round down).
+	// Total = 1355 + 3290 = 4645, exact.
+	if inv.SubtotalCents != 4645 {
+		t.Errorf("segment-aware total: got %d cents, want 4645 (14d @ pln_a $30 = 1355 + 17d @ pln_b $60 = 3290)", inv.SubtotalCents)
 	}
 
 	// Two base-fee lines expected: one per segment.

--- a/internal/subscription/handler_test.go
+++ b/internal/subscription/handler_test.go
@@ -851,11 +851,12 @@ func TestAddItem_ProratesMidCycle(t *testing.T) {
 	if inv.SubscriptionID != subID {
 		t.Errorf("invoice subscription_id: got %q, want %q", inv.SubscriptionID, subID)
 	}
-	// Factor is ~0.5 (seeded period is ±15 days, now is midpoint), so the
-	// prorated amount on a $20 plan should be roughly $10. Accept 800-1200
-	// to absorb any near-midnight drift.
-	if inv.SubtotalCents < 800 || inv.SubtotalCents > 1200 {
-		t.Errorf("invoice subtotal: got %d, want ~1000 (half of 2000)", inv.SubtotalCents)
+	// Period is an exact 30-day span (now ± 15 days) with now at the midpoint,
+	// so remainingPeriodRatio is exactly 15/30: RoundHalfToEven(2000×15, 30) =
+	// 1000. Deterministic — no midnight snapping, and sub-second clock skew
+	// can't move the 15-day rounding.
+	if inv.SubtotalCents != 1000 {
+		t.Errorf("invoice subtotal: got %d, want 1000 ($20 × 15/30)", inv.SubtotalCents)
 	}
 	if inv.AmountDueCents <= 0 {
 		t.Errorf("invoice amount_due: got %d, want > 0", inv.AmountDueCents)
@@ -910,8 +911,8 @@ func TestUpdateItem_QuantityIncreaseProratesAsInvoice(t *testing.T) {
 	if inv.SourceSubscriptionItemID != itemID {
 		t.Errorf("invoice item_id: got %q, want %q", inv.SourceSubscriptionItemID, itemID)
 	}
-	if inv.SubtotalCents < 800 || inv.SubtotalCents > 1200 {
-		t.Errorf("invoice subtotal: got %d, want ~1000 (half of 2000 delta)", inv.SubtotalCents)
+	if inv.SubtotalCents != 1000 {
+		t.Errorf("invoice subtotal: got %d, want 1000 (2000 delta × 15/30)", inv.SubtotalCents)
 	}
 	if len(credits.grantCalls) != 0 {
 		t.Errorf("grantCalls: got %d, want 0 — qty increase should bill not credit", len(credits.grantCalls))
@@ -967,8 +968,8 @@ func TestUpdateItem_QuantityDecreaseProratesAsCredit(t *testing.T) {
 	if call.SourceChangeType != domain.ItemChangeTypeQuantity {
 		t.Errorf("credit SourceChangeType: got %q, want %q", call.SourceChangeType, domain.ItemChangeTypeQuantity)
 	}
-	if call.AmountCents < 800 || call.AmountCents > 1200 {
-		t.Errorf("credit amount: got %d, want ~1000", call.AmountCents)
+	if call.AmountCents != 1000 {
+		t.Errorf("credit amount: got %d, want 1000 ($20 × 15/30)", call.AmountCents)
 	}
 }
 
@@ -1019,9 +1020,9 @@ func TestRemoveItem_ProratesAsCredit(t *testing.T) {
 	if call.SourceSubscriptionItemID != firstItemID {
 		t.Errorf("credit item_id: got %q, want %q", call.SourceSubscriptionItemID, firstItemID)
 	}
-	// plan_a is $20/period, half-period → ~$10 credit.
-	if call.AmountCents < 800 || call.AmountCents > 1200 {
-		t.Errorf("credit amount: got %d, want ~1000", call.AmountCents)
+	// plan_a is $20/period; exact 15/30 half-period → RoundHalfToEven(2000×15, 30) = 1000.
+	if call.AmountCents != 1000 {
+		t.Errorf("credit amount: got %d, want 1000 ($20 × 15/30)", call.AmountCents)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #176. The segment/immediate proration tests asserted **tolerance ranges** (±2¢ to ±200¢) that can't catch a banker's-rounding or off-by-a-cent regression. Each of these amounts is **deterministic** int64 banker's-rounded math (`RoundHalfToEven` over fixed day ratios / calendar cycles), so the ranges are replaced with the exact value — derivation in each comment:

| Test | Was | Now (exact) | Derivation |
|---|---|---|---|
| `BillOnPlanSwapImmediate` unused refund | `[3095,3100]` | **3097** | `RoundHalfToEven(6000×16, 31)` (96000/31, round up) |
| stub-period refund | `[1540,1560]` | **1548** | `RoundHalfToEven(6000×8, 31)` (48000/31, round down) |
| segment-aware in_arrears total | `[4500,4800]` | **4645** | `1355 (3000×14/31) + 3290 (6000×17/31)` |
| `BillOnCancel` proration credit (integration) | `±1` | **2529** | `RoundHalfToEven(4900×16, 31)` (78400/31, round down) |
| immediate plan/qty proration + credits ×4 | `[800,1200]` | **1000** | `RoundHalfToEven(2000×15, 30)` — exact 30-day span, now at midpoint → 15/30 |

**Why exact is safe here:** the segment/integration cases use hardcoded calendar dates (Mar 1, Jul 16, …) → deterministic day counts. The ×4 handler cases seed an exact 30-day span (`now ± 15d`) with `now` at the midpoint, and there's no midnight snapping, so the ratio is 15/30 by construction (sub-second clock skew can't move the rounding boundary). Confirmed non-flaky with `-count=5`.

**Not tightened:** the tax-retry backoff jitter test (±10% is genuine randomness, not a rounding artifact).

Test-only — no production change. Verified: subscription proration tests `-count=5`, the integration assertion against live postgres (`-short=false`), full subscription + billing suites, gofmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)