### PR TITLE
chore(webhooks): remove 4 EventType constants that are never emitted

### DIFF
--- a/internal/domain/webhook_outbound.go
+++ b/internal/domain/webhook_outbound.go
@@ -77,7 +77,6 @@ type EventDispatcher interface {
 
 // Well-known event types emitted by Velox.
 const (
-	EventInvoiceCreated   = "invoice.created"
 	EventInvoiceFinalized = "invoice.finalized"
 	EventInvoicePaid      = "invoice.paid"
 	EventInvoiceVoided    = "invoice.voided"
@@ -113,11 +112,8 @@ const (
 	EventSubscriptionTrialEnded             = "subscription.trial_ended"
 	EventSubscriptionTrialExtended          = "subscription.trial_extended"
 	EventSubscriptionThresholdCrossed       = "subscription.threshold_crossed"
-	EventCustomerCreated                    = "customer.created"
 	EventCustomerEmailBounced               = "customer.email_bounced"
 	EventDunningStarted                     = "dunning.started"
 	EventDunningEscalated                   = "dunning.escalated"
 	EventDunningResolved                    = "dunning.resolved"
-	EventCreditGranted                      = "credit.granted"
-	EventCreditNoteIssued                   = "credit_note.issued"
 )


### PR DESCRIPTION
`invoice.created`, `customer.created`, `credit.granted`, `credit_note.issued` had **zero dispatch sites** and were removed from the dashboard event picker in #215. With `invoice.paid` now emitted (#216), **every** constant in the catalog actually fires — so the file comment *"event types emitted by Velox"* is true again. Re-add a constant when the corresponding event is implemented.

(The `"invoice.created"` string literals in `webhook/service_test.go` test the wildcard/exact matcher generically and don't reference these constants, so they're unaffected.)

`go build` + webhook/domain tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)