### PR TITLE
chore: remove dead coupon discount machinery + fix stale comments (cleanup round 2)

### DIFF
--- a/internal/api/adapters.go
+++ b/internal/api/adapters.go
@@ -227,10 +227,6 @@ func (a *invoiceWriterAdapter) ListLineItems(ctx context.Context, tenantID, invo
 	return a.store.ListLineItems(ctx, tenantID, invoiceID)
 }
 
-func (a *invoiceWriterAdapter) ApplyDiscountAtomic(ctx context.Context, tenantID, invoiceID string, update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
-	return a.store.ApplyDiscountAtomic(ctx, tenantID, invoiceID, update, lineItems)
-}
-
 func (a *invoiceWriterAdapter) UpdateTaxAtomic(ctx context.Context, tenantID, invoiceID string, update domain.InvoiceTaxRetryUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
 	return a.store.UpdateTaxAtomic(ctx, tenantID, invoiceID, update, lineItems)
 }

--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -345,10 +345,6 @@ type InvoiceWriter interface {
 	// reference (Stripe: tx_xxx) after CommitTax succeeds. Required for
 	// later reversal when a credit note is issued against the invoice.
 	SetTaxTransaction(ctx context.Context, tenantID, id string, taxTransactionID string) error
-	// ApplyDiscountAtomic stamps a coupon discount + recomputed tax
-	// snapshot onto a draft invoice in one tx. Used by
-	// Engine.ApplyCouponToInvoice for the apply-coupon-after-issue flow.
-	ApplyDiscountAtomic(ctx context.Context, tenantID, invoiceID string, update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error)
 	// UpdateTaxAtomic re-stamps an invoice's tax decision after a manual
 	// retry. Used by Engine.RetryTaxForInvoice to persist the recomputed
 	// per-line and invoice-level tax fields atomically.

--- a/internal/billing/engine_integration_test.go
+++ b/internal/billing/engine_integration_test.go
@@ -179,10 +179,6 @@ func (a *invoiceStoreAdapter) ListLineItems(ctx context.Context, tenantID, invoi
 	return a.store.ListLineItems(ctx, tenantID, invoiceID)
 }
 
-func (a *invoiceStoreAdapter) ApplyDiscountAtomic(ctx context.Context, tenantID, invoiceID string, update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
-	return a.store.ApplyDiscountAtomic(ctx, tenantID, invoiceID, update, lineItems)
-}
-
 func (a *invoiceStoreAdapter) UpdateTaxAtomic(ctx context.Context, tenantID, invoiceID string, update domain.InvoiceTaxRetryUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
 	return a.store.UpdateTaxAtomic(ctx, tenantID, invoiceID, update, lineItems)
 }

--- a/internal/billing/engine_test.go
+++ b/internal/billing/engine_test.go
@@ -727,63 +727,6 @@ func (m *mockInvoices) ListLineItems(_ context.Context, _, invoiceID string) ([]
 	return out, nil
 }
 
-func (m *mockInvoices) ApplyDiscountAtomic(_ context.Context, tenantID, invoiceID string, update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
-	idx := -1
-	for i, inv := range m.invoices {
-		if inv.ID == invoiceID && inv.TenantID == tenantID {
-			idx = i
-			break
-		}
-	}
-	if idx < 0 {
-		return domain.Invoice{}, errs.ErrNotFound
-	}
-	inv := m.invoices[idx]
-	if inv.Status != domain.InvoiceDraft {
-		return domain.Invoice{}, errs.InvalidState(fmt.Sprintf("invoice must be draft (current: %s)", inv.Status))
-	}
-	if inv.DiscountCents > 0 {
-		return domain.Invoice{}, errs.InvalidState("invoice already has a discount applied")
-	}
-	byID := make(map[string]domain.InvoiceLineItem, len(lineItems))
-	for _, li := range lineItems {
-		byID[li.ID] = li
-	}
-	for i, existing := range m.lineItems {
-		if existing.InvoiceID != invoiceID {
-			continue
-		}
-		if updated, ok := byID[existing.ID]; ok {
-			m.lineItems[i].AmountCents = updated.AmountCents
-			m.lineItems[i].TaxRate = updated.TaxRate
-			m.lineItems[i].TaxAmountCents = updated.TaxAmountCents
-			m.lineItems[i].TotalAmountCents = updated.TotalAmountCents
-		}
-	}
-	inv.SubtotalCents = update.SubtotalCents
-	inv.DiscountCents = update.DiscountCents
-	inv.TaxAmountCents = update.TaxAmountCents
-	inv.TaxRate = update.TaxRate
-	inv.TaxName = update.TaxName
-	inv.TaxCountry = update.TaxCountry
-	inv.TaxID = update.TaxID
-	inv.TaxProvider = update.TaxProvider
-	inv.TaxCalculationID = update.TaxCalculationID
-	inv.TaxReverseCharge = update.TaxReverseCharge
-	inv.TaxExemptReason = update.TaxExemptReason
-	inv.TaxStatus = update.TaxStatus
-	inv.TaxDeferredAt = update.TaxDeferredAt
-	inv.TaxPendingReason = update.TaxPendingReason
-	inv.TotalAmountCents = update.SubtotalCents - update.DiscountCents + update.TaxAmountCents
-	due := inv.TotalAmountCents - inv.AmountPaidCents - inv.CreditsAppliedCents
-	if due < 0 {
-		due = 0
-	}
-	inv.AmountDueCents = due
-	m.invoices[idx] = inv
-	return inv, nil
-}
-
 func (m *mockInvoices) UpdateTaxAtomic(_ context.Context, tenantID, invoiceID string, update domain.InvoiceTaxRetryUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
 	idx := -1
 	for i, inv := range m.invoices {

--- a/internal/billing/threshold_scan.go
+++ b/internal/billing/threshold_scan.go
@@ -329,7 +329,7 @@ func (e *Engine) evaluateThresholds(ctx context.Context, sub domain.Subscription
 //
 // The invoice is built from the same line items evaluateThresholds already
 // computed — re-aggregating would risk a different running total if usage
-// landed between evaluate and fire. Tax + coupon + credit are applied via
+// landed between evaluate and fire. Tax + credit are applied via
 // the same paths the natural cycle uses so an early-finalize charge looks
 // identical to the customer.
 func (e *Engine) fireThreshold(ctx context.Context, sub domain.Subscription, eval thresholdEval, periodStart, now time.Time) (bool, error) {

--- a/internal/domain/invoice.go
+++ b/internal/domain/invoice.go
@@ -274,34 +274,6 @@ const (
 	LineTypeTax      InvoiceLineItemType = "tax"
 )
 
-// InvoiceDiscountUpdate is the snapshot ApplyDiscountAtomic writes to a
-// draft invoice: the coupon discount plus the tax recompute that follows
-// from the new (subtotal - discount) base. Per-line tax fields travel
-// with the line items passed alongside. SubtotalCents is included
-// because tax-inclusive mode requires the caller to resolve the final net
-// subtotal before persistence.
-//
-// Lives in domain so invoice.Store (producer of the SQL) and the billing
-// engine (producer of the tax recompute) can agree on the shape without
-// importing each other.
-type InvoiceDiscountUpdate struct {
-	SubtotalCents    int64
-	DiscountCents    int64
-	TaxAmountCents   int64
-	TaxRate          float64 // ADR-042/043: percent rate (4-decimal precision).
-	TaxName          string
-	TaxCountry       string
-	TaxID            string
-	TaxProvider      string
-	TaxCalculationID string
-	TaxReverseCharge bool
-	TaxExemptReason  string
-	TaxStatus        InvoiceTaxStatus
-	TaxDeferredAt    *time.Time
-	TaxPendingReason string
-	TaxErrorCode     string
-}
-
 // InvoiceTaxRetryUpdate is the snapshot UpdateTaxAtomic writes to a
 // pending or failed invoice when an operator (or the retry worker)
 // triggers a tax recompute. Carries the new tax decision plus the

--- a/internal/invoice/postgres.go
+++ b/internal/invoice/postgres.go
@@ -89,9 +89,7 @@ func (d decryptScanner) Scan(src any) error {
 // string literals so the constraint-name router in mapInvoiceUniqueViolation
 // is type-checked against actual index names — a typo here surfaces in
 // integration tests, not as a silent fall-through to the generic
-// "unknown constraint" branch. Mirrors the pattern in
-// internal/coupon/postgres.go which has been doing this since the
-// customer-discount idempotency work.
+// "unknown constraint" branch.
 const (
 	idxInvoicesBillingIdempotency  = "idx_invoices_billing_idempotency"
 	idxInvoicesProrationDedup      = "idx_invoices_proration_dedup"
@@ -1084,138 +1082,6 @@ func (s *PostgresStore) AddLineItemAtomic(
 	return item, inv, nil
 }
 
-// ApplyDiscountAtomic stamps a coupon discount (and the recomputed tax
-// snapshot) onto a draft invoice in a single transaction. The gate
-// re-check lives inside the tx — the caller's outer validate-then-write
-// pattern would race a concurrent finalize or a parallel apply-coupon
-// attempt; taking FOR UPDATE and re-asserting status=draft,
-// discount_cents=0, tax_transaction_id IS NULL closes the TOCTOU window.
-//
-// Per-line tax fields (tax_rate_bp, tax_amount_cents, total_amount_cents,
-// amount_cents) are rewritten from the caller's supplied lineItems because
-// the post-discount tax base may shift the per-line splits (inclusive-mode
-// carving in particular). Lines keyed by id; ids that don't belong to this
-// invoice are silently ignored so a caller can't corrupt a sibling.
-func (s *PostgresStore) ApplyDiscountAtomic(
-	ctx context.Context, tenantID, invoiceID string,
-	update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem,
-) (domain.Invoice, error) {
-	tx, err := s.db.BeginTx(ctx, postgres.TxTenant, tenantID)
-	if err != nil {
-		return domain.Invoice{}, err
-	}
-	defer postgres.Rollback(tx)
-
-	var (
-		status           domain.InvoiceStatus
-		existingDiscount int64
-		taxTransactionID string
-	)
-	err = tx.QueryRowContext(ctx, `
-		SELECT status, discount_cents, COALESCE(tax_transaction_id,'')
-		FROM invoices WHERE id = $1 FOR UPDATE
-	`, invoiceID).Scan(&status, &existingDiscount, &taxTransactionID)
-	if err == sql.ErrNoRows {
-		return domain.Invoice{}, errs.ErrNotFound
-	}
-	if err != nil {
-		return domain.Invoice{}, err
-	}
-	if status != domain.InvoiceDraft {
-		return domain.Invoice{}, errs.InvalidState(fmt.Sprintf(
-			"invoice must be draft to apply a coupon (current: %s)", status))
-	}
-	if existingDiscount > 0 {
-		return domain.Invoice{}, errs.InvalidState("invoice already has a discount applied")
-	}
-	if taxTransactionID != "" {
-		return domain.Invoice{}, errs.InvalidState("invoice tax has already been committed upstream")
-	}
-
-	now := clock.Now(ctx)
-
-	for _, li := range lineItems {
-		if li.ID == "" {
-			continue
-		}
-		_, err = tx.ExecContext(ctx, `
-			UPDATE invoice_line_items
-			SET amount_cents = $3,
-			    tax_rate = $4,
-			    tax_amount_cents = $5,
-			    total_amount_cents = $6,
-			    tax_reason = $7
-			WHERE invoice_id = $1 AND id = $2
-		`, invoiceID, li.ID, li.AmountCents, li.TaxRate, li.TaxAmountCents, li.TotalAmountCents, li.TaxabilityReason)
-		if err != nil {
-			return domain.Invoice{}, fmt.Errorf("update line item tax stamp: %w", err)
-		}
-	}
-
-	total := update.SubtotalCents - update.DiscountCents + update.TaxAmountCents
-
-	var inv domain.Invoice
-	err = tx.QueryRowContext(ctx, `
-		UPDATE invoices SET
-			subtotal_cents = $2,
-			discount_cents = $3,
-			tax_amount_cents = $4,
-			tax_rate = $5,
-			tax_name = $6,
-			tax_country = $7,
-			tax_id = $8,
-			tax_provider = $9,
-			tax_calculation_id = $10,
-			tax_reverse_charge = $11,
-			tax_exempt_reason = $12,
-			tax_status = $13,
-			tax_deferred_at = $14,
-			tax_pending_reason = $15,
-			tax_error_code = $16,
-			total_amount_cents = $17,
-			amount_due_cents = GREATEST($17 - amount_paid_cents - credits_applied_cents, 0),
-			updated_at = $18
-		WHERE id = $1
-		RETURNING `+invCols,
-		invoiceID,
-		update.SubtotalCents, update.DiscountCents, update.TaxAmountCents, update.TaxRate,
-		update.TaxName, update.TaxCountry, update.TaxID,
-		// tax_provider + tax_calculation_id are NOT NULL DEFAULT ''
-		// — pass empty string directly. NullableString would
-		// convert "" → SQLNULL → constraint violation. Bug surfaced
-		// 2026-05-04 when tax retry on orphan invoices wrote empty
-		// calculation_ids (none/manual providers don't issue them)
-		// and tripped SQLSTATE 23502.
-		update.TaxProvider,
-		update.TaxCalculationID,
-		update.TaxReverseCharge, update.TaxExemptReason,
-		update.TaxStatus, postgres.NullableTime(update.TaxDeferredAt), update.TaxPendingReason,
-		postgres.NullableString(update.TaxErrorCode),
-		total, now,
-	).Scan(s.scanInvDest(&inv)...)
-	if err != nil {
-		return domain.Invoice{}, err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return domain.Invoice{}, err
-	}
-	return inv, nil
-}
-
-// UpdateTaxAtomic re-stamps an invoice's tax decision after a manual
-// retry (or, eventually, the retry worker). Locks the invoice row FOR
-// UPDATE, gates on tax_status in (pending, failed) and status='draft',
-// rewrites per-line tax fields from the supplied lineItems, rewrites
-// the invoice-level tax columns, recomputes total / amount_due, and
-// increments tax_retry_count. Returns the updated row with attention
-// re-derivable from the new fields.
-//
-// A retry that succeeds writes tax_status='ok' with calculation_id
-// populated and tax_pending_reason / tax_error_code cleared. A retry
-// that fails again writes tax_status='pending' or 'failed' with the
-// new code/reason — the row stays blocked from finalize and the
-// dashboard banner refreshes.
 func (s *PostgresStore) UpdateTaxAtomic(
 	ctx context.Context, tenantID, invoiceID string,
 	update domain.InvoiceTaxRetryUpdate, lineItems []domain.InvoiceLineItem,

--- a/internal/invoice/service.go
+++ b/internal/invoice/service.go
@@ -48,8 +48,7 @@ type TaxReverser interface {
 
 // TaxRetrier is the narrow view into tax recompute + persistence the
 // retry-tax endpoint depends on. Satisfied by billing.Engine in
-// production. Same rationale as CouponApplier — the contract lives
-// next to the handler that calls it.
+// production — the contract lives next to the handler that calls it.
 type TaxRetrier interface {
 	RetryTaxForInvoice(ctx context.Context, tenantID, invoiceID string) (domain.Invoice, error)
 	// ComputeTaxForInvoice computes tax for a draft invoice regardless of
@@ -199,7 +198,7 @@ func (s *Service) bindForCreate(ctx context.Context, tenantID string, input Crea
 
 // bindForInvoice binds effective-now from an invoice id. Used by
 // every per-invoice mutation entry point (Finalize, Void,
-// RecordPayment, ApplyDiscount, RetryTax, etc.) so downstream stamps
+// RecordPayment, RetryTax, etc.) so downstream stamps
 // inherit simulated time.
 func (s *Service) bindForInvoice(ctx context.Context, tenantID, invoiceID string) context.Context {
 	bound, _ := clock.BindEffectiveNow(ctx, s.resolver, clock.Pin{TenantID: tenantID, InvoiceID: invoiceID})

--- a/internal/invoice/service_test.go
+++ b/internal/invoice/service_test.go
@@ -319,54 +319,6 @@ func (m *memStore) ListApproachingDue(_ context.Context, _ int) ([]domain.Invoic
 	return nil, nil
 }
 
-func (m *memStore) ApplyDiscountAtomic(_ context.Context, tenantID, invoiceID string, update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
-	inv, ok := m.invoices[invoiceID]
-	if !ok || inv.TenantID != tenantID {
-		return domain.Invoice{}, errs.ErrNotFound
-	}
-	if inv.Status != domain.InvoiceDraft {
-		return domain.Invoice{}, errs.InvalidState(fmt.Sprintf("invoice must be draft (current: %s)", inv.Status))
-	}
-	if inv.DiscountCents > 0 {
-		return domain.Invoice{}, errs.InvalidState("invoice already has a discount applied")
-	}
-	byID := make(map[string]domain.InvoiceLineItem, len(lineItems))
-	for _, li := range lineItems {
-		byID[li.ID] = li
-	}
-	for i, existing := range m.lineItems[invoiceID] {
-		if updated, ok := byID[existing.ID]; ok {
-			m.lineItems[invoiceID][i].AmountCents = updated.AmountCents
-			m.lineItems[invoiceID][i].TaxRate = updated.TaxRate
-			m.lineItems[invoiceID][i].TaxAmountCents = updated.TaxAmountCents
-			m.lineItems[invoiceID][i].TotalAmountCents = updated.TotalAmountCents
-		}
-	}
-	inv.SubtotalCents = update.SubtotalCents
-	inv.DiscountCents = update.DiscountCents
-	inv.TaxAmountCents = update.TaxAmountCents
-	inv.TaxRate = update.TaxRate
-	inv.TaxName = update.TaxName
-	inv.TaxCountry = update.TaxCountry
-	inv.TaxID = update.TaxID
-	inv.TaxProvider = update.TaxProvider
-	inv.TaxCalculationID = update.TaxCalculationID
-	inv.TaxReverseCharge = update.TaxReverseCharge
-	inv.TaxExemptReason = update.TaxExemptReason
-	inv.TaxStatus = update.TaxStatus
-	inv.TaxDeferredAt = update.TaxDeferredAt
-	inv.TaxPendingReason = update.TaxPendingReason
-	inv.TotalAmountCents = update.SubtotalCents - update.DiscountCents + update.TaxAmountCents
-	due := inv.TotalAmountCents - inv.AmountPaidCents - inv.CreditsAppliedCents
-	if due < 0 {
-		due = 0
-	}
-	inv.AmountDueCents = due
-	inv.UpdatedAt = time.Now().UTC()
-	m.invoices[invoiceID] = inv
-	return inv, nil
-}
-
 func (m *memStore) UpdateTaxAtomic(_ context.Context, tenantID, invoiceID string, update domain.InvoiceTaxRetryUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error) {
 	inv, ok := m.invoices[invoiceID]
 	if !ok || inv.TenantID != tenantID {

--- a/internal/invoice/store.go
+++ b/internal/invoice/store.go
@@ -57,17 +57,6 @@ type Store interface {
 	// item and the updated invoice.
 	AddLineItemAtomic(ctx context.Context, tenantID, invoiceID string, item domain.InvoiceLineItem) (domain.InvoiceLineItem, domain.Invoice, error)
 
-	// ApplyDiscountAtomic stamps a coupon discount (and the recomputed tax
-	// snapshot that follows from it) onto a draft invoice in a single tx.
-	// Locks the invoice FOR UPDATE, re-checks the state gates (draft,
-	// discount_cents = 0, tax_transaction_id IS NULL) under the lock, then
-	// rewrites discount/tax/totals. Per-line tax stamps are rewritten from
-	// the supplied lineItems (keyed by id) so the recompute is authoritative.
-	//
-	// Returns errs.InvalidState when a gate fails (caller surfaces 409) and
-	// errs.ErrNotFound when the invoice doesn't exist (caller surfaces 404).
-	ApplyDiscountAtomic(ctx context.Context, tenantID, invoiceID string, update domain.InvoiceDiscountUpdate, lineItems []domain.InvoiceLineItem) (domain.Invoice, error)
-
 	// UpdateTaxAtomic re-stamps an invoice's tax decision after a manual
 	// retry. Locks the invoice row, gates on tax_status in (pending, failed)
 	// and status='draft', rewrites per-line tax stamps and invoice-level tax

--- a/internal/pricing/handler.go
+++ b/internal/pricing/handler.go
@@ -71,8 +71,8 @@ func (h *Handler) OverrideRoutes() chi.Router {
 
 // MeterPricingRuleRoutes is the sub-router for
 // /v1/meters/{meter_id}/pricing-rules. Reads use the read perm; upsert and
-// delete need write. Pattern mirrors coupon.CustomerAssignmentRoutes so
-// the router can compose perms in the same place — see router.go.
+// delete need write. The pattern lets the router compose perms in the
+// same place — see router.go.
 func (h *Handler) MeterPricingRuleRoutes(requireRead, requireWrite func(http.Handler) http.Handler) chi.Router {
 	r := chi.NewRouter()
 	r.With(requireRead).Get("/", h.listMeterPricingRules)

--- a/internal/subscription/handler.go
+++ b/internal/subscription/handler.go
@@ -1080,8 +1080,8 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 	// explicit skip here is the only safe guard.
 	if !atomic && prorationEligible && prorationRemainingDays > 0 && h.invoices != nil && !result.OrchestratedCrossAxis {
 		// Re-hydrate the subscription post-change so the Items slice reflects
-		// the swapped plan/quantity — handleProration walks it to resolve
-		// coupon plan eligibility. Fall back to subBefore on error so the
+		// the swapped plan/quantity — handleProration walks it to price the
+		// change (currency/naming). Fall back to subBefore on error so the
 		// handler still responds, but use the fresh Items when available.
 		subAfter, getErr := h.svc.Get(ctx, tenantID, subID)
 		if getErr != nil {
@@ -1285,7 +1285,7 @@ func (h *Handler) removeItem(w http.ResponseWriter, r *http.Request) {
 
 	// Legacy non-atomic proration emission path — only when atomic wasn't taken.
 	if !atomic && prorationRemainingDays > 0 && removedPlanID != "" {
-		// Re-fetch for coupon plan eligibility over the remaining items.
+		// Re-fetch to price the proration over the remaining items.
 		subAfter, getErr := h.svc.Get(ctx, tenantID, subID)
 		if getErr != nil {
 			subAfter = subBefore
@@ -1631,7 +1631,7 @@ func (h *Handler) issueClawbackCreditNote(ctx context.Context, tenantID string, 
 
 func (h *Handler) handleItemProration(ctx context.Context, tenantID string, sub domain.Subscription, spec itemProrationSpec, tx *sql.Tx) (*ProrationDetail, error) {
 	// Resolve plans needed for pricing and naming. The "effective" plan drives
-	// currency and coupon eligibility — for a remove it's the old plan; for
+	// currency and pricing — for a remove it's the old plan; for
 	// anything else it's the new plan.
 	var oldPlan, newPlan domain.Plan
 	if spec.oldPlanID != "" {

--- a/internal/tax/provider.go
+++ b/internal/tax/provider.go
@@ -1,7 +1,7 @@
 // Package tax defines the tenant-selectable tax calculation backend and
 // three concrete implementations: NoneProvider (skip tax), ManualProvider
-// (flat tenant-level rate), and StripeTaxProvider (Stripe Tax API with a
-// manual fallback on errors).
+// (flat tenant-level rate), and StripeTaxProvider (Stripe Tax API; defers
+// the invoice to tax_status=pending for retry on error).
 //
 // Every tenant picks one Provider via tenant_settings.tax_provider; the
 // billing engine calls Calculate at invoice build time and, for

--- a/internal/tax/stripe.go
+++ b/internal/tax/stripe.go
@@ -171,8 +171,8 @@ func (p *StripeTaxProvider) Commit(ctx context.Context, calcRef, invoiceID strin
 	}
 	client := p.clientForCtx(ctx)
 	if client == nil {
-		// No client for mode — the calculation was a fallback result that
-		// has no Stripe calc_id to commit. No-op, consistent with manual.
+		// No client for the current mode (mode/credential mismatch at commit
+		// time); nothing to commit upstream. No-op, consistent with manual.
 		return "", nil
 	}
 	params := &stripe.TaxTransactionCreateFromCalculationParams{

--- a/internal/webhook/eventbus.go
+++ b/internal/webhook/eventbus.go
@@ -45,7 +45,7 @@ func FrameFromEvent(e domain.WebhookEvent, status string, lastAttemptAt *time.Ti
 		// Most Velox event payloads carry the affected customer's ID
 		// at top-level under "customer_id" — see internal/billing,
 		// internal/subscription, internal/invoice. The few that don't
-		// (coupon.created, plan-change.scheduled with no customer
+		// (some system/scheduled events with no customer
 		// scope) drop through to "" and the dashboard renders "—".
 		if v, ok := e.Payload["customer_id"].(string); ok {
 			customerID = v

--- a/internal/webhook/wire_shape_test.go
+++ b/internal/webhook/wire_shape_test.go
@@ -379,9 +379,8 @@ func TestWireShape_WebhookEventDeliveries(t *testing.T) {
 }
 
 // mapKeys returns the keys of a JSON-decoded object as a slice for
-// stable error-message rendering. Local to the test file since the
-// helper in other packages (billingalert/wire_shape_test.go) lives in
-// its own package and isn't importable.
+// stable error-message rendering. Local to the test file since helpers
+// in other test packages aren't importable.
 func mapKeys(m map[string]any) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
## What

Behavior-preserving cleanup round 2 (continues #201). **16 files, +17 / −309 LOC**, no schema/behavior/codegen change.

## A — Remove the dead `ApplyDiscountAtomic` coupon machinery

The coupon discount-stamping chain has had **no live caller** since coupons were deleted in ADR-039 (the `ApplyCouponToInvoice` flow that drove it is gone). Removed across the whole chain:

- engine `InvoiceWriter` interface decl + `invoiceWriterAdapter` (`api/adapters.go`)
- invoice `Store` interface + `PostgresStore` impl (the ~120-line transactional method)
- the now-unused `domain.InvoiceDiscountUpdate` type
- the three test mocks (`mockInvoices`, `invoiceStoreAdapter`, `memStore`)

No remaining references anywhere; the integration-test adapter compiles clean (`go vet -tags integration`).

## B — Doc-drift sweep (12 comment-only fixes)

Comments that **factually contradicted** the current code, corrected to match behavior (found via a dedicated scan):

| File | Was → Now |
|---|---|
| `billing/threshold_scan.go` | "Tax + coupon + credit" → "Tax + credit" |
| `subscription/handler.go` (×3) | "coupon plan eligibility" → "price the proration/change" |
| `invoice/service.go` | drop "ApplyDiscount" from the mutation list; drop "CouponApplier" analogy |
| `invoice/postgres.go` | drop dangling `internal/coupon/postgres.go` cross-ref |
| `tax/provider.go` + `tax/stripe.go` | "manual fallback on errors" → "defers to `tax_status=pending`" (ADR-041, matches code) |
| `webhook/eventbus.go` | drop dead `coupon.created` / `plan-change.scheduled` event examples |
| `webhook/wire_shape_test.go` | drop dead `billingalert` package reference |
| `pricing/handler.go` | drop dead `coupon.CustomerAssignmentRoutes` reference |

## Deliberately untouched

- The retained **coupon schema** (ADR-039 keeps it as the rebuild trigger).
- The intentional **zero-discount stubs** in the engine.
- Accurate historical notes (e.g. "coupons removed 2026-05-29").

## Verification

`go build ./...`, `go vet` (incl. `-tags integration`), `gofmt`, and the full `go test ./... -short` suite all pass. No residual references to any removed symbol or stale comment phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
