### PR TITLE
chore(db): drop duplicate index on usage_events (0112)

### DIFF
--- a/internal/platform/migrate/sql/0112_drop_duplicate_usage_events_index.down.sql
+++ b/internal/platform/migrate/sql/0112_drop_duplicate_usage_events_index.down.sql
@@ -1,0 +1,6 @@
+-- velox:no-transaction
+--
+-- Recreate the duplicate index (restores the 0001 state). CONCURRENTLY so the
+-- rebuild never locks usage_events.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_events_aggregate
+    ON usage_events (tenant_id, customer_id, meter_id, "timestamp");

--- a/internal/platform/migrate/sql/0112_drop_duplicate_usage_events_index.up.sql
+++ b/internal/platform/migrate/sql/0112_drop_duplicate_usage_events_index.up.sql
@@ -1,0 +1,10 @@
+-- velox:no-transaction
+--
+-- Drop the duplicate index on usage_events. idx_usage_events_aggregate and
+-- idx_usage_events_customer_meter are byte-identical btrees over
+-- (tenant_id, customer_id, meter_id, timestamp) — both created in 0001. The
+-- planner can only ever use one; the other is pure write amplification on the
+-- highest-write table in the engine (every usage-event ingest maintains both).
+-- CONCURRENTLY (no-tx) so the drop never holds an AccessExclusiveLock on
+-- usage_events — see 0062 for the same posture on this table.
+DROP INDEX CONCURRENTLY IF EXISTS idx_usage_events_aggregate;


### PR DESCRIPTION
`idx_usage_events_aggregate` and `idx_usage_events_customer_meter` are **byte-identical** btrees over `(tenant_id, customer_id, meter_id, timestamp)`, both created in `0001`. The planner can only use one — the other is pure write amplification on the engine's **highest-write table** (every usage-event ingest maintains both).

Migration `0112` drops the redundant `idx_usage_events_aggregate` **CONCURRENTLY** (no-tx header, matching `0062`'s posture on this exact table) so the drop never holds an `AccessExclusiveLock` on `usage_events`. Down recreates it (restores the `0001` state). Migration round-trip (up→down→up) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)