### PR TITLE
fix(frontend): status badges (uncollectible/trialing) + adjustment proration type

### DIFF
--- a/web-v2/src/lib/api.ts
+++ b/web-v2/src/lib/api.ts
@@ -580,7 +580,10 @@ export interface ProrationDetail {
   new_plan_id: string
   proration_factor: number
   amount_cents: number
-  type: 'invoice' | 'credit'
+  // 'invoice' = a proration charge invoice; 'credit' = a balance credit;
+  // 'adjustment' = reduced an unpaid open invoice's amount due (ADR-050
+  // unpaid-source path — NOT a refundable balance credit).
+  type: 'invoice' | 'credit' | 'adjustment'
   invoice_id?: string
 }
 

--- a/web-v2/src/lib/status.ts
+++ b/web-v2/src/lib/status.ts
@@ -3,9 +3,9 @@ export function statusBadgeVariant(status: string): 'default' | 'secondary' | 'd
     // Green
     case 'active': case 'paid': case 'succeeded': case 'resolved': return 'success'
     // Blue
-    case 'finalized': case 'processing': case 'issued': return 'info'
+    case 'finalized': case 'processing': case 'issued': case 'trialing': return 'info'
     // Red
-    case 'voided': case 'canceled': case 'failed': case 'revoked': return 'danger'
+    case 'voided': case 'canceled': case 'failed': case 'revoked': case 'uncollectible': return 'danger'
     // Amber
     case 'paused': case 'pending': case 'escalated': return 'warning'
     // Gray
@@ -17,8 +17,8 @@ export function statusBadgeVariant(status: string): 'default' | 'secondary' | 'd
 export function statusBorderColor(status: string): string {
   switch (status) {
     case 'active': case 'paid': case 'succeeded': case 'resolved': return 'border-l-emerald-500'
-    case 'finalized': case 'processing': case 'issued': return 'border-l-blue-500'
-    case 'voided': case 'canceled': case 'failed': case 'revoked': return 'border-l-red-500'
+    case 'finalized': case 'processing': case 'issued': case 'trialing': return 'border-l-blue-500'
+    case 'voided': case 'canceled': case 'failed': case 'revoked': case 'uncollectible': return 'border-l-red-500'
     case 'paused': case 'pending': case 'escalated': return 'border-l-amber-500'
     case 'draft': case 'archived': return 'border-l-gray-300 dark:border-l-gray-600'
     default: return 'border-l-transparent'

--- a/web-v2/src/pages/SubscriptionDetail.tsx
+++ b/web-v2/src/pages/SubscriptionDetail.tsx
@@ -1215,6 +1215,8 @@ export default function SubscriptionDetailPage() {
             if (res.proration) {
               if (res.proration.type === 'invoice') {
                 toast.success(`Proration invoice created for ${formatCents(res.proration.amount_cents)}`)
+              } else if (res.proration.type === 'adjustment') {
+                toast.success(`Open invoice reduced by ${formatCents(Math.abs(res.proration.amount_cents))}`)
               } else {
                 toast.success(`${formatCents(Math.abs(res.proration.amount_cents))} credited to customer balance`)
               }
@@ -1238,6 +1240,8 @@ export default function SubscriptionDetailPage() {
             if (res.proration) {
               if (res.proration.type === 'invoice') {
                 toast.success(`Proration invoice created for ${formatCents(res.proration.amount_cents)}`)
+              } else if (res.proration.type === 'adjustment') {
+                toast.success(`Open invoice reduced by ${formatCents(Math.abs(res.proration.amount_cents))}`)
               } else {
                 toast.success(`${formatCents(Math.abs(res.proration.amount_cents))} credited to customer balance`)
               }


### PR DESCRIPTION
Two 🟡 frontend-correctness items from the audit.

- **Status badges** — `statusBadgeVariant`/`statusBorderColor` had no case for `uncollectible` or `trialing`, so both fell through to the neutral `outline` badge. `uncollectible` (bad debt) now renders **red** like `voided`; `trialing` renders **blue** like other in-progress states. Both are real backend-emitted statuses.
- **`adjustment` proration type** — the ADR-050 unpaid-source path returns `type='adjustment'`, but the TS union was `'invoice' | 'credit'`, so it fell into the `credit` else-branch and told the operator **"$X credited to customer balance"** — exactly the thing ADR-050 says does *not* happen (it reduces the open invoice's amount due, not a refundable balance credit). Added `'adjustment'` to the union and a distinct toast: **"Open invoice reduced by $X"**.

Frontend-only; `tsc -b && vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)