### PR TITLE
refactor(money): land AllocateByWeight move + restore its unit test (dropped in #276)

### DIFF
--- a/internal/billing/engine.go
+++ b/internal/billing/engine.go
@@ -3984,57 +3984,6 @@ func (e *Engine) creditUnusedPrebill(ctx context.Context, sub domain.Subscriptio
 	return netUnused, nil
 }
 
-// allocateByWeight splits `total` across len(weights) buckets in proportion to
-// weights using the largest-remainder method, so the parts sum to `total`
-// EXACTLY (no rounding drift) and each part is >= 0. This is what keeps a
-// period-wide credit fanned across multiple funding invoices from over- or
-// under-crediting: the authoritative engine figure is PARTITIONED, never
-// recomputed independently per invoice (independent recompute double-counts
-// after a reversing change — e.g. upgrade→downgrade→cancel). Zero-weight
-// buckets get nothing; if every weight is zero the whole total lands in
-// bucket 0.
-func allocateByWeight(total int64, weights []int64) []int64 {
-	out := make([]int64, len(weights))
-	if len(weights) == 0 {
-		return out
-	}
-	var sum int64
-	for _, w := range weights {
-		if w > 0 {
-			sum += w
-		}
-	}
-	if sum <= 0 {
-		out[0] = total
-		return out
-	}
-	type rem struct {
-		idx int
-		r   int64
-	}
-	rems := make([]rem, 0, len(weights))
-	var allocated int64
-	for i, w := range weights {
-		if w <= 0 {
-			rems = append(rems, rem{i, -1}) // never receives a remainder cent
-			continue
-		}
-		num := total * w
-		out[i] = num / sum
-		allocated += out[i]
-		rems = append(rems, rem{i, num % sum})
-	}
-	// Largest-remainder: hand the leftover cents to the biggest remainders
-	// (ties: lower index, via stable sort). leftover < count of positive-weight
-	// buckets, so it never reaches a zero-weight (r==-1) bucket.
-	leftover := total - allocated
-	sort.SliceStable(rems, func(a, b int) bool { return rems[a].r > rems[b].r })
-	for k := int64(0); k < leftover && int(k) < len(rems); k++ {
-		out[rems[k].idx]++
-	}
-	return out
-}
-
 // settleUnusedAcrossFunding relieves the unused in_advance prepayment of a
 // canceled / swapped period across EVERY invoice that funded it. `totalUnused`
 // (net, sized off the post-change base across all items) is the authoritative
@@ -4074,7 +4023,7 @@ func (e *Engine) settleUnusedAcrossFunding(ctx context.Context, sub domain.Subsc
 		}
 		weights[i] = money.RoundHalfToEven(src.SubtotalCents*int64(ud), int64(windowDays))
 	}
