### PR TITLE
fix(frontend): pause-collection auto-resume date anchors in tenant timezone

### DIFF
--- a/web-v2/src/pages/SubscriptionDetail.tsx
+++ b/web-v2/src/pages/SubscriptionDetail.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
 import { api, formatCents, formatDate, formatDateTime, getTenantTimezone, type Subscription, type SubscriptionItem, type Plan, type ItemChangeResult } from '@/lib/api'
-import { formatCivilDate, formatCivilPeriod } from '@/lib/dates'
+import { formatCivilDate, formatCivilPeriod, startOfDayInTZ } from '@/lib/dates'
 import { showApiError } from '@/lib/formErrors'
 import { Layout } from '@/components/Layout'
 import { TestClockBanner } from '@/components/TestClockBanner'
@@ -178,11 +178,13 @@ export default function SubscriptionDetailPage() {
   const pauseCollectionMutation = useMutation({
     mutationFn: () => {
       const body: { behavior: 'keep_as_draft'; resumes_at?: string } = { behavior: 'keep_as_draft' }
-      // DatePicker emits yyyy-MM-dd (date-only). Append start-of-day in
-      // the operator's local zone so the catchup orchestrator picks the
-      // pause back up on the right cycle close.
+      // DatePicker emits yyyy-MM-dd (date-only). Interpret it as start-of-day
+      // in the TENANT timezone (not the browser's): the backend's auto-resume
+      // scan compares the instant literally, and every other operator-picked
+      // civil date (extend-trial, credit expiry) anchors in tenant TZ. A
+      // browser-local parse shifted the resume by the operator/tenant offset.
       if (pauseResumesAt.trim() !== '') {
-        body.resumes_at = new Date(pauseResumesAt + 'T00:00:00').toISOString()
+        body.resumes_at = startOfDayInTZ(pauseResumesAt)
       }
       return api.pauseSubscriptionCollection(id!, body)
     },


### PR DESCRIPTION
The pause-collection dialog's date-only picker was parsed with `new Date(yyyy-MM-dd + 'T00:00:00').toISOString()`. Offset-less date-times parse in the **browser's** local zone (ES spec), so an operator whose browser TZ differs from the tenant's scheduled the auto-resume instant hours off — and across the date line, on the **wrong tenant civil day**. The backend's auto-resume scan (`pause_collection_resumes_at <= now`, `internal/subscription/postgres.go:864`) consumes the instant literally.

Fix: `startOfDayInTZ(pauseResumesAt)` — the picked civil date anchors at start-of-day in the **tenant** timezone, the same convention every other operator-picked civil date already follows (extend-trial uses `fromZonedTime` + tenant TZ; credit expiry uses `endOfDayInTZ`). The displayed value (`formatDateTime`) already renders in tenant TZ, so the picked and shown dates now agree.

This was drift, not a decision: `git log -L` shows the local-zone parse is a leftover from the old `datetime-local` input; the DatePicker migration didn't adopt the tenant-TZ helper. (Surfaced by the audit + the red eslint pass.)

Frontend-only; `tsc -b && vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)