### PR TITLE
docs(invoice): note the MarkPaid async-capture divergence at the call site

### DIFF
--- a/internal/invoice/postgres.go
+++ b/internal/invoice/postgres.go
@@ -752,6 +752,17 @@ func (s *PostgresStore) MarkPaidReportingTransition(ctx context.Context, tenantI
 
 	now := clock.Now(ctx)
 	var inv domain.Invoice
+	// amount_paid_cents records the CURRENT amount_due (what the PaymentIntent was
+	// created for), NOT Stripe's actual captured amount. Holds because the PI is
+	// created for exactly amount_due and capture is synchronous + full on the
+	// card-on-file path. KNOWN EDGE — deferred, no synchronous-card exposure: on
+	// an ASYNC / SCA charge (payment_status='processing'), a credit note that
+	// reduces amount_due AFTER PI-create but BEFORE this settle would record
+	// amount_paid BELOW the captured amount, under-reporting the refund cap
+	// (creditnote refund is capped at amount_paid). Fix when a first
+	// async-payment-method / EU-SCA design partner lands: thread the PI's
+	// amount_received through to here instead of re-reading amount_due.
+	// (2026-06-15 proration audit, re-verify wf_29503f6d: 2/3 real, low, rare.)
 	err = tx.QueryRowContext(ctx, `
 		UPDATE invoices SET
 			status = 'paid',


### PR DESCRIPTION
## What

A one-line-block breadcrumb (no code change) at `MarkPaid` (`internal/invoice/postgres.go`) for the deferred audit finding: `amount_paid_cents` is set to `amount_due`, not Stripe's captured amount.

Correct on the synchronous card-on-file path (PI is created for exactly `amount_due`, capture is synchronous + full). The documented edge: on an **async / SCA** charge (`payment_status='processing'`), a credit note that reduces `amount_due` after PI-create but before settle would record `amount_paid` below the captured amount → under-reports the credit-note refund cap. Re-verified 2/3 real, **low + rare**, no pre-launch exposure. Trigger to fix: first async-payment-method / EU-SCA design partner (thread the PI's `amount_received` through).

Documents the invariant so a future async-payment integrator finds it instead of rediscovering it. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)