-	nets := allocateByWeight(totalUnused, weights)
+	nets := money.AllocateByWeight(totalUnused, weights)
 
 	var credited int64
 	for i, src := range sources {

--- a/internal/platform/money/allocate.go
+++ b/internal/platform/money/allocate.go
@@ -1,0 +1,58 @@
+package money
+
+import "sort"
+
+// AllocateByWeight splits `total` across len(weights) buckets in proportion to
+// weights using the largest-remainder method, so the parts sum to `total`
+// EXACTLY (no rounding drift) and each part is >= 0.
+//
+// This is the primitive that lets a single authoritative figure (e.g. a
+// period's unused-prepayment credit) be fanned across multiple targets (the
+// invoices that funded the period) without over- or under-counting: the one
+// authoritative total is PARTITIONED, never recomputed independently per
+// bucket. Independent per-bucket recompute double-counts after a reversing
+// change (e.g. upgrade→downgrade→cancel); a partition cannot.
+//
+// Zero-weight buckets receive nothing; if every weight is zero the whole total
+// lands in bucket 0. `total` is assumed non-negative.
+func AllocateByWeight(total int64, weights []int64) []int64 {
+	out := make([]int64, len(weights))
+	if len(weights) == 0 {
+		return out
+	}
+	var sum int64
+	for _, w := range weights {
+		if w > 0 {
+			sum += w
+		}
+	}
+	if sum <= 0 {
+		out[0] = total
+		return out
+	}
+	type rem struct {
+		idx int
+		r   int64
+	}
+	rems := make([]rem, 0, len(weights))
+	var allocated int64
+	for i, w := range weights {
+		if w <= 0 {
+			rems = append(rems, rem{i, -1}) // never receives a remainder cent
+			continue
+		}
+		num := total * w
+		out[i] = num / sum
+		allocated += out[i]
+		rems = append(rems, rem{i, num % sum})
+	}
+	// Largest-remainder: hand the leftover cents to the biggest remainders
+	// (ties: lower index, via stable sort). leftover < count of positive-weight
+	// buckets, so it never reaches a zero-weight (r==-1) bucket.
+	leftover := total - allocated
+	sort.SliceStable(rems, func(a, b int) bool { return rems[a].r > rems[b].r })
+	for k := int64(0); k < leftover && int(k) < len(rems); k++ {
+		out[rems[k].idx]++
+	}
+	return out
+}

--- a/internal/platform/money/allocate_test.go
+++ b/internal/platform/money/allocate_test.go
@@ -1,0 +1,75 @@
+package money
+
+import "testing"
+
+// TestAllocateByWeight pins the largest-remainder partition. The critical
+// property: the parts ALWAYS sum to the input total exactly — this is what
+// stops a credit fanned across funding invoices from over-crediting (an
+// independent per-bucket recompute would double-count; a partition cannot).
+func TestAllocateByWeight(t *testing.T) {
+	sum := func(xs []int64) int64 {
+		var s int64
+		for _, x := range xs {
+			s += x
+		}
+		return s
+	}
+
+	t.Run("two equal weights split evenly", func(t *testing.T) {
+		got := AllocateByWeight(4000, []int64{4000, 4000})
+		if got[0] != 2000 || got[1] != 2000 {
+			t.Fatalf("got %v, want [2000 2000]", got)
+		}
+	})
+
+	t.Run("over-credit guard: raw weights summing to 2x total still partition to total", func(t *testing.T) {
+		// upgrade→downgrade→cancel shape: engine total $40, each funding invoice
+		// independently looks like $40 unused. A naive recompute credits $80; the
+		// partition must scale both down so the sum is exactly $40.
+		got := AllocateByWeight(4000, []int64{4000, 4000})
+		if s := sum(got); s != 4000 {
+			t.Fatalf("sum=%d, want 4000 (no over-credit)", s)
+		}
+	})
+
+	t.Run("uneven weights, residual cent to largest remainder", func(t *testing.T) {
+		got := AllocateByWeight(100, []int64{1, 2})
+		if sum(got) != 100 {
+			t.Fatalf("sum=%d, want 100", sum(got))
+		}
+		if got[1] < got[0] {
+			t.Fatalf("got %v, want larger share in bucket 1", got)
+		}
+	})
+
+	t.Run("realistic upgrade→cancel: $153.33 across base+upgrade unused weights", func(t *testing.T) {
+		got := AllocateByWeight(15333, []int64{7667, 7666})
+		if sum(got) != 15333 {
+			t.Fatalf("sum=%d, want 15333", sum(got))
+		}
+		if got[0] <= 0 || got[1] <= 0 {
+			t.Fatalf("both funding invoices must receive a share, got %v", got)
+		}
+	})
+
+	t.Run("zero weights → all to bucket 0, never negative", func(t *testing.T) {
+		got := AllocateByWeight(500, []int64{0, 0})
+		if got[0] != 500 || got[1] != 0 {
+			t.Fatalf("got %v, want [500 0]", got)
+		}
+	})
+
+	t.Run("one zero weight gets nothing", func(t *testing.T) {
+		got := AllocateByWeight(900, []int64{0, 3})
+		if got[0] != 0 || got[1] != 900 {
+			t.Fatalf("got %v, want [0 900]", got)
+		}
+	})
+
+	t.Run("single source receives the whole total", func(t *testing.T) {
+		got := AllocateByWeight(12345, []int64{999})
+		if len(got) != 1 || got[0] != 12345 {
+			t.Fatalf("got %v, want [12345]", got)
+		}
+	})
+}


### PR DESCRIPTION
## What

Follow-up to #276. The refactor commit there hit a `git add` pathspec error (on an already-`git rm`'d file) and silently staged **only the test deletion** — so main shipped with the partition allocator left **inline in `engine.go`** and the dedicated `TestAllocateByWeight` **removed**.

**No correctness impact on #276:** the inline `allocateByWeight` works and `TestBillOnCancel_FansAcrossUpgradeInvoice` still exercised the fan-out end to end. This PR just lands the intended cleanup.

## Change
- Move `allocateByWeight` → `internal/platform/money.AllocateByWeight` (shared home alongside `RoundHalfToEven`; the cross-package home the downgrade-clawback fast-follow needs).
- `billing.settleUnusedAcrossFunding` now calls `money.AllocateByWeight`; the inline copy is removed.
- **Restore `TestAllocateByWeight`** in the money package (partition sums to the total exactly; the over-credit guard for upgrade→downgrade→cancel).

No behavior change. `-short` green for `billing` + `money`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)