### PR TITLE
test(billing): cover the 4 money-correctness ACI gaps

### DIFF
--- a/internal/credit/postgres_grant_creditnote_test.go
+++ b/internal/credit/postgres_grant_creditnote_test.go
@@ -1,0 +1,110 @@
+package credit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/credit"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestGrantForCreditNote_IdempotentNoDoubleCredit asserts the real
+// migration-0093 partial unique index idx_credit_ledger_credit_note_dedup
+// makes GrantForCreditNote exactly-once.
+//
+// The paid-CN clawback path (creditnote.Issue → GrantForCreditNote) can be
+// retried after a downstream-step failure (tax reversal / UpdateStatus). The
+// retry calls GrantForCreditNote again with the SAME credit-note id. Without
+// the DB-enforced unique index, the second Grant() appends a SECOND grant row
+// and double-credits the customer. The index makes the second insert violate
+// idx_credit_ledger_credit_note_dedup → store returns ErrAlreadyExists
+// (code "credit_note_source_taken") → service fetches the existing grant via
+// GetByCreditNoteSource and returns it as an idempotent no-op.
+//
+// A mem-store emulation guards this today; this test exercises the actual
+// Postgres constraint + the real route in appendEntryInTx.
+func TestGrantForCreditNote_IdempotentNoDoubleCredit(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	creditStore := credit.NewPostgresStore(db)
+	svc := credit.NewService(creditStore)
+	tenantID := testutil.CreateTestTenant(t, db, "Grant CN Idempotent")
+
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_grant_cn_idem", DisplayName: "Grant CN Idem",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	// Same shape creditnote.Issue() uses for a credit-type CN.
+	const creditNoteID = "vlx_cn_grant_idem"
+	input := credit.GrantInput{
+		CustomerID:  cust.ID,
+		AmountCents: 4000,
+		Description: "Credit note CN-001 — duplicate_charge",
+	}
+
+	// First grant: restores $40 to the customer's balance.
+	first, err := svc.GrantForCreditNote(ctx, tenantID, creditNoteID, input)
+	if err != nil {
+		t.Fatalf("first GrantForCreditNote: %v", err)
+	}
+	if first.AmountCents != 4000 {
+		t.Fatalf("first grant amount: got %d, want 4000", first.AmountCents)
+	}
+
+	balAfterFirst, err := svc.GetBalance(ctx, tenantID, cust.ID)
+	if err != nil {
+		t.Fatalf("get balance after first grant: %v", err)
+	}
+	if balAfterFirst.BalanceCents != 4000 {
+		t.Fatalf("balance after first grant: got %d, want 4000", balAfterFirst.BalanceCents)
+	}
+
+	// Second grant: retry of Issue() after a downstream-step failure. Pre-index
+	// this appended a SECOND $40 grant → balance $80. Post-index the insert hits
+	// idx_credit_ledger_credit_note_dedup; GrantForCreditNote returns the
+	// EXISTING grant with no error and no second row.
+	second, err := svc.GrantForCreditNote(ctx, tenantID, creditNoteID, input)
+	if err != nil {
+		t.Fatalf("second GrantForCreditNote: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Errorf("second grant should return the existing row: got id %q, want %q", second.ID, first.ID)
+	}
+	if second.AmountCents != 4000 {
+		t.Errorf("second grant amount: got %d, want 4000 (existing grant)", second.AmountCents)
+	}
+
+	// Balance reflects a SINGLE grant, not doubled.
+	balAfterSecond, err := svc.GetBalance(ctx, tenantID, cust.ID)
+	if err != nil {
+		t.Fatalf("get balance after second grant: %v", err)
+	}
+	if balAfterSecond.BalanceCents != 4000 {
+		t.Errorf("balance after second grant: got %d, want 4000 (no double-credit)", balAfterSecond.BalanceCents)
+	}
+
+	// Exactly one ledger grant row exists for this credit-note source — the
+	// invariant the partial unique index enforces.
+	tx, err := db.BeginTx(ctx, postgres.TxBypass, "")
+	if err != nil {
+		t.Fatalf("begin bypass tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var grantRows int
+	if err := tx.QueryRow(`
+		SELECT count(*) FROM customer_credit_ledger
+		WHERE source_credit_note_id = $1
+	`, creditNoteID).Scan(&grantRows); err != nil {
+		t.Fatalf("count credit-note grant rows: %v", err)
+	}
+	if grantRows != 1 {
+		t.Errorf("grant rows for credit note: got %d, want 1", grantRows)
+	}
+}

--- a/internal/invoice/postgres_update_tax_atomic_test.go
+++ b/internal/invoice/postgres_update_tax_atomic_test.go
@@ -1,0 +1,126 @@
+package invoice_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/errs"
+	"github.com/sagarsuperuser/velox/internal/invoice"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestUpdateTaxAtomic_RejectsNonDraft is the symmetric counterpart to
+// TestAddLineItemAtomic_RejectsNonDraft: the draft-only invariant is
+// re-asserted inside the locking tx (the SELECT ... FOR UPDATE in
+// UpdateTaxAtomic), so a caller cannot stamp tax onto a finalized invoice —
+// even if it raced a concurrent Finalize. Tax is mutable while a draft and
+// frozen once finalized; this pins that the store guards it, not just the
+// engine layer.
+func TestUpdateTaxAtomic_RejectsNonDraft(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	store := invoice.NewPostgresStore(db)
+	tenantID := testutil.CreateTestTenant(t, db, "UpdateTax NonDraft")
+	invID := seedDraftInvoice(t, db, tenantID)
+
+	if _, err := store.UpdateStatus(ctx, tenantID, invID, domain.InvoiceFinalized); err != nil {
+		t.Fatalf("finalize invoice: %v", err)
+	}
+
+	_, err := store.UpdateTaxAtomic(ctx, tenantID, invID, domain.InvoiceTaxRetryUpdate{
+		TaxAmountCents:   100,
+		TaxStatus:        domain.InvoiceTaxOK,
+		TotalAmountCents: 600,
+		SubtotalCents:    500,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error updating tax on finalized invoice, got nil")
+	}
+	// The store raises the draft-only invariant as a typed InvalidState error,
+	// not a generic SQL failure.
+	if !errors.Is(err, errs.ErrInvalidState) {
+		t.Fatalf("expected ErrInvalidState (draft-only rejection), got %v", err)
+	}
+}
+
+// TestUpdateTaxAtomic_ConcurrentSerializes is the lost-update regression for
+// UpdateTaxAtomic, mirroring TestAddLineItemAtomic_ConcurrentAdds. Every call
+// bumps tax_retry_count by 1 under the SELECT ... FOR UPDATE row lock, so N
+// concurrent calls on one draft invoice must serialize: each increment is
+// applied on top of the prior committed value, leaving tax_retry_count == N.
+// Without the lock the read-modify-write on the counter would lose increments
+// and the final header would be an incoherent partial result.
+func TestUpdateTaxAtomic_ConcurrentSerializes(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+
+	store := invoice.NewPostgresStore(db)
+	tenantID := testutil.CreateTestTenant(t, db, "UpdateTax Concurrency")
+	invID := seedDraftInvoice(t, db, tenantID)
+
+	const (
+		goroutines = 8
+		taxCents   = int64(100)
+		subtotal   = int64(500)
+		total      = subtotal + taxCents
+	)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Go(func() {
+			_, err := store.UpdateTaxAtomic(ctx, tenantID, invID, domain.InvoiceTaxRetryUpdate{
+				TaxAmountCents:   taxCents,
+				TaxRate:          20,
+				TaxStatus:        domain.InvoiceTaxOK,
+				SubtotalCents:    subtotal,
+				DiscountCents:    0,
+				TotalAmountCents: total,
+			}, nil)
+			if err != nil {
+				errCh <- err
+			}
+		})
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatalf("concurrent UpdateTaxAtomic: %v", err)
+	}
+
+	inv, err := store.Get(ctx, tenantID, invID)
+	if err != nil {
+		t.Fatalf("get final invoice: %v", err)
+	}
+
+	// Every call increments tax_retry_count = tax_retry_count + 1 inside its
+	// locked tx; if any read the counter before another committed, the final
+	// value would be < goroutines (a lost update). Exactly N proves the row
+	// lock serialized the read-modify-write.
+	if inv.TaxRetryCount != goroutines {
+		t.Fatalf("lost-update race: tax_retry_count = %d, want %d (concurrent updates were not serialized on the row lock)",
+			inv.TaxRetryCount, goroutines)
+	}
+	// The serialized winner leaves a coherent header: the last committed
+	// snapshot, not a torn mix of two writers.
+	if inv.TaxAmountCents != taxCents {
+		t.Fatalf("tax_amount_cents = %d, want %d", inv.TaxAmountCents, taxCents)
+	}
+	if inv.TotalAmountCents != total {
+		t.Fatalf("total_amount_cents = %d, want %d", inv.TotalAmountCents, total)
+	}
+	// amount_due = GREATEST(total - amount_paid - credits_applied, 0); a fresh
+	// draft has neither, so it must equal total.
+	if inv.AmountDueCents != total {
+		t.Fatalf("amount_due_cents = %d, want %d", inv.AmountDueCents, total)
+	}
+	if inv.TaxStatus != domain.InvoiceTaxOK {
+		t.Fatalf("tax_status = %q, want %q", inv.TaxStatus, domain.InvoiceTaxOK)
+	}
+}

--- a/internal/subscription/clawback_draft_rollback_integration_test.go
+++ b/internal/subscription/clawback_draft_rollback_integration_test.go
@@ -1,0 +1,168 @@
+package subscription
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sagarsuperuser/velox/internal/auth"
+	"github.com/sagarsuperuser/velox/internal/customer"
+	"github.com/sagarsuperuser/velox/internal/domain"
+	"github.com/sagarsuperuser/velox/internal/platform/clock"
+	"github.com/sagarsuperuser/velox/internal/platform/postgres"
+	"github.com/sagarsuperuser/velox/internal/pricing"
+	"github.com/sagarsuperuser/velox/internal/testutil"
+)
+
+// TestRemoveItem_ClawbackDraftCreateFailure_RealTxRollsBackItemDelete is the
+// real-Postgres proof of the ADR-056/ADR-057 atomicity guarantee on the
+// downgrade/removal CLAWBACK path: createClawbackDraftsTx creates the
+// tax-reversing credit note as a DRAFT inside the SAME tx as the item delete,
+// so a draft-create failure must roll the item delete back. Today this is only
+// exercised manually (MANUAL_TEST FLOW B3 "REVOKE INSERT ON credit_notes").
+//
+// The sibling cross_interval_swap_integration_test.go proves the rollback when
+// the in-tx new-period BILL fails (a different in-tx side effect); this is the
+// closest automated analog for the clawback-draft seam, where the failure is in
+// h.creditNotes.CreateAdjustmentDraftTx. The item delete runs on the caller's
+// real tx via h.svc.RemoveItemTx -> store.RemoveItemTx, so only a real tx can
+// prove the DELETE is undone (the in-memory store can't model tx rollback).
+func TestRemoveItem_ClawbackDraftCreateFailure_RealTxRollsBackItemDelete(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	ctx := postgres.WithLivemode(context.Background(), false)
+	tenantID := testutil.CreateTestTenant(t, db, "Clawback Draft Rollback")
+
+	cust, err := customer.NewPostgresStore(db).Create(ctx, tenantID, domain.Customer{
+		ExternalID: "cus_clawback_rb", DisplayName: "Clawback RB",
+	})
+	if err != nil {
+		t.Fatalf("create customer: %v", err)
+	}
+
+	// Real plan row — subscription_items has a FK to plans, so the item insert
+	// needs a persisted plan even though the proration logic reads the mock below.
+	ps := pricing.NewPostgresStore(db)
+	realPlan, err := ps.CreatePlan(ctx, tenantID, domain.Plan{
+		Code: "pro-monthly-adv", Name: "Pro", Currency: "USD",
+		BillingInterval: domain.BillingMonthly, BaseBillTiming: domain.BillInAdvance,
+		BaseAmountCents: 6000, Status: domain.PlanActive,
+	})
+	if err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+	// A distinct second plan: an active sub refuses to drop its last item AND
+	// refuses duplicate plans in items, so the keeper item needs its own plan.
+	keeperPlan, err := ps.CreatePlan(ctx, tenantID, domain.Plan{
+		Code: "keeper-monthly-adv", Name: "Keeper", Currency: "USD",
+		BillingInterval: domain.BillingMonthly, BaseBillTiming: domain.BillInAdvance,
+		BaseAmountCents: 3000, Status: domain.PlanActive,
+	})
+	if err != nil {
+		t.Fatalf("create keeper plan: %v", err)
+	}
+
+	// A 30-day in_advance period straddling proNow (15/30 days remain) so the
+	// removal claws back the unused prebill — the branch that creates a clawback
+	// draft in-tx. The handler reads clock.Now(ctx) for the remaining-days ratio,
+	// so bind effective-now to a mid-period instant.
+	store := NewPostgresStore(db)
+	created, err := store.Create(ctx, tenantID, domain.Subscription{
+		Code: "sub-clawback-rb", DisplayName: "Clawback RB", CustomerID: cust.ID,
+		Status: domain.SubscriptionActive, BillingTime: domain.BillingTimeCalendar,
+		StartedAt:                 &proPeriodStart,
+		CurrentBillingPeriodStart: &proPeriodStart,
+		CurrentBillingPeriodEnd:   &proPeriodEnd,
+		NextBillingAt:             &proPeriodEnd,
+		// Two items so RemoveItemTx is allowed (an active sub refuses to drop its
+		// last item). We remove the first; the second keeps the sub valid.
+		Items: []domain.SubscriptionItem{
+			{PlanID: realPlan.ID, Quantity: 1},
+			{PlanID: keeperPlan.ID, Quantity: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create sub: %v", err)
+	}
+	sub, err := store.Get(ctx, tenantID, created.ID)
+	if err != nil {
+		t.Fatalf("get created sub: %v", err)
+	}
+	if len(sub.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(sub.Items))
+	}
+	removeItemID := sub.Items[0].ID
+
+	// Proration deps: an in_advance plan + a PAID funding invoice so the removal
+	// resolves a clawback (net + tax) and reaches createClawbackDraftsTx. The
+	// invoice rows are mock-resolved — the property under test is the item-delete
+	// rollback, not invoice resolution.
+	plans := &plansMock{plans: map[string]domain.Plan{
+		realPlan.ID:   realPlan,
+		keeperPlan.ID: keeperPlan,
+	}}
+	invoices := &invoicesMock{
+		sourceInvoice: domain.Invoice{
+			ID: "src_inv", PaymentStatus: domain.PaymentSucceeded,
+			SubtotalCents: 6000, TaxAmountCents: 600, TotalAmountCents: 6600,
+			CreatedAt: proPeriodStart,
+		},
+	}
+	credits := &creditsMock{}
+	// fakeCNIssuer.err fails CreateAdjustmentDraftTx in-tx — the exact failure
+	// the atomic remove path must roll the item delete back from. CreditedCents
+	// stays 0 (full headroom) so the clawback resolves a non-empty piece first.
+	cn := &fakeCNIssuer{err: errors.New("simulated in-tx clawback draft create failure")}
+
+	h := NewHandler(svcWithStore(store))
+	h.SetDB(db)
+	h.SetProrationDeps(plans, invoices, credits)
+	h.SetCreditNoteIssuer(cn)
+
+	// Mid-period instant so remainingPeriodRatio > 0 → atomic clawback path taken.
+	reqCtx := clock.WithEffectiveNow(context.WithValue(ctx, auth.TestTenantIDKey(), tenantID), proNow)
+	req := removeItemURL(reqCtx, sub.ID, removeItemID)
+	rr := httptest.NewRecorder()
+	h.removeItem(rr, req)
+
+	// The in-tx draft-create failure must surface as an error (NOT 204) — the
+	// remove did not succeed.
+	if rr.Code == http.StatusNoContent || (rr.Code >= 200 && rr.Code < 300) {
+		t.Fatalf("expected removeItem to fail when the in-tx clawback draft create errors, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Sanity: the failing seam was actually reached (the draft-create was attempted).
+	if len(cn.calls) == 0 {
+		t.Fatalf("CreateAdjustmentDraftTx was never called — the clawback seam was not exercised (test is vacuous)")
+	}
+
+	// The real assertion: the item DELETE on the caller's tx MUST have rolled
+	// back. A fresh read from a new connection still sees BOTH items, the removed
+	// one unchanged. Without atomicity the item would be gone (deleted on the tx)
+	// while the customer was never credited (draft create failed) — a silent loss.
+	after, err := store.Get(ctx, tenantID, sub.ID)
+	if err != nil {
+		t.Fatalf("get after rollback: %v", err)
+	}
+	if len(after.Items) != 2 {
+		t.Fatalf("item delete must roll back on in-tx clawback draft failure: got %d items, want 2", len(after.Items))
+	}
+	var found bool
+	for _, it := range after.Items {
+		if it.ID == removeItemID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the removed item (%s) must still exist after rollback", removeItemID)
+	}
+	// No bare net ledger grant either — the downgrade/removal credit routes
+	// exclusively through the CN draft, which failed and rolled back.
+	if len(credits.grantCalls) != 0 {
+		t.Errorf("GrantProration must not have fired on the clawback path: got %d calls", len(credits.grantCalls))
+	}
+}
+
+// svcWithStore builds a Service over the real Postgres store so the handler's
+// atomic RemoveItemTx runs the DELETE on the caller's tx (the rollback target).
+func svcWithStore(store Store) *Service { return NewService(store, nil) }

--- a/internal/tax/stripe_idempotency_test.go
+++ b/internal/tax/stripe_idempotency_test.go
@@ -1,0 +1,208 @@
+package tax
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stripe/stripe-go/v82"
+)
+
+// capturingBackend implements stripe.Backend and records the params + path of
+// the single outbound Call so the test can assert the exact request SHAPE the
+// SDK would put on the wire — without any network. It also sets a fake
+// transaction id on the response so Reverse/Commit return cleanly.
+type capturingBackend struct {
+	method string
+	path   string
+	params stripe.ParamsContainer
+}
+
+func (b *capturingBackend) Call(method, path, _ string, params stripe.ParamsContainer, v stripe.LastResponseSetter) error {
+	b.method, b.path, b.params = method, path, params
+	if txn, ok := v.(*stripe.TaxTransaction); ok {
+		txn.ID = "tax_txn_fake"
+	}
+	return nil
+}
+
+func (b *capturingBackend) CallStreaming(string, string, string, stripe.ParamsContainer, stripe.StreamingLastResponseSetter) error {
+	return nil
+}
+
+func (b *capturingBackend) CallRaw(string, string, string, []byte, *stripe.Params, stripe.LastResponseSetter) error {
+	return nil
+}
+
+func (b *capturingBackend) CallMultipart(string, string, string, string, *bytes.Buffer, *stripe.Params, stripe.LastResponseSetter) error {
+	return nil
+}
+
+func (b *capturingBackend) SetMaxNetworkRetries(int64) {}
+
+// staticClientResolver hands the same *stripe.Client to every ctx — enough for
+// these unit tests, which only exercise param building, not per-tenant routing.
+type staticClientResolver struct{ c *stripe.Client }
+
+func (r staticClientResolver) ForCtx(context.Context) *stripe.Client { return r.c }
+
+// newCapturingProvider wires a StripeTaxProvider whose Stripe client routes
+// every API call into the returned capturingBackend.
+func newCapturingProvider() (*StripeTaxProvider, *capturingBackend) {
+	be := &capturingBackend{}
+	client := stripe.NewClient("sk_test_fake", stripe.WithBackends(&stripe.Backends{
+		API:         be,
+		Connect:     be,
+		Uploads:     be,
+		MeterEvents: be,
+	}))
+	return NewStripeTaxProvider(staticClientResolver{c: client}), be
+}
+
+// TestReverse_RequestShape pins the money-correctness ACI property for the
+// credit-note tax-reversal path: a retried reversal must NOT create a second
+// (double) reversal. That guarantee rests entirely on two request fields, both
+// derived from the reversal Reference:
+//
+//   - Reference            = ref            (Stripe enforces account-wide uniqueness)
+//   - IdempotencyKey header = "velox_tax_rev_" + ref
+//
+// plus, for partial reversals, a NEGATIVE FlatAmount (Stripe requires the
+// reversal amount in negative smallest-currency units). If a refactor silently
+// drops the idempotency key, changes its prefix, sends the wrong reference, or
+// flips the partial amount sign, this test fails — closing the G1-class
+// regression window where double tax-reversal could ship with CI green.
+func TestReverse_RequestShape(t *testing.T) {
+	t.Run("full reversal", func(t *testing.T) {
+		p, be := newCapturingProvider()
+		res, err := p.Reverse(context.Background(), ReversalRequest{
+			OriginalTransactionID: "tax_txn_orig",
+			Reference:             "cn_abc123",
+			Mode:                  ReversalModeFull,
+		})
+		if err != nil {
+			t.Fatalf("Reverse: unexpected error: %v", err)
+		}
+		if res == nil || res.TransactionID != "tax_txn_fake" {
+			t.Fatalf("ReversalResult = %+v, want TransactionID=tax_txn_fake", res)
+		}
+		if be.path != "/v1/tax/transactions/create_reversal" {
+			t.Errorf("path = %q, want /v1/tax/transactions/create_reversal", be.path)
+		}
+		params, ok := be.params.(*stripe.TaxTransactionCreateReversalParams)
+		if !ok {
+			t.Fatalf("captured params type = %T, want *stripe.TaxTransactionCreateReversalParams", be.params)
+		}
+		if got := stripe.StringValue(params.Reference); got != "cn_abc123" {
+			t.Errorf("Reference = %q, want cn_abc123 (Stripe-side dedup key)", got)
+		}
+		if got := idemKey(params); got != "velox_tax_rev_cn_abc123" {
+			t.Errorf("IdempotencyKey = %q, want velox_tax_rev_cn_abc123 (retry-dedup; prefix+ref must not drift)", got)
+		}
+		if got := stripe.StringValue(params.Mode); got != string(ReversalModeFull) {
+			t.Errorf("Mode = %q, want full", got)
+		}
+		// Full reversals must NOT pin an amount — Stripe reverses the whole
+		// original transaction. A stray FlatAmount would under/over-reverse tax.
+		if params.FlatAmount != nil {
+			t.Errorf("FlatAmount = %d, want nil for full reversal", *params.FlatAmount)
+		}
+	})
+
+	t.Run("partial reversal sends negative FlatAmount", func(t *testing.T) {
+		p, be := newCapturingProvider()
+		_, err := p.Reverse(context.Background(), ReversalRequest{
+			OriginalTransactionID: "tax_txn_orig",
+			Reference:             "cn_partial",
+			Mode:                  ReversalModePartial,
+			GrossAmountCents:      4499,
+		})
+		if err != nil {
+			t.Fatalf("Reverse(partial): unexpected error: %v", err)
+		}
+		params, ok := be.params.(*stripe.TaxTransactionCreateReversalParams)
+		if !ok {
+			t.Fatalf("captured params type = %T, want *stripe.TaxTransactionCreateReversalParams", be.params)
+		}
+		if got := stripe.StringValue(params.Mode); got != string(ReversalModePartial) {
+			t.Errorf("Mode = %q, want partial", got)
+		}
+		if params.FlatAmount == nil {
+			t.Fatalf("FlatAmount = nil, want -4499 (partial reversal must send a negative amount)")
+		}
+		if *params.FlatAmount != -4499 {
+			t.Errorf("FlatAmount = %d, want -4499 (Stripe requires negative smallest-currency units; sign must not flip)", *params.FlatAmount)
+		}
+		if got := idemKey(params); got != "velox_tax_rev_cn_partial" {
+			t.Errorf("IdempotencyKey = %q, want velox_tax_rev_cn_partial", got)
+		}
+	})
+
+	t.Run("reference falls back to credit note id", func(t *testing.T) {
+		p, be := newCapturingProvider()
+		_, err := p.Reverse(context.Background(), ReversalRequest{
+			OriginalTransactionID: "tax_txn_orig",
+			CreditNoteID:          "cn_fallback",
+			// Reference intentionally empty — must fall back to CreditNoteID
+			// for BOTH the Reference field and the idempotency key, so the
+			// legacy credit-note caller still dedups.
+		})
+		if err != nil {
+			t.Fatalf("Reverse(fallback): unexpected error: %v", err)
+		}
+		params := be.params.(*stripe.TaxTransactionCreateReversalParams)
+		if got := stripe.StringValue(params.Reference); got != "cn_fallback" {
+			t.Errorf("Reference = %q, want cn_fallback (fallback to CreditNoteID)", got)
+		}
+		if got := idemKey(params); got != "velox_tax_rev_cn_fallback" {
+			t.Errorf("IdempotencyKey = %q, want velox_tax_rev_cn_fallback (key must use the same ref)", got)
+		}
+	})
+}
+
+// TestCommit_RequestShape pins the money-correctness ACI property for the
+// tax-commit path: a retried finalize/commit must NOT create a second (double)
+// tax_transaction. That rests on:
+//
+//   - Reference            = invoiceID                (Stripe-side uniqueness)
+//   - IdempotencyKey header = "velox_tax_commit_" + invoiceID
+//
+// On a within-window retry Stripe returns the cached original transaction id
+// (lets the reconciler recover a commit whose local persist failed). If a
+// refactor drops the key or sends the wrong reference, a duplicate
+// tax_transaction could be created — double tax committed upstream with CI
+// green. This test fails before that ships.
+func TestCommit_RequestShape(t *testing.T) {
+	p, be := newCapturingProvider()
+	id, err := p.Commit(context.Background(), "taxcalc_ref", "vlx_inv_123")
+	if err != nil {
+		t.Fatalf("Commit: unexpected error: %v", err)
+	}
+	if id != "tax_txn_fake" {
+		t.Errorf("Commit returned id = %q, want tax_txn_fake", id)
+	}
+	if be.path != "/v1/tax/transactions/create_from_calculation" {
+		t.Errorf("path = %q, want /v1/tax/transactions/create_from_calculation", be.path)
+	}
+	params, ok := be.params.(*stripe.TaxTransactionCreateFromCalculationParams)
+	if !ok {
+		t.Fatalf("captured params type = %T, want *stripe.TaxTransactionCreateFromCalculationParams", be.params)
+	}
+	if got := stripe.StringValue(params.Calculation); got != "taxcalc_ref" {
+		t.Errorf("Calculation = %q, want taxcalc_ref", got)
+	}
+	if got := stripe.StringValue(params.Reference); got != "vlx_inv_123" {
+		t.Errorf("Reference = %q, want vlx_inv_123 (invoice-keyed Stripe dedup)", got)
+	}
+	if got := idemKey(params); got != "velox_tax_commit_vlx_inv_123" {
+		t.Errorf("IdempotencyKey = %q, want velox_tax_commit_vlx_inv_123 (prefix+invoiceID must not drift)", got)
+	}
+}
+
+// idemKey reads the request-level Idempotency-Key off any Stripe params struct
+// (it lives on the embedded Params, sent as an HTTP header — form:"-").
+func idemKey(p stripe.ParamsContainer) string {
+	return stripe.StringValue(p.GetParams().IdempotencyKey)
+}
+
+var _ stripe.Backend = (*capturingBackend)(nil)


### PR DESCRIPTION
## What & why

An ACI (atomicity/concurrency/idempotency) **test-coverage audit** mapped ~55 mechanisms across the product: ~38 already CI-locked, the rest partial/pending. This PR closes the 4 gaps that protect a **money-correctness invariant** but had only manual or mem-store coverage — so a future refactor can't silently break them. **No production code changes.**

| Test | Invariant locked | Kind |
|---|---|---|
| `internal/tax/stripe_idempotency_test.go` | Stripe `Reverse`/`Commit` idempotency-key shape (`velox_tax_rev_<ref>` / `velox_tax_commit_<id>`), Reference, partial-reversal negative `FlatAmount` — the exactly-once levers behind the **G1 double-reversal fix**. Uses a capturing stripe-go `Backend` (no network). **Mutation-verified** (drifting the prefix fails it). | unit |
| `internal/credit/postgres_grant_creditnote_test.go` | migration-0093 dedup index → `GrantForCreditNote` exactly-once (same CN grant twice → one ledger row, balance not doubled) — the no-double-credit basis of the clawback-retry path, previously only mem-store-emulated | integration |
| `internal/invoice/postgres_update_tax_atomic_test.go` | `UpdateTaxAtomic` rejects a non-draft under the `FOR UPDATE` re-assert + concurrent calls serialize (no lost `tax_retry_count` update) — the symmetric coverage `AddLineItemAtomic` already had | integration |
| `internal/subscription/clawback_draft_rollback_integration_test.go` | real-tx proof that an in-tx clawback-draft create failure **rolls back the item delete** (`atomicRemoveItemWithProration`) — previously only manual (FLOW B3 `REVOKE INSERT ON credit_notes`) | integration |

## Verification
All 4 pass locally (tax unit; the other 3 real-Postgres). `golangci-lint` + custom lint scripts (`lint-clock`/`funding-set`/`manual-test`) + `go vet` all clean. No production code touched, so no CHANGELOG/ADR/MANUAL_TEST entry (this is regression coverage for already-shipped behavior).

The remaining audit gaps (reliability: outbox SKIP-LOCKED concurrency, dispatcher livemode→ctx, advisory-lock crash-failover) are deferred — not money-correctness, not live risks at single-replica/0-customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)