### PR TITLE
test(webhook): fix data race in mockHTTPClient under -race (flaky CI)

### DIFF
--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -281,16 +281,29 @@ func (m *memStore) ListPendingDeliveries(_ context.Context, limit int) ([]domain
 }
 
 // mockHTTPClient captures requests and returns configurable responses.
+//
+// The webhook service delivers ASYNCHRONOUSLY (go s.deliver(...)), so a test
+// that fires two overlapping deliveries — e.g. TestReplay_PinsLivemodeOnDelivery
+// dispatches an event AND replays it — has two goroutines calling Do at once.
+// mu guards the captured fields so those concurrent writes don't data-race
+// under `-race` (the same reason the neighbouring memStore carries `dmu`).
+// statusCode is set once at construction and never mutated, so Do reads it
+// without the lock; lastRequest/lastBody are read back only by synchronous-
+// delivery (NewTestService) tests, where program order already places the read
+// after the write.
 type mockHTTPClient struct {
+	mu          sync.Mutex
 	lastRequest *http.Request
 	lastBody    []byte
 	statusCode  int
 }
 
 func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	m.lastRequest = req
 	body, _ := io.ReadAll(req.Body)
+	m.mu.Lock()
+	m.lastRequest = req
 	m.lastBody = body
+	m.mu.Unlock()
 	return &http.Response{
 		StatusCode: m.statusCode,
 		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),


### PR DESCRIPTION
## Root cause of the flaky `test (with race detector)` CI job

The webhook service delivers **asynchronously** (`go s.deliver(...)`). The test's `mockHTTPClient.Do` captured each request into shared fields with **no synchronization**:

```go
func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
	m.lastRequest = req   // unguarded write
	m.lastBody = body     // unguarded write
```

A test that fires two overlapping deliveries — `TestReplay_PinsLivemodeOnDelivery` dispatches an event **and** replays it, i.e. two delivery goroutines — has both goroutines write those fields at once. The `-race` detector flags it intermittently, failing CI on **unrelated** PRs (it just blocked #261, whose own package tests passed).

It's an unsynchronized-memory bug in the test double, not a flaky assertion. The neighbouring `memStore` was **already** hardened with a `dmu` mutex for exactly this (during the #249 replay-livemode fix, comment: *"so the async goroutine path can be exercised under -race"*) — the HTTP mock was the one shared double that got missed.

## Fix

Guard the writes in `Do` with a mutex. `statusCode` is set once at construction (safe to read unlocked); `lastRequest`/`lastBody` are read back only by **synchronous-delivery** (`NewTestService`) tests, where program order already orders the read after the write — so the write-write race was the only one, and locking the writes resolves it completely. No production code touched; no churn on the 13 provably-safe read sites.

Verified clean across **`go test ./internal/webhook/... -race -count=10`** (42s, 10 consecutive runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)