### PR TITLE
docs(creditnote): mark issued-CN grant-failure resume as deferred-with-trigger

### DIFF
--- a/internal/creditnote/service.go
+++ b/internal/creditnote/service.go
@@ -824,6 +824,20 @@ func (s *Service) Issue(ctx context.Context, tenantID, id string) (domain.Credit
 			}); err != nil {
 				return domain.CreditNote{}, fmt.Errorf("grant credit: %w", err)
 			}
+			// KNOWN GAP (deferred — liveness audit 2026-06-23): the draft→issued
+			// CAS above already committed in its OWN transaction, so if this grant
+			// fails the credit note is persisted status=issued with NO balance
+			// credit — the customer is shown a completed credit they never
+			// received, and there is no automatic resume (re-Issue refused:
+			// status!=draft; Void refused: issued is final). The 0093 dedup index
+			// makes a RE-GRANT idempotent/safe, but nothing calls
+			// GrantForCreditNote post-issue. Fix-when-triggered: a reconciler that
+			// re-runs the grant for issued credit-channel CNs that have no ledger
+			// entry (no-migration path: scan all issued credit-channel CNs + an
+			// idempotent re-grant via 0093; an at-scale alternative is a bounded
+			// grant_settled column). TRIGGER: the first design partner issuing
+			// account-credit credit notes (the feature carries real money). Until
+			// then a grant failure here is an operator-visible error + manual fix.
 		}
 	} else {
 		// Invoice not yet paid — reduce amount_due. This is the


### PR DESCRIPTION
Records the one remaining liveness-audit sink as **deferred with a named trigger**, at its exact code site — comment-only, no behavior change.

**The gap:** `Issue()`'s `draft→issued` CAS commits in its own transaction, so if the subsequent `GrantForCreditNote` fails, the credit note is persisted `status=issued` with **no balance credit** — the customer is shown a completed credit they never received, and there's no automatic resume (re-Issue refused: `status!=draft`; Void refused: issued is final). The 0093 dedup index already makes a re-grant idempotent/safe, but nothing calls it post-issue.

**Deferred** per pre-launch scoping — lowest-severity confirmed sink, needs a transient DB error at one instant, no victim at zero customers.

**Trigger:** the first design partner issuing account-credit credit notes (the feature carries real money).

**Chosen fix when triggered:** a reconciler that re-runs the grant for issued credit-channel CNs with no ledger entry (no-migration path via the 0093 dedup index; a bounded `grant_settled` column is the at-scale alternative).

The marker lives at the grant site so a future maintainer doesn't assume grant-after-issue is recovered. This closes out the liveness-audit work — every "build-now" sink is shipped (#297, #299, #300); this one is the documented defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)