### PR TITLE
fix(frontend): label-map raw enums + interaction polish on previously-unaudited pages

### DIFF
--- a/web-v2/src/pages/ApiKeys.tsx
+++ b/web-v2/src/pages/ApiKeys.tsx
@@ -70,6 +70,17 @@ function keyTypeVariant(type: string): 'default' | 'secondary' | 'outline' {
   }
 }
 
+// Human label for a key type — the raw enum ("secret") is a backend
+// identifier, not operator copy.
+function keyTypeLabel(type: string): string {
+  switch (type) {
+    case 'secret': return 'Secret'
+    case 'publishable': return 'Publishable'
+    case 'platform': return 'Platform'
+    default: return type
+  }
+}
+
 function isExpired(key: ApiKeyInfo): boolean {
   return !!key.expires_at && new Date(key.expires_at) < new Date()
 }
@@ -78,6 +89,7 @@ export default function ApiKeysPage() {
   const [showCreate, setShowCreate] = useState(false)
   const [createdKey, setCreatedKey] = useState<string | null>(null)
   const [revokeTarget, setRevokeTarget] = useState<ApiKeyInfo | null>(null)
+  const [revoking, setRevoking] = useState(false)
   const [rotateTarget, setRotateTarget] = useState<ApiKeyInfo | null>(null)
   const [showRevoked, setShowRevoked] = useState(false)
   const [showExpired, setShowExpired] = useState(false)
@@ -102,7 +114,8 @@ export default function ApiKeysPage() {
   const errorMsg = loadError instanceof Error ? loadError.message : loadError ? String(loadError) : null
 
   const handleRevoke = async () => {
-    if (!revokeTarget) return
+    if (!revokeTarget || revoking) return
+    setRevoking(true)
     try {
       await api.revokeApiKey(revokeTarget.id)
       toast.success('API key revoked')
@@ -110,6 +123,8 @@ export default function ApiKeysPage() {
       queryClient.invalidateQueries({ queryKey: ['api-keys'] })
     } catch (err) {
       showApiError(err, 'Failed to revoke key')
+    } finally {
+      setRevoking(false)
     }
   }
 
@@ -185,7 +200,7 @@ export default function ApiKeysPage() {
                           {k.key_prefix}--------
                         </code>
                         <div className="flex items-center gap-4 mt-2">
-                          <Badge variant={keyTypeVariant(k.key_type)}>{k.key_type}</Badge>
+                          <Badge variant={keyTypeVariant(k.key_type)}>{keyTypeLabel(k.key_type)}</Badge>
                           <span className="text-xs text-muted-foreground">Created {relativeTime(k.created_at)}</span>
                           <span className="text-xs text-muted-foreground">
                             {k.last_used_at ? `Last used ${relativeTime(k.last_used_at)}` : 'Never used'}
@@ -366,8 +381,8 @@ export default function ApiKeysPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={() => setRevokeTarget(null)}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleRevoke} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-              Revoke Key
+            <AlertDialogAction onClick={handleRevoke} disabled={revoking} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              {revoking ? 'Revoking…' : 'Revoke Key'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -611,8 +626,9 @@ function RotateKeyDialog({
         <DialogHeader>
           <DialogTitle>Rotate API Key</DialogTitle>
           <DialogDescription>
-            A new {target.key_type} key will be issued for "{target.name}". Choose how long the current key
-            stays valid so deployed clients can swap credentials.
+            A new {keyTypeLabel(target.key_type).toLowerCase()} key will be issued for "{target.name}". The current key
+            stops working when the grace period ends — immediately if you pick "Now" — so anything
+            still using it must switch to the new key within that window.
           </DialogDescription>
         </DialogHeader>
 

--- a/web-v2/src/pages/Credits.tsx
+++ b/web-v2/src/pages/Credits.tsx
@@ -80,6 +80,16 @@ type CreditFormData = z.infer<typeof creditSchema>
 
 const ENTRY_TYPES = ['All', 'grant', 'usage', 'adjustment'] as const
 
+// Human labels for ledger entry types — 'usage' as a bare badge is
+// ambiguous (a usage event? a deduction?); spell it out.
+const ENTRY_TYPE_LABELS: Record<string, string> = {
+  grant: 'Grant',
+  usage: 'Deduction',
+  adjustment: 'Adjustment',
+  expiry: 'Expiry',
+}
+const entryTypeLabel = (t: string): string => ENTRY_TYPE_LABELS[t] ?? t
+
 function SortableHead({
   label, sortKey: key, activeSortKey, sortDir, onSort, className,
 }: {
@@ -250,7 +260,7 @@ export default function CreditsPage() {
                 className="flex h-8 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
                 {ENTRY_TYPES.map(t => (
-                  <option key={t} value={t}>{t === 'All' ? 'All types' : t.charAt(0).toUpperCase() + t.slice(1)}</option>
+                  <option key={t} value={t}>{t === 'All' ? 'All types' : entryTypeLabel(t)}</option>
                 ))}
               </select>
               {ledger.length > 0 && (
@@ -297,7 +307,7 @@ export default function CreditsPage() {
                     {ledgerPaginated.map(entry => (
                       <TableRow key={entry.id}>
                         <TableCell className="text-sm text-muted-foreground whitespace-nowrap">{formatDate(entry.created_at)}</TableCell>
-                        <TableCell><Badge variant={entryTypeVariant(entry.entry_type)}>{entry.entry_type}</Badge></TableCell>
+                        <TableCell><Badge variant={entryTypeVariant(entry.entry_type)}>{entryTypeLabel(entry.entry_type)}</Badge></TableCell>
                         <TableCell className="text-sm text-foreground">{entry.description || '—'}</TableCell>
                         <TableCell className="text-sm">
                           {entry.invoice_id ? (

--- a/web-v2/src/pages/Dunning.tsx
+++ b/web-v2/src/pages/Dunning.tsx
@@ -62,6 +62,15 @@ function effectiveNowMs(effectiveNowISO?: string): number {
   return Date.now()
 }
 
+// Human labels for the resolution enum — raw values like
+// "payment_recovered" are backend identifiers, not operator copy.
+const RESOLUTION_LABELS: Record<string, string> = {
+  payment_recovered: 'Payment recovered',
+  manually_resolved: 'Manually resolved',
+  write_off: 'Written off',
+  invoice_not_collectible: 'Uncollectible',
+}
+
 function relativeTime(dateStr: string, effectiveNowISO?: string): string {
   const now = effectiveNowMs(effectiveNowISO)
   const then = new Date(dateStr).getTime()
@@ -264,6 +273,9 @@ function RunsTab() {
                   <p className="text-sm text-muted-foreground mt-1">
                     Dunning runs will appear here when Velox detects a failed payment and begins the recovery process.
                   </p>
+                  <Link to="/dunning-policies" className="inline-block mt-4">
+                    <Button variant="outline" size="sm">Configure a dunning policy</Button>
+                  </Link>
                 </>
               )}
             </div>
@@ -337,7 +349,7 @@ function RunsTab() {
                             <div className="flex items-center gap-2">
                               <Badge variant={statusBadgeVariant(run.state)}>{run.state}</Badge>
                               {run.resolution && run.resolution !== run.state && (
-                                <Badge variant={run.resolution === 'payment_recovered' ? 'success' : run.resolution === 'manually_resolved' ? 'info' : run.resolution === 'write_off' ? 'warning' : 'outline'}>{run.resolution}</Badge>
+                                <Badge variant={run.resolution === 'payment_recovered' ? 'success' : run.resolution === 'manually_resolved' ? 'info' : run.resolution === 'write_off' ? 'warning' : 'outline'}>{RESOLUTION_LABELS[run.resolution] ?? run.resolution}</Badge>
                               )}
                               {!isFinished && (
                                 <Button variant="outline" size="sm" className="h-6 text-xs ml-1"

--- a/web-v2/src/pages/MeterDetail.tsx
+++ b/web-v2/src/pages/MeterDetail.tsx
@@ -41,12 +41,17 @@ import { DetailBreadcrumb } from '@/components/DetailBreadcrumb'
 const statusVariant = statusBadgeVariant
 
 const AGGREGATION_MODES: { value: MeterAggregationMode; label: string; help: string }[] = [
-  { value: 'sum', label: 'sum', help: 'Add all event values in the period.' },
-  { value: 'count', label: 'count', help: 'Count matching events; ignore values.' },
-  { value: 'last_during_period', label: 'last_during_period', help: 'Take the latest event in the period.' },
-  { value: 'last_ever', label: 'last_ever', help: 'Take the latest event across all time (state-style billing).' },
-  { value: 'max', label: 'max', help: 'Take the largest value in the period.' },
+  { value: 'sum', label: 'Sum', help: 'Add all event values in the period.' },
+  { value: 'count', label: 'Count', help: 'Count matching events; ignore values.' },
+  { value: 'last_during_period', label: 'Last value in period', help: 'Take the latest event in the period.' },
+  { value: 'last_ever', label: 'Last value ever', help: 'Take the latest event across all time (state-style billing).' },
+  { value: 'max', label: 'Maximum', help: 'Take the largest value in the period.' },
 ]
+
+// Human label for an aggregation mode — operator copy never shows the raw
+// snake_case enum.
+const aggregationLabel = (mode: string): string =>
+  AGGREGATION_MODES.find(m => m.value === mode)?.label ?? mode
 
 export default function MeterDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -182,7 +187,7 @@ export default function MeterDetailPage() {
             <CopyButton text={meter.id} />
           </div>
         </div>
-        <Badge variant="secondary">{meter.aggregation}</Badge>
+        <Badge variant="secondary">{aggregationLabel(meter.aggregation)}</Badge>
       </div>
 
       {/* Properties */}
@@ -202,7 +207,7 @@ export default function MeterDetailPage() {
             </div>
             <div className="flex items-center justify-between px-6 py-3">
               <span className="text-sm text-muted-foreground">Default aggregation</span>
-              <Badge variant="secondary">{meter.aggregation}</Badge>
+              <Badge variant="secondary">{aggregationLabel(meter.aggregation)}</Badge>
             </div>
             <div className="flex items-center justify-between px-6 py-3">
               <span className="text-sm text-muted-foreground">Created</span>
@@ -335,7 +340,7 @@ export default function MeterDetailPage() {
                         </div>
                       </TableCell>
                       <TableCell>
-                        <Badge variant="secondary" className="font-mono text-xs">{rule.aggregation_mode}</Badge>
+                        <Badge variant="secondary" className="text-xs">{aggregationLabel(rule.aggregation_mode)}</Badge>
                       </TableCell>
                       <TableCell className="text-sm text-muted-foreground">
                         {ratingRuleName ? (

--- a/web-v2/src/pages/ResetPassword.tsx
+++ b/web-v2/src/pages/ResetPassword.tsx
@@ -160,6 +160,10 @@ export default function ResetPasswordPage() {
                 {loading ? <Loader2 size={16} className="animate-spin mr-2" /> : null}
                 {loading ? 'Updating…' : 'Update password'}
               </Button>
+
+              <Link to="/login" className="block text-center text-xs text-muted-foreground hover:text-foreground transition-colors">
+                Back to sign in
+              </Link>
             </form>
           )}
         </CardContent>

--- a/web-v2/src/pages/Settings.tsx
+++ b/web-v2/src/pages/Settings.tsx
@@ -826,7 +826,21 @@ export default function SettingsPage() {
                 <span className="text-sm text-muted-foreground">Unsaved changes</span>
               </div>
               <div className="flex items-center gap-3">
-                <Button variant="ghost" onClick={() => loadSettings()}>Discard</Button>
+                <AlertDialog>
+                  <AlertDialogTrigger render={<Button variant="ghost" />}>Discard</AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Discard changes?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        All unsaved edits on this page will be lost and the form reset to the last saved values.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Keep editing</AlertDialogCancel>
+                      <AlertDialogAction onClick={() => loadSettings()}>Discard changes</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
                 <Button onClick={() => handleSave()} disabled={saving}>
                   {saving ? <><Loader2 size={14} className="animate-spin mr-2" /> Saving...</> : 'Save Changes'}
                 </Button>
@@ -1274,7 +1288,7 @@ function ApiKeysForm({ livemode, connected, onSuccess }: {
     mutationFn: (data: StripeConnectForm) => api.connectStripe({ ...data, livemode }),
     onSuccess: (row) => {
       if (row.last_verified_error) {
-        toast.error(`Saved, but Stripe verify failed: ${row.last_verified_error}`)
+        toast.error('Saved, but Stripe could not verify these keys — see the details below the form.')
       } else {
         const base = `${connected ? 'Rotated' : 'Connected'} ${livemode ? 'live' : 'test'} mode${
           row.stripe_account_name ? ` as ${row.stripe_account_name}` : ''
@@ -1288,8 +1302,8 @@ function ApiKeysForm({ livemode, connected, onSuccess }: {
         const queued = row.retries_queued ?? 0
         const description = queued > 0
           ? queued === 1
-            ? 'Retrying 1 invoice that was stuck on tax in the background.'
-            : `Retrying ${queued} invoices that were stuck on tax in the background.`
+            ? 'Retrying 1 invoice that was waiting for a Stripe connection.'
+            : `Retrying ${queued} invoices that were waiting for a Stripe connection.`
           : undefined
         if (description) {
           toast.success(base, { description })

--- a/web-v2/src/pages/TestClockDetail.tsx
+++ b/web-v2/src/pages/TestClockDetail.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { api, formatDateTime, getTenantTimezone, type TestClock } from '@/lib/api'
+import { showApiError } from '@/lib/formErrors'
 import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
 import { Layout } from '@/components/Layout'
 import { Button } from '@/components/ui/button'
@@ -19,7 +20,6 @@ import {
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import { useAuth } from '@/contexts/AuthContext'
-import { ApiError } from '@/lib/api'
 import { ChevronLeft, FastForward, Loader2, Trash2, AlertTriangle, Clock as ClockIcon, Users } from 'lucide-react'
 import { EmptyState } from '@/components/EmptyState'
 
@@ -47,6 +47,7 @@ export default function TestClockDetailPage() {
   const [showAdvance, setShowAdvance] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
   const [retryingAdvance, setRetryingAdvance] = useState(false)
+  const [deleting, setDeleting] = useState(false)
 
   // Test-mode-only — same redirect guard as the index page.
   useEffect(() => {
@@ -96,15 +97,15 @@ export default function TestClockDetailPage() {
       // first poll tick.
       queryClient.invalidateQueries({ queryKey: ['test-clocks', id] })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to retry'
-      toast.error(msg)
+      showApiError(err, 'Failed to retry')
     } finally {
       setRetryingAdvance(false)
     }
   }
 
   const handleDelete = async () => {
-    if (!id) return
+    if (!id || deleting) return
+    setDeleting(true)
     try {
       await api.deleteTestClock(id)
       toast.success('Test clock deleted')
@@ -124,8 +125,8 @@ export default function TestClockDetailPage() {
       navigate('/test-clocks')
       queryClient.invalidateQueries({ queryKey: ['test-clocks'], exact: true })
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to delete'
-      toast.error(msg)
+      showApiError(err, 'Failed to delete')
+      setDeleting(false)
     }
   }
 
@@ -342,8 +343,8 @@ export default function TestClockDetailPage() {
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={() => setShowDelete(false)}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-              Delete clock
+            <AlertDialogAction onClick={handleDelete} disabled={deleting} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              {deleting ? 'Deleting…' : 'Delete clock'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -447,8 +448,7 @@ function AdvanceClockDialog({
       queryClient.invalidateQueries({ queryKey: ['invoices'] })
       onClose()
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : err instanceof Error ? err.message : 'Failed to advance clock'
-      toast.error(msg)
+      showApiError(err, 'Failed to advance clock')
     } finally {
       setSubmitting(false)
     }


### PR DESCRIPTION
Operator‑copy and interaction fixes from the post‑audit UX walk of the pages the earlier pass skipped (Dunning, MeterDetail, ApiKeys, Credits, Settings, TestClockDetail, ResetPassword). **No layout or redesign** — these are rule‑violation fixes to existing surfaces.

## Label‑mapping (no raw enums in operator copy)
- **Dunning** resolution badge: `payment_recovered`/`write_off` → 'Payment recovered'/'Written off'; empty state now links to *Configure a dunning policy*.
- **MeterDetail** aggregation badges (3 sites): `last_during_period`/`last_ever` → human labels, via the `AGGREGATION_MODES` table that was already defined in the file but unused for display.
- **ApiKeys** key‑type badge: `secret`/`publishable` → 'Secret'/'Publishable'.
- **Credits** ledger badge: `usage` → 'Deduction' (ambiguous as a bare badge), shared with the filter dropdown so the two can't disagree.
- **Settings**: 'stuck on tax' jargon and the raw Stripe verify error string are now plain operator copy; the raw error stays in the inline card where it's actually debuggable.

## Interaction polish
- **Settings Discard** now confirms before wiping unsaved edits.
- **ApiKeys revoke** + **TestClockDetail delete**: disabled‑while‑in‑flight (no double‑submit); TestClockDetail's retry/delete/advance catches switched to `showApiError` (preserves the request‑ID copy action), dropping a now‑unused `ApiError` import.
- **ApiKeys rotate dialog**: real consequence copy — the current key stops working after the grace window, immediately on 'Now'.
- **ResetPassword**: 'Back to sign in' link in the valid‑token state (was a nav dead‑end).

Frontend‑only; `tsc -b && vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)