### PR TITLE
test(domain): lock the decimal per-unit rate JSON-string contract (ADR-045)

### DIFF
--- a/internal/domain/pricing_decimal_json_test.go
+++ b/internal/domain/pricing_decimal_json_test.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestRatingRuleVersion_FlatAmountCents_SerializesAsDecimalString is FLOW B2b
+// checkbox 3 (ADR-045): GET /v1/rating-rules/<id> must serialize the per-unit
+// rate as a JSON STRING ("0.0003"), not a number. A JSON number is a float64 and
+// would drift / round a sub-cent rate toward 0; the string preserves arbitrary
+// precision (Stripe's unit_amount_decimal shape). It must also round-trip back
+// to the exact decimal.
+func TestRatingRuleVersion_FlatAmountCents_SerializesAsDecimalString(t *testing.T) {
+	rr := RatingRuleVersion{
+		ID:              "rr_1",
+		RuleKey:         "c35_sonnet_input",
+		FlatAmountCents: decimal.RequireFromString("0.0003"), // 0.0003¢/unit = $3.00 / 1,000,000 units
+	}
+	b, err := json.Marshal(rr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+	t.Logf("GET /v1/rating-rules/<id> JSON → %s", js)
+
+	// (1) It is a QUOTED string "0.0003" — the API contract.
+	if !strings.Contains(js, `"flat_amount_cents":"0.0003"`) {
+		t.Fatalf("flat_amount_cents not serialized as the string \"0.0003\":\n%s", js)
+	}
+	// (2) It is NOT a bare JSON number (no precision loss / rounding to 0).
+	for _, bad := range []string{
+		`"flat_amount_cents":0.0003`,
+		`"flat_amount_cents":0,`,
+		`"flat_amount_cents":0}`,
+	} {
+		if strings.Contains(js, bad) {
+			t.Fatalf("flat_amount_cents serialized as a number (precision-lossy): found %q in\n%s", bad, js)
+		}
+	}
+
+	// (3) Round-trips back to the EXACT decimal — no float drift.
+	var back RatingRuleVersion
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !back.FlatAmountCents.Equal(decimal.RequireFromString("0.0003")) {
+		t.Fatalf("round-trip lost precision: got %s, want 0.0003", back.FlatAmountCents)
+	}
+
+	// (4) Sanity: 0.0003¢/unit × 1,000,000 units = 300¢ exactly (the line amount
+	// that checkbox 4 asserts — rate stays decimal, line rounds to whole cents).
+	line := back.FlatAmountCents.Mul(decimal.NewFromInt(1_000_000))
+	if !line.Equal(decimal.NewFromInt(300)) {
+		t.Fatalf("0.0003¢ × 1,000,000 = %s, want 300 (¢) = $3.00", line)
+	}
+}


### PR DESCRIPTION
## What

Adds the missing regression for **FLOW B2b checkbox 3** (ADR-045 decimal per-unit rates).

The existing API e2e test (`internal/api/e2e_test.go:74`) creates a rating rule with `flat_amount_cents: 1000` — **whole cents only** — so the **sub-cent JSON-string contract was never actually tested**. This locks it:

- A `RatingRuleVersion` with `FlatAmountCents = 0.0003` serializes `flat_amount_cents` as the **quoted string `"0.0003"`**, not a number (a JSON number is float64 and would drift / round a sub-cent rate toward 0 — Stripe's `unit_amount_decimal` uses a string for the same reason).
- It **round-trips** back to the exact decimal.
- Sanity: `0.0003¢ × 1,000,000 = 300¢` ($3.00) — ties the rate contract to the line-amount math in checkbox 4.

Verified output: `{ … "flat_amount_cents":"0.0003" … }`. Green + lint clean. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